### PR TITLE
css: ajout d'un style pour le statut

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -127,6 +127,22 @@ ul.no-list-style li {
     padding-left: 1.5em;
 }
 
+.ds_state__accepte{
+    color: var(--text-default-success)
+}
+
+.ds_state__accepte::before{
+    content: "✅";
+}
+
+.ds_state__refuse{
+    color: var(--text-default-error)
+}
+
+.ds_state__refuse::before{
+    content: "❌";
+}
+
 /* simulation */
 
 .status-draft {

--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -132,7 +132,7 @@ ul.no-list-style li {
 }
 
 .ds_state__accepte::before{
-    content: "✅";
+    content: "✅" / "";
 }
 
 .ds_state__refuse{

--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -140,7 +140,7 @@ ul.no-list-style li {
 }
 
 .ds_state__refuse::before{
-    content: "❌";
+    content: "❌" / "";
 }
 
 /* simulation */

--- a/gsl_projet/templates/gsl_projet/projet_list.html
+++ b/gsl_projet/templates/gsl_projet/projet_list.html
@@ -137,8 +137,8 @@
                                 {% endfor %}
                             </ul>
                         </td>
-                        <td>
-                            {{ projet.dossier_ds.get_ds_state_display }}
+                        <td class="ds_state__{{ projet.dossier_ds.ds_state }}">
+                            <b>{{ projet.dossier_ds.get_ds_state_display }}</b>
                         </td>
                         <td class="fr-cell--right">
                             <a class="fr-btn--tertiary-no-outline gsl-no-underline"


### PR DESCRIPTION
## 🌮 Objectif

Rajouter un style (couleur + emoji) au statut dans la liste des projets

## 🔍 Liste des modifications

- `projet_list.html` et `gsl.css`

## 🖼️ Images

<img width="424" alt="Capture d’écran 2025-01-06 à 18 20 22" src="https://github.com/user-attachments/assets/49497f8f-552e-4b1b-bb85-6373dcfeb566" />
