### PR TITLE
Création automatique des projets à partir des dossiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ruff format && ruff check --fix
 ## Première installation
 
 Dépendances :
-- PostgreSQL
+- PostgreSQL ≥ 15
 - Python 3.12 (avec pip et venv)
 
 Tout d'abord, créez la base de données en lançant une invite de commande PostgreSQL :

--- a/gsl_projet/signals.py
+++ b/gsl_projet/signals.py
@@ -1,0 +1,13 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from gsl_demarches_simplifiees.models import Dossier
+
+from .tasks import update_projet_from_dossier
+
+
+@receiver(post_save, sender=Dossier)
+def create_projet_from_valid_dossier(sender, instance: Dossier, *args, **kwargs):
+    if not instance.ds_state or instance.ds_state == Dossier.STATE_EN_CONSTRUCTION:
+        return
+    update_projet_from_dossier.delay(instance.ds_number)

--- a/gsl_projet/tasks.py
+++ b/gsl_projet/tasks.py
@@ -9,3 +9,12 @@ from .models import Projet
 def update_projet_from_dossier(ds_dossier_number):
     ds_dossier = Dossier.objects.get(ds_number=ds_dossier_number)
     Projet.get_or_create_from_ds_dossier(ds_dossier)
+
+
+@shared_task
+def create_all_projets_from_dossiers():
+    dossiers = Dossier.objects.exclude(ds_state=Dossier.STATE_EN_CONSTRUCTION).exclude(
+        ds_state=""
+    )
+    for dossier in dossiers.all():
+        update_projet_from_dossier.delay(dossier.ds_number)

--- a/gsl_projet/tests/test_signals.py
+++ b/gsl_projet/tests/test_signals.py
@@ -1,0 +1,21 @@
+from unittest import mock
+
+import pytest
+
+import gsl_projet.signals as projet_signals  # noqa F401
+from gsl_demarches_simplifiees.models import Dossier
+from gsl_demarches_simplifiees.tests.factories import DossierFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_dont_create_projets_from_incomplete_data():
+    with mock.patch("gsl_projet.tasks.update_projet_from_dossier.delay") as task_mock:
+        DossierFactory(ds_state=Dossier.STATE_EN_CONSTRUCTION)
+        task_mock.assert_not_called()
+    with mock.patch("gsl_projet.tasks.update_projet_from_dossier.delay") as task_mock:
+        DossierFactory(ds_state="")
+        task_mock.assert_not_called()
+    with mock.patch("gsl_projet.tasks.update_projet_from_dossier.delay") as task_mock:
+        dossier = DossierFactory(ds_state=Dossier.STATE_EN_INSTRUCTION)
+        task_mock.assert_called_once_with(dossier.ds_number)

--- a/gsl_projet/tests/test_tasks.py
+++ b/gsl_projet/tests/test_tasks.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+import pytest
+
+from gsl_demarches_simplifiees.models import Dossier
+from gsl_demarches_simplifiees.tests.factories import DossierFactory
+from gsl_projet.tasks import (
+    create_all_projets_from_dossiers,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test_create_all_projets():
+    DossierFactory(ds_state=Dossier.STATE_EN_CONSTRUCTION)
+    dossier_en_instruction = DossierFactory(ds_state=Dossier.STATE_EN_INSTRUCTION)
+    with mock.patch("gsl_projet.tasks.update_projet_from_dossier.delay") as task_mock:
+        create_all_projets_from_dossiers()
+        task_mock.assert_called_once_with(dossier_en_instruction.ds_number)


### PR DESCRIPTION
## 🌮 Objectif

Les utilisateurs en préfecture ne devraient pas avoir d'action à faire pour voir leurs projets dans la liste.

Pour autant, on ne veut pas afficher tous les dossiers en construction dans la liste affichée. Pour l'instant, on se base sur le champ `ds_state` : s'il est vide ou s'il indique un dossier "en construction", on importe le projet.

On prévoira peut-être du filtrage plus intelligent à l'avenir. Par exemple, créer ou non un projet pour les dossiers refusés ou classés sans suite sur DS ? On ne voudra pas les inclure dans les simulations, mais l'information sera intéressante à connaître dans les blocs de récapitulation de l'historique…

## 🔍 Liste des modifications

- Ajout d'une tâche celery permettant de synchroniser tous les projets d'un coup
- Ajout d'un signal qui crée automatiquement un Projet si on sauvegarde un Dossier qui a l'air complet.
- Tests automatisés là-dessus.
