### PR TITLE
Importer les données INSEE région/département/arrondissement

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -56,11 +56,6 @@ if SENTRY_DSN:
 # Application definition
 
 INSTALLED_APPS = [
-    "unfold",  # before django.contrib.admin
-    # "unfold.contrib.filters",  # optional, if special filters are needed
-    # "unfold.contrib.forms",  # optional, if special form elements are needed
-    # "unfold.contrib.inlines",  # optional, if special inlines are needed
-    "unfold.contrib.import_export",  # optional, if django-import-export package is used
     "django.contrib.admin",
     "django.contrib.auth",
     "mozilla_django_oidc",
@@ -73,6 +68,7 @@ INSTALLED_APPS = [
     # dependencies:
     "widget_tweaks",
     "dsfr",
+    "import_export",
     # gsl apps:
     "gsl_core",
     "gsl_demarches_simplifiees",

--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -219,28 +219,3 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_TIMEZONE = "Europe/Paris"
 CELERY_RESULT_BACKEND = "django-db"
 CELERY_RESULT_EXTENDED = True
-
-
-UNFOLD = {
-    # see https://unfoldadmin.com/docs/configuration/settings/
-    "SITE_TITLE": "Admin Gestion des Subventions Locales",
-    "SITE_HEADER": "Gestion des Subventions Locales",
-    "SIDEBAR": {
-        "show_search": True,
-    },
-    "COLORS": {
-        "primary": {
-            "50": "245 245 254",  # blue-france-975
-            "100": "236 236 254",  # blue-france-950
-            "200": "227 227 253",  # blue-france-925
-            "300": "202 202 251",  # blue-france-850
-            "400": "198 198 251",  # blue-france-625-active
-            "500": "133 133 246",  # blue-france-625
-            "600": "106 106 244",  # blue-france-525
-            "700": "49 49 120",  # blue-france-200
-            "800": "39 39 71",  # blue-france-125
-            "900": "33 33 63",  # blue-france-100
-            "950": "27 27 53",  # blue-france-75
-        },
-    },
-}

--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -60,7 +60,7 @@ INSTALLED_APPS = [
     # "unfold.contrib.filters",  # optional, if special filters are needed
     # "unfold.contrib.forms",  # optional, if special form elements are needed
     # "unfold.contrib.inlines",  # optional, if special inlines are needed
-    # "unfold.contrib.import_export",  # optional, if django-import-export package is used
+    "unfold.contrib.import_export",  # optional, if django-import-export package is used
     "django.contrib.admin",
     "django.contrib.auth",
     "mozilla_django_oidc",

--- a/gsl_core/admin.py
+++ b/gsl_core/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import Group
-from unfold.admin import ModelAdmin
+from import_export.admin import ImportMixin
 
 from gsl_core.models import (
     Adresse,
@@ -11,6 +11,8 @@ from gsl_core.models import (
     Departement,
     Region,
 )
+
+from .resources import ArrondissementResource, DepartementResource, RegionResource
 
 
 class AllPermsForStaffUser:
@@ -31,7 +33,7 @@ class AllPermsForStaffUser:
 
 
 @admin.register(Collegue)
-class CollegueAdmin(UserAdmin, ModelAdmin):
+class CollegueAdmin(UserAdmin, admin.ModelAdmin):
     list_display = ("username", "email", "first_name", "last_name", "is_staff")
     fieldsets = (
         (None, {"fields": ("username", "password")}),
@@ -63,7 +65,7 @@ class CollegueAdmin(UserAdmin, ModelAdmin):
 
 
 @admin.register(Adresse)
-class AdresseAdmin(AllPermsForStaffUser, ModelAdmin):
+class AdresseAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     list_display = ("label", "postal_code", "commune")
 
     def get_queryset(self, request):
@@ -72,11 +74,23 @@ class AdresseAdmin(AllPermsForStaffUser, ModelAdmin):
         return queryset
 
 
-@admin.register(Commune)
-@admin.register(Arrondissement)
-@admin.register(Departement)
 @admin.register(Region)
-class CoreModelAdmin(AllPermsForStaffUser, ModelAdmin):
+class RegionAdmin(AllPermsForStaffUser, ImportMixin, admin.ModelAdmin):
+    resource_classes = (RegionResource,)
+
+
+@admin.register(Departement)
+class DepartementAdmin(AllPermsForStaffUser, ImportMixin, admin.ModelAdmin):
+    resource_classes = (DepartementResource,)
+
+
+@admin.register(Arrondissement)
+class ArrondissementAdmin(AllPermsForStaffUser, ImportMixin, admin.ModelAdmin):
+    resource_classes = (ArrondissementResource,)
+
+
+@admin.register(Commune)
+class CoreModelAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     pass
 
 

--- a/gsl_core/resources.py
+++ b/gsl_core/resources.py
@@ -1,0 +1,47 @@
+from import_export import resources
+from import_export.fields import Field
+from import_export.widgets import ForeignKeyWidget
+
+from .models import Arrondissement, Departement, Region
+
+
+class RegionResource(resources.ModelResource):
+    """
+    Documentation for the imported CSV files is available at
+    https://www.insee.fr/fr/information/7766585
+    """
+
+    insee_code = Field(attribute="insee_code", column_name="REG")
+    name = Field(attribute="name", column_name="NCCENR")
+
+    class Meta:
+        model = Region
+        import_id_fields = ("insee_code",)
+
+
+class DepartementResource(resources.ModelResource):
+    insee_code = Field(attribute="insee_code", column_name="DEP")
+    name = Field(attribute="name", column_name="NCCENR")
+    region = Field(
+        attribute="region",
+        column_name="REG",
+        widget=ForeignKeyWidget(Region, field="insee_code"),
+    )
+
+    class Meta:
+        model = Departement
+        import_id_fields = ("insee_code",)
+
+
+class ArrondissementResource(resources.ModelResource):
+    insee_code = Field(attribute="insee_code", column_name="ARR")
+    name = Field(attribute="name", column_name="NCCENR")
+    departement = Field(
+        attribute="departement",
+        column_name="DEP",
+        widget=ForeignKeyWidget(Departement, field="insee_code"),
+    )
+
+    class Meta:
+        model = Arrondissement
+        import_id_fields = ("insee_code",)

--- a/gsl_demarches_simplifiees/admin.py
+++ b/gsl_demarches_simplifiees/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from unfold.admin import ModelAdmin
 
 from gsl_core.admin import AllPermsForStaffUser
 
@@ -15,13 +14,13 @@ from .tasks import task_refresh_dossier_from_saved_data
 
 
 @admin.register(Demarche)
-class DemarcheAdmin(AllPermsForStaffUser, ModelAdmin):
+class DemarcheAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     readonly_fields = [field.name for field in Demarche._meta.get_fields()]
     list_display = ("ds_number", "ds_title", "ds_state")
 
 
 @admin.register(PersonneMorale)
-class PersonneMoraleAdmin(AllPermsForStaffUser, ModelAdmin):
+class PersonneMoraleAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     raw_id_fields = ("address",)
     list_display = ("__str__", "siret")
     fieldsets = (
@@ -43,7 +42,7 @@ class PersonneMoraleAdmin(AllPermsForStaffUser, ModelAdmin):
 
 
 @admin.register(Dossier)
-class DossierAdmin(AllPermsForStaffUser, ModelAdmin):
+class DossierAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     list_filter = ("ds_demarche__ds_number", "ds_state")
     list_display = ("ds_number", "ds_demarche__ds_number", "ds_state")
     fieldsets = (
@@ -98,12 +97,12 @@ class DossierAdmin(AllPermsForStaffUser, ModelAdmin):
 
 
 @admin.register(FieldMappingForHuman)
-class FieldMappingForHumanAdmin(AllPermsForStaffUser, ModelAdmin):
+class FieldMappingForHumanAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     list_display = ("label", "django_field")
 
 
 @admin.register(FieldMappingForComputer)
-class FieldMappingForComputerAdmin(AllPermsForStaffUser, ModelAdmin):
+class FieldMappingForComputerAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     readonly_fields = [
         field.name for field in FieldMappingForComputer._meta.get_fields()
     ]
@@ -112,5 +111,5 @@ class FieldMappingForComputerAdmin(AllPermsForStaffUser, ModelAdmin):
 
 
 @admin.register(Profile)
-class ProfileAdmin(AllPermsForStaffUser, ModelAdmin):
+class ProfileAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     pass

--- a/gsl_programmation/admin.py
+++ b/gsl_programmation/admin.py
@@ -1,25 +1,19 @@
 from django.contrib import admin
-from unfold.admin import ModelAdmin, TabularInline
 
 from .models import Enveloppe, Scenario, SimulationProjet
 
 
 @admin.register(Enveloppe)
-class EnveloppeAdmin(ModelAdmin):
+class EnveloppeAdmin(admin.ModelAdmin):
     pass
 
 
-class SimulationProjetInline(TabularInline):
-    model = SimulationProjet
-    fields = ("projet", "enveloppe", "montant", "taux", "status")
-
-
 @admin.register(Scenario)
-class ScenarioAdmin(ModelAdmin):
+class ScenarioAdmin(admin.ModelAdmin):
     pass
 
 
 @admin.register(SimulationProjet)
-class SimulationProjetAdmin(ModelAdmin):
+class SimulationProjetAdmin(admin.ModelAdmin):
     list_display = ("__str__", "projet__dossier_ds__projet_intitule")
     search_fields = ("projet__dossier_ds__projet_intitule",)

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from unfold.admin import ModelAdmin
 
 from gsl_core.admin import AllPermsForStaffUser
 
@@ -7,12 +6,12 @@ from .models import Demandeur, Projet
 
 
 @admin.register(Demandeur)
-class DemandeurAdmin(AllPermsForStaffUser, ModelAdmin):
+class DemandeurAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     pass
 
 
 @admin.register(Projet)
-class ProjetAdmin(AllPermsForStaffUser, ModelAdmin):
+class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     raw_id_fields = ("address", "departement")
     list_display = ("__str__", "dossier_ds__ds_state", "address", "departement")
     list_filter = ("departement", "dossier_ds__ds_state")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "django-referrer-policy",
     "django-unfold",
     "django_celery_results",
+    "django-import-export",
     "gunicorn",
     "mozilla-django-oidc",
     "psycopg2-binary",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "django-csp",
     "django-dsfr",
     "django-referrer-policy",
-    "django-unfold",
     "django_celery_results",
     "django-import-export",
     "gunicorn",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -67,7 +67,6 @@ django==5.1.4
     #   django-import-export
     #   django-referrer-policy
     #   django-timezone-field
-    #   django-unfold
     #   gsl (pyproject.toml)
     #   mozilla-django-oidc
 django-celery-beat==2.7.0
@@ -88,8 +87,6 @@ django-referrer-policy==1.0
     # via gsl (pyproject.toml)
 django-timezone-field==7.0
     # via django-celery-beat
-django-unfold==0.42.0
-    # via gsl (pyproject.toml)
 django-widget-tweaks==1.5.0
     # via django-dsfr
 execnet==2.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -50,6 +50,8 @@ cryptography==43.0.3
     #   pyopenssl
 diff-cover==9.2.0
     # via gsl (pyproject.toml)
+diff-match-patch==20241021
+    # via django-import-export
 distlib==0.3.8
     # via virtualenv
 dj-database-url==2.2.0
@@ -62,6 +64,7 @@ django==5.1.4
     #   django-crispy-forms
     #   django-csp
     #   django-dsfr
+    #   django-import-export
     #   django-referrer-policy
     #   django-timezone-field
     #   django-unfold
@@ -76,6 +79,8 @@ django-crispy-forms==2.3
 django-csp==3.8
     # via gsl (pyproject.toml)
 django-dsfr==1.3.1
+    # via gsl (pyproject.toml)
+django-import-export==4.3.3
     # via gsl (pyproject.toml)
 django-query-counter==0.4.0
     # via gsl (pyproject.toml)
@@ -179,6 +184,8 @@ six==1.16.0
     # via python-dateutil
 sqlparse==0.5.1
     # via django
+tablib==3.7.0
+    # via django-import-export
 tabulate==0.9.0
     # via django-query-counter
 typing-extensions==4.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,8 @@ cryptography==43.0.3
     #   josepy
     #   mozilla-django-oidc
     #   pyopenssl
+diff-match-patch==20241021
+    # via django-import-export
 dj-database-url==2.2.0
     # via gsl (pyproject.toml)
 django==5.1.4
@@ -52,6 +54,7 @@ django==5.1.4
     #   django-crispy-forms
     #   django-csp
     #   django-dsfr
+    #   django-import-export
     #   django-referrer-policy
     #   django-timezone-field
     #   django-unfold
@@ -66,6 +69,8 @@ django-crispy-forms==2.3
 django-csp==3.8
     # via gsl (pyproject.toml)
 django-dsfr==1.3.1
+    # via gsl (pyproject.toml)
+django-import-export==4.3.3
     # via gsl (pyproject.toml)
 django-referrer-policy==1.0
     # via gsl (pyproject.toml)
@@ -115,6 +120,8 @@ six==1.16.0
     # via python-dateutil
 sqlparse==0.5.1
     # via django
+tablib==3.7.0
+    # via django-import-export
 typing-extensions==4.12.2
     # via dj-database-url
 tzdata==2024.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,6 @@ django==5.1.4
     #   django-import-export
     #   django-referrer-policy
     #   django-timezone-field
-    #   django-unfold
     #   gsl (pyproject.toml)
     #   mozilla-django-oidc
 django-celery-beat==2.7.0
@@ -76,8 +75,6 @@ django-referrer-policy==1.0
     # via gsl (pyproject.toml)
 django-timezone-field==7.0
     # via django-celery-beat
-django-unfold==0.42.0
-    # via gsl (pyproject.toml)
 django-widget-tweaks==1.5.0
     # via django-dsfr
 gunicorn==23.0.0


### PR DESCRIPTION
## 🌮 Objectif

Avoir une base de toutes les régions/départements/arrondissements.

Je continue de mettre à jour les communes au fil de l'eau, mais on peut prévoir d'importer les communes d'un coup aussi au besoin.

On pourra réutiliser le module d'import-export pour d'autres usages (notamment les enveloppes).

## 🔍 Liste des modifications

- Installation du module django-import-export
- Configuration des imports sur les classes Région, Département, Arrondissement

## ⚠️ Informations supplémentaires

Suppression du module unfold-admin qui rendait l'interface d'admin plus jolie mais qui m'ajoutait du travail, ce dont je n'ai pas besoin pour l'instant.


