### PR TITLE
Page de liste de projets non modifiables

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -33,6 +33,10 @@ ul.no-list-style li {
     text-align: right !important;
 }
 
+.gsl-no-underline {
+    background-image: none;
+}
+
 /* Page un projet */
 
 .blue-icon {
@@ -75,4 +79,43 @@ ul.no-list-style li {
 
 .gsl-projet > section + section {
     border-top: 1px solid #ddd;
+}
+
+/* Liste de projets */
+.gsl-project-table thead {
+    background-image: linear-gradient(0, #6a6af4, #6a6af4);
+    background-size: 100% 2px;
+    background-repeat: no-repeat;
+    background-position: bottom center;
+    background-color: #e3e2fd;
+    border-bottom: 1px solid #6a6af4;
+    text-transform: uppercase;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+.gsl-project-table thead th {
+    padding: 1em .75em;
+    text-align: left;
+    line-height: 1.3;
+}
+.gsl-project-table thead th:first-child {
+    padding-left: 1.5em;
+}
+.gsl-project-table {
+    font-size: .8em;
+}
+
+.gsl-project-table table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.gsl-project-table table tbody td {
+    border-bottom: 1px solid #929292;
+    padding: .75em;
+    line-height: 1.5;
+}
+.gsl-project-table table tbody td:first-child {
+    padding-left: 1.5em;
 }

--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -22,12 +22,15 @@ html {
 ul.no-list-style {
     list-style-type: none;
     padding-inline-start: 0;
-
-
 }
 
 ul.no-list-style li {
     padding: 0;
+}
+
+.gsl-money {
+    font-variant-numeric: tabular-nums;
+    text-align: right !important;
 }
 
 /* Page un projet */
@@ -69,6 +72,7 @@ ul.no-list-style li {
 .gsl-projet > section {
     padding: 3em;
 }
+
 .gsl-projet > section + section {
     border-top: 1px solid #ddd;
 }

--- a/gsl_core/templates/blocks/main_menu.html
+++ b/gsl_core/templates/blocks/main_menu.html
@@ -23,6 +23,13 @@
                        target="_self"
                        {% if request.path == home_url %}aria-current="true"{% endif %}>Accueil</a>
                 </li>
+                <li class="fr-nav__item">
+                    {% url 'projet:list' as projets_url %}
+                    <a class="fr-nav__link" href="{{ projets_url }}" target="_self"
+                    {% if request.path == projet_url %}aria-current="true"{% endif %}>
+                        Projets 2025 {# todo #}
+                    </a>
+                </li>
                 {% if request.user.is_staff %}
                     <li class="fr-nav__item">
                         <button class="fr-nav__btn"

--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -1,0 +1,14 @@
+from decimal import Decimal
+
+from django import template
+from django.template.defaultfilters import floatformat
+
+register = template.Library()
+
+
+@register.filter
+def percent(value, decimals=0):
+    if not isinstance(value, Decimal):
+        return value
+    """Removes all values of arg from the given string"""
+    return floatformat(value * Decimal("100.0"), decimals) + " %"

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -67,11 +67,17 @@ class Projet(models.Model):
         projet.save()
         return projet
 
+    @property
+    def assiette_or_cout_total(self):
+        if self.assiette:
+            return self.assiette
+        return self.dossier_ds.finance_cout_total
+
     def get_taux_de_subvention_sollicite(self):
-        if self.assiette is None:
+        if self.assiette_or_cout_total is None:
             return
-        if self.assiette > 0:
-            return self.dossier_ds.demande_montant / self.assiette
+        if self.assiette_or_cout_total > 0:
+            return self.dossier_ds.demande_montant / self.assiette_or_cout_total
 
     def get_taux_subventionnable(self):
         if self.assiette is None:
@@ -79,3 +85,10 @@ class Projet(models.Model):
 
         if self.assiette > 0:
             return int(100 * self.assiette / self.dossier_ds.finance_cout_total)
+
+    @property
+    def categorie_doperation(self):
+        if "DETR" in self.dossier_ds.demande_dispositif_sollicite:
+            yield from self.dossier_ds.demande_eligibilite_detr.all()
+        if "DSIL" in self.dossier_ds.demande_dispositif_sollicite:
+            yield from self.dossier_ds.demande_eligibilite_dsil.all()

--- a/gsl_projet/templates/gsl_projet/projet.html
+++ b/gsl_projet/templates/gsl_projet/projet.html
@@ -8,7 +8,7 @@
 
 {% block content %}
     <div class="fr-mb-4w">
-        <a href="#todo" class="fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-btn--tertiary">
+        <a href="{% url "projet:list" %}" class="fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-btn--tertiary">
             Retour à la liste des projets
         </a>
     </div>

--- a/gsl_projet/templates/gsl_projet/projet_list.html
+++ b/gsl_projet/templates/gsl_projet/projet_list.html
@@ -8,12 +8,61 @@
 
 {% block content %}
     <h1>Liste des projets</h1>
-    <ul>
-        {% for projet in object_list %}
-            <li>
-                <a href="{{ projet.get_absolute_url }}">{{ projet }}</a>
-            </li>
-        {% endfor %}
-    </ul>
+    <div class="fr-table--lg fr-table fr-table--no-scroll" id="table-lg-component">
+        <div class="fr-table__wrapper">
+            <div class="fr-table__container">
+                <div class="fr-table__content">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Commune</th>
+                            <th>N° D.S.</th>
+                            <th>Dotation</th>
+                            <th>Coût total du projet {% dsfr_badge %}</th>
+                            <th>Montant sollicité {% dsfr_badge %}</th>
+                            <th>Montant retenu</th>
+                            <th>Catégorie</th>
+                            <th>Statut</th>
+                            <th><span class="fr-sr-only">Actions</span></th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for projet in object_list %}
+                            <tr>
+                                <td></td>
+                                <td>{{ projet.address.commune.name }}</td>
+                                <td>{{ projet.dossier_ds.ds_number }}</td>
+                                <td>{{ projet.dossier_ds.demande_dispositif_sollicite }}</td>
+                                <td class="gsl-money">{{ projet.dossier_ds.finance_cout_total|floatformat:"2g"|default:"—" }}&nbsp;€</td>
+                                <td class="gsl-money">{{ projet.dossier_ds.demande_montant|floatformat:"2g"|default:"—" }}&nbsp;€</td>
+                                <td>{# todo montant retenu #}</td>
+                                <td>{# todo catégorie #}</td>
+                                <td>{{ projet.dossier_ds.get_ds_state_display }}</td>
+                                <td class="fr-cell--right">
+                                    <a class="fr-btn--tertiary-no-outline" href="{{ projet.get_absolute_url }}">
+                                        <span class="fr-sr-only">Voir le projet {{ projet.dossier_ds.ds_number }}</span>
+                                        <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="fr-table__footer">
+            <div class="fr-table__footer--start">
+
+            </div>
+            <div class="fr-table__footer--middle">
+                {% dsfr_pagination page_obj %}
+            </div>
+            <div class="fr-table__footer--end">
+                
+            </div>
+        </div>
+    </div>
 
 {% endblock %}

--- a/gsl_projet/templates/gsl_projet/projet_list.html
+++ b/gsl_projet/templates/gsl_projet/projet_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static dsfr_tags %}
+{% load static dsfr_tags gsl_filters %}
 
 {% block breadcrumb %}
     {% dsfr_breadcrumb breadcrumb_dict %}
@@ -8,61 +8,77 @@
 
 {% block content %}
     <h1>Liste des projets</h1>
-    <div class="fr-table--lg fr-table fr-table--no-scroll" id="table-lg-component">
-        <div class="fr-table__wrapper">
-            <div class="fr-table__container">
-                <div class="fr-table__content">
-                    <table>
-                        <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Commune</th>
-                            <th>N° D.S.</th>
-                            <th>Dotation</th>
-                            <th>Coût total du projet {% dsfr_badge %}</th>
-                            <th>Montant sollicité {% dsfr_badge %}</th>
-                            <th>Montant retenu</th>
-                            <th>Catégorie</th>
-                            <th>Statut</th>
-                            <th><span class="fr-sr-only">Actions</span></th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for projet in object_list %}
-                            <tr>
-                                <td></td>
-                                <td>{{ projet.address.commune.name }}</td>
-                                <td>{{ projet.dossier_ds.ds_number }}</td>
-                                <td>{{ projet.dossier_ds.demande_dispositif_sollicite }}</td>
-                                <td class="gsl-money">{{ projet.dossier_ds.finance_cout_total|floatformat:"2g"|default:"—" }}&nbsp;€</td>
-                                <td class="gsl-money">{{ projet.dossier_ds.demande_montant|floatformat:"2g"|default:"—" }}&nbsp;€</td>
-                                <td>{# todo montant retenu #}</td>
-                                <td>{# todo catégorie #}</td>
-                                <td>{{ projet.dossier_ds.get_ds_state_display }}</td>
-                                <td class="fr-cell--right">
-                                    <a class="fr-btn--tertiary-no-outline" href="{{ projet.get_absolute_url }}">
-                                        <span class="fr-sr-only">Voir le projet {{ projet.dossier_ds.ds_number }}</span>
-                                        <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
-                                    </a>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-        <div class="fr-table__footer">
-            <div class="fr-table__footer--start">
+    <div class="fr-table--lg gsl-project-table" id="table-lg-component">
+        <table>
+            <thead>
+            <tr>
+                <th>Date de dépôt</th>
+                <th>Intitulé du projet</th>
+                <th>Commune</th>
+                <th>N° D.S.</th>
+                <th>Dotation</th>
+                <th class="gsl-money">
+                    Coût total du projet<br>
+                    {% dsfr_badge label="123 000 €" extra_classes="fr-badge--blue-ecume" %}
+                </th>
+                <th class="gsl-money">
+                    Montant et taux sollicités<br>
+                    {% dsfr_badge label="23 000 €" extra_classes="fr-badge--yellow-tournesol" %}
 
-            </div>
-            <div class="fr-table__footer--middle">
-                {% dsfr_pagination page_obj %}
-            </div>
-            <div class="fr-table__footer--end">
-                
-            </div>
+                </th>
+                <th class="gsl-money">
+                    Montant et taux retenus<br>
+                    {% dsfr_badge label="23 000 €" extra_classes="fr-badge--green-menthe" %}
+                </th>
+                <th>Catégorie d'opération</th>
+                <th>Statut</th>
+                <th><span class="fr-sr-only">Actions</span></th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for projet in object_list %}
+                <tr>
+                    <td>{{ projet.dossier_ds.ds_date_depot|date:"d/m/Y" }}</td>
+                    <td>{{ projet.dossier_ds.projet_intitule }}</td>
+                    <td>{{ projet.address.commune.name }}</td>
+                    <td>{{ projet.dossier_ds.ds_number }}</td>
+                    <td>{{ projet.dossier_ds.demande_dispositif_sollicite }}</td>
+                    <td class="gsl-money">{{ projet.assiette_or_cout_total|floatformat:"2g"|default:"—" }}&nbsp;€</td>
+                    <td class="gsl-money">
+                        {{ projet.dossier_ds.demande_montant|floatformat:"2g"|default:"—" }}&nbsp;€<br>
+                        {{ projet.get_taux_de_subvention_sollicite|percent }}
+                    </td>
+                    <td class="gsl-money">25 000 €<br>20 %</td>
+                    <td>
+                        <ul class="no-list-style">
+                            {% for categorie in projet.categorie_doperation %}
+                                <li>{{ categorie }}</li>
+                            {% endfor %}
+                        </ul>
+                    </td>
+                    <td>{{ projet.dossier_ds.get_ds_state_display }}</td>
+                    <td class="fr-cell--right">
+                        <a class="fr-btn--tertiary-no-outline gsl-no-underline" href="{{ projet.get_absolute_url }}">
+                            <span class="fr-sr-only">Voir le projet {{ projet.dossier_ds.ds_number }}</span>
+                            <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
+                        </a>
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="fr-table__footer">
+        <div class="fr-table__footer--start">
+
         </div>
+        <div class="fr-table__footer--middle">
+            {% dsfr_pagination page_obj %}
+        </div>
+        <div class="fr-table__footer--end">
+
+        </div>
+    </div>
     </div>
 
 {% endblock %}

--- a/gsl_projet/templates/gsl_projet/projet_list.html
+++ b/gsl_projet/templates/gsl_projet/projet_list.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% load static dsfr_tags %}
+
+{% block breadcrumb %}
+    {% dsfr_breadcrumb breadcrumb_dict %}
+{% endblock breadcrumb %}
+
+
+{% block content %}
+    <h1>Liste des projets</h1>
+    <ul>
+        {% for projet in object_list %}
+            <li>
+                <a href="{{ projet.get_absolute_url }}">{{ projet }}</a>
+            </li>
+        {% endfor %}
+    </ul>
+
+{% endblock %}

--- a/gsl_projet/urls.py
+++ b/gsl_projet/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
         views.get_projet,
         name="get-projet",
     ),
+    path("liste", views.ProjectListView.as_view(), name="list"),
 ]

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -1,5 +1,7 @@
 from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
 from django.views.decorators.http import require_GET
+from django.views.generic import ListView
 
 from .models import Projet
 
@@ -12,7 +14,7 @@ def get_projet(request, projet_id):
         "projet": projet,
         "dossier": projet.dossier_ds,
         "breadcrumb_dict": {
-            "links": [{"url": "@todo", "title": "Liste des projets"}],
+            "links": [{"url": reverse("projet:list"), "title": "Liste des projets"}],
             "current": f"Projet {projet}",
         },
         "menu_dict": {
@@ -68,3 +70,8 @@ def get_projet(request, projet_id):
         },
     }
     return render(request, "gsl_projet/projet.html", context)
+
+
+class ProjectListView(ListView):
+    model = Projet
+    paginate_by = 100

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -74,4 +74,4 @@ def get_projet(request, projet_id):
 
 class ProjectListView(ListView):
     model = Projet
-    paginate_by = 100
+    paginate_by = 25


### PR DESCRIPTION
## 🌮 Objectif

> Je peux visualiser la liste des projets déposés sur ma démarche et voir les informations clés sur chaque projet.

On se concentre dans cette PR sur l'affichage de la liste, avant ajout de fonctionnalités.

## 🔍 Liste des modifications

- J'ai écrit du CSS pour le tableau "gsl-projets" hors DSFR, car le tableau de la maquette était trop différent du standard DSFR.
- Mise en place d'un raccourci (un "template filter") pour affichage facile et fiable de pourcentages divers
- Raccourcis de calcul des assiettes subventionnables, des taux subventionnables et des catégories d'opération.
- Il reste beaucoup d'informations "en dur", ça va s'arranger au fil de l'eau : 
  - le lien "projets 2025" ne filtre pas spécialement sur les projets 2025 et ne se met pas à jour en fonction de la "vraie" campagne en cours ;
  - on affiche tous les projets, y compris ceux qui ont été mal récupérés depuis DS et sans aucun filtre sur l'identité de l'utilisateur connecté·e ;
  - les totaux des listes (coût total/montant demandé) ne sont pas encore calculés ;
  - les montants et taux retenus, qui vont dépendre du modèle de données "programmation", ne sont pas encore là non plus.

## ⚠️ Informations supplémentaires

- Clarification à demander côté DGCL sur les "catégories d'opération".
- Si l'assiette subventionnable n'est pas renseignée explicitement, je prends par défaut le coût total du projet. <del>Je ne crois pas avoir vu l'info dans DS.</del> En fait si, "Montant des dépenses éligibles retenues" dans les annotations privées.

## 🖼️ Images

<details><summary>Liste complète</summary>
<img src="https://github.com/user-attachments/assets/d3fa4df6-4ea9-49d5-bc42-c5c6e127899f" alt="liste complète">
</details>

<details><summary>L'en-tête du tableau est sticky !</summary>
<img src="https://github.com/user-attachments/assets/e07dd767-89f0-41bf-a80e-2b685207f38b" alt="en-tête sticky">

</details>


