### PR TITLE
Ajout d'un compteur de requêtes SQL

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -78,6 +78,7 @@ INSTALLED_APPS = [
     "gsl_oidc",
 ]
 
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -90,6 +91,10 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+if DEBUG:
+    INSTALLED_APPS.append("query_counter")
+    MIDDLEWARE.append("query_counter.middleware.DjangoQueryCounterMiddleware")
 
 AUTHENTICATION_BACKENDS = [
     "gsl_oidc.backends.OIDCAuthenticationBackend",


### PR DESCRIPTION
## 🌮 Objectif

Résoudre les problèmes de performance avant qu'ils se produisent en prod

## 🔍 Liste des modifications

- Configuration du module `django-query-counter`, déjà installé depuis le début. Il s'active uniquement en mode debug, càd a priori uniquement dans nos environnements de dev.

