### PR TITLE
Résolution du problème de connexion Proconnect et amélioration de l'admin

### DIFF
--- a/gsl_core/admin.py
+++ b/gsl_core/admin.py
@@ -12,6 +12,23 @@ from gsl_core.models import (
 )
 
 
+class AllPermsForStaffUser:
+    def has_module_permission(self, request):
+        return request.user.is_staff or request.user.is_superuser
+
+    def has_view_permission(self, request, obj=None):
+        return self.has_module_permission(request)
+
+    def has_add_permission(self, request, obj=None):
+        return self.has_module_permission(request)
+
+    def has_change_permission(self, request, obj=None):
+        return self.has_module_permission(request)
+
+    def has_delete_permission(self, request, obj=None):
+        return self.has_module_permission(request)
+
+
 @admin.register(Collegue)
 class CollegueAdmin(UserAdmin):
     list_display = ("username", "email", "first_name", "last_name", "is_staff")
@@ -45,7 +62,7 @@ class CollegueAdmin(UserAdmin):
 
 
 @admin.register(Adresse)
-class AdresseAdmin(admin.ModelAdmin):
+class AdresseAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     list_display = ("label", "postal_code", "commune")
 
     def get_queryset(self, request):
@@ -54,8 +71,12 @@ class AdresseAdmin(admin.ModelAdmin):
         return queryset
 
 
-admin.site.register(Commune)
-admin.site.register(Arrondissement)
-admin.site.register(Departement)
-admin.site.register(Region)
+@admin.register(Commune)
+@admin.register(Arrondissement)
+@admin.register(Departement)
+@admin.register(Region)
+class CoreModelAdmin(AllPermsForStaffUser, admin.ModelAdmin):
+    pass
+
+
 admin.site.unregister(Group)

--- a/gsl_core/admin.py
+++ b/gsl_core/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import Group
 
 from gsl_core.models import (
@@ -12,7 +13,8 @@ from gsl_core.models import (
 
 
 @admin.register(Collegue)
-class CollegueAdmin(admin.ModelAdmin):
+class CollegueAdmin(UserAdmin):
+    list_display = ("username", "email", "first_name", "last_name", "is_staff")
     fieldsets = (
         (None, {"fields": ("username", "password")}),
         ("Informations personnelles", {"fields": ("first_name", "last_name", "email")}),

--- a/gsl_demarches_simplifiees/admin.py
+++ b/gsl_demarches_simplifiees/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
+from gsl_core.admin import AllPermsForStaffUser
+
 from .models import (
     Demarche,
     Dossier,
@@ -10,13 +12,13 @@ from .tasks import task_refresh_dossier_from_saved_data
 
 
 @admin.register(Demarche)
-class DemarcheAdmin(admin.ModelAdmin):
+class DemarcheAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     readonly_fields = [field.name for field in Demarche._meta.get_fields()]
     list_display = ("ds_number", "ds_title", "ds_state")
 
 
 @admin.register(Dossier)
-class DossierAdmin(admin.ModelAdmin):
+class DossierAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     list_filter = ("ds_demarche__ds_number", "ds_state")
     list_display = ("ds_number", "ds_demarche__ds_number", "ds_state")
     fieldsets = (
@@ -59,12 +61,12 @@ class DossierAdmin(admin.ModelAdmin):
 
 
 @admin.register(FieldMappingForHuman)
-class FieldMappingForHumanAdmin(admin.ModelAdmin):
+class FieldMappingForHumanAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     list_display = ("label", "django_field")
 
 
 @admin.register(FieldMappingForComputer)
-class FieldMappingForComputerAdmin(admin.ModelAdmin):
+class FieldMappingForComputerAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     readonly_fields = [
         field.name for field in FieldMappingForComputer._meta.get_fields()
     ]

--- a/gsl_oidc/backends.py
+++ b/gsl_oidc/backends.py
@@ -48,6 +48,10 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
             "proconnect_chorusdt": claims.get("chorusdt", ""),
         }
 
+    def filter_users_by_claims(self, claims):
+        username = self.get_username(claims)
+        return self.UserModel.objects.filter(username=username)
+
     def create_user(self, claims):
         username = self.get_username(claims)
         return self.UserModel.objects.create_user(

--- a/gsl_oidc/backends.py
+++ b/gsl_oidc/backends.py
@@ -66,4 +66,4 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         return user
 
     def get_username(self, claims):
-        return default_username_algo(claims.get("proconnect_sub"))
+        return default_username_algo(claims.get("sub"))

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -1,13 +1,15 @@
 from django.contrib import admin
 
+from gsl_core.admin import AllPermsForStaffUser
+
 from .models import Demandeur, Projet
 
 
 @admin.register(Demandeur)
-class DemandeurAdmin(admin.ModelAdmin):
+class DemandeurAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     pass
 
 
 @admin.register(Projet)
-class ProjetAdmin(admin.ModelAdmin):
+class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     pass


### PR DESCRIPTION
## 🌮 Objectif

Tous les utilisateurs qui essayaient de se connecter à proconnect après le premier rencontraient une erreur 500. C'était ma faute. Pardon.

J'en ai profité pour ajuster les droits d'accès aux informations dans l'interface d'admin, pour ne pas s'obliger à donner le statut "super-utilisateur" à tout le monde.

