### PR TITLE
Utilisation de PostgreSQL version 15 pour l'intégration continue

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:15
         env:
           POSTGRES_DB: gsl
           POSTGRES_USER: gsl_team


### PR DESCRIPTION
## 🌮 Objectif

Éviter des bugs liés à des versions différentes entre notre version de test en local et la version déployée en prod.

## 🔍 Liste des modifications

- Utilisation de PostgreSQL 15 à la place de 16 pour les tests automatisés (la production utilise PostgreSQL 15)
