### PR TITLE
Changement de la manière dont on récupère les projets sur la page "détail d'une simulation"

### DIFF
--- a/gsl_programmation/templates/gsl_programmation/simulation_detail.html
+++ b/gsl_programmation/templates/gsl_programmation/simulation_detail.html
@@ -33,9 +33,6 @@
                 Rappel de la dotation/des dotations
             </li>
             <li>
-                Filtres et tri : reporté à Janvier / à mutualiser avec les filtres des projets ?
-            </li>
-            <li>
                 tableau : colonnes case à cocher pour sélectionner, date de dépôt, intitulé du projet, commune,
                 dotation,
                 coût total, montant sollicité, montant prévi accordé, taux de subvention, choix de la catégorie, statut,
@@ -43,6 +40,7 @@
             </li>
         </ul>
     </details>
+    {% include "gsl_projet/includes/_projet_list_filters.html" %}
     <div class="fr-table--lg gsl-projet-table">
         <table>
             <thead>

--- a/gsl_programmation/templates/gsl_programmation/simulation_detail.html
+++ b/gsl_programmation/templates/gsl_programmation/simulation_detail.html
@@ -128,12 +128,13 @@
                                 {{ projet.get_taux_de_subvention_sollicite|percent }}
                             </td>
                             <td class="gsl-money">
-                                <div class="fr-input-wrap fr-icon-money-euro-circle-line">
-                                    <input type="number" class="fr-input">
-                                </div>
+                                <input type="text" class="fr-input" value="{{ simu.montant }}">
                             </td>
                             <td class="gsl-money">
-                                <input type="number" inputmode="numeric" class="fr-input">
+                                <input type="text"
+                                       inputmode="numeric"
+                                       class="fr-input"
+                                       value="{{ simu.taux }}">
                             </td>
                             <td>
                                 <select class="fr-select" name="" id="">

--- a/gsl_programmation/templates/gsl_programmation/simulation_detail.html
+++ b/gsl_programmation/templates/gsl_programmation/simulation_detail.html
@@ -90,73 +90,75 @@
                 </tr>
             </thead>
             <tbody>
-                {% for simu in simulations_list %}
-                    <tr>
-                        <td>
-                            <input type="checkbox"
-                                   name="simu[{{ simu.pk }}]"
-                                   aria-label="Sélectionner le projet {{ simu.projet.dossier_ds.projet_intitule }}">
-                        </td>
-                        <td>
-                            {{ simu.projet.dossier_ds.ds_date_depot|date:"d/m/Y" }}
-                        </td>
-                        <td>
-                            {{ simu.projet.dossier_ds.projet_intitule }}
-                        </td>
-                        <td>
-                            {{ simu.projet.address.commune.name }}
-                        </td>
-                        <td>
-                            <select>
-                                <option value="DETR">
-                                    DETR
-                                </option>
-                                <option value="DSIL">
-                                    DSIL
-                                </option>
-                            </select>
-                        </td>
-                        <td class="gsl-money">
-                            {{ simu.projet.assiette_or_cout_total|floatformat:"2g"|default:"—" }}&nbsp;€
-                            <br>
-                            &nbsp;
-                        </td>
-                        <td class="gsl-money">
-                            {{ simu.projet.dossier_ds.demande_montant|floatformat:"2g"|default:"—" }}&nbsp;€
-                            <br>
-                            {{ simu.projet.get_taux_de_subvention_sollicite|percent }}
-                        </td>
-                        <td class="gsl-money">
-                            <div class="fr-input-wrap fr-icon-money-euro-circle-line">
-                                <input type="number" class="fr-input">
-                            </div>
-                        </td>
-                        <td class="gsl-money">
-                            <input type="number" inputmode="numeric" class="fr-input">
-                        </td>
-                        <td>
-                            <select class="fr-select" name="" id="">
-                                <option value="">
-                                    {{ simu.projet.categorie_doperation.first }}
-                                </option>
-                            </select>
-                        </td>
-                        <td>
-                            <span class="status-{{ simu.status }}">{{ simu.get_status_display }}</span>
-                        </td>
-                        <td class="fr-cell--right gsl-nowrap">
-                            <a class="fr-btn--tertiary-no-outline gsl-no-underline"
-                               href="{{ simu.projet.get_absolute_url }}">
-                                <span class="fr-sr-only">Modifier le projet {{ simu.projet.dossier_ds.ds_number }}</span>
-                                <span class="fr-icon-edit-fill" aria-hidden="true"></span>
-                            </a>
-                            <a class="fr-btn--tertiary-no-outline gsl-no-underline"
-                               href="{{ simu.projet.get_absolute_url }}">
-                                <span class="fr-sr-only">Voir le projet {{ simu.projet.dossier_ds.ds_number }}</span>
-                                <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
-                            </a>
-                        </td>
-                    </tr>
+                {% for projet in simulations_list %}
+                    {% with projet.simu.0 as simu %}
+                        <tr>
+                            <td>
+                                <input type="checkbox"
+                                       name="simu[{{ simu.pk }}]"
+                                       aria-label="Sélectionner le projet {{ projet.dossier_ds.projet_intitule }}">
+                            </td>
+                            <td>
+                                {{ projet.dossier_ds.ds_date_depot|date:"d/m/Y" }}
+                            </td>
+                            <td>
+                                {{ projet.dossier_ds.projet_intitule }}
+                            </td>
+                            <td>
+                                {{ projet.address.commune.name }}
+                            </td>
+                            <td>
+                                <select>
+                                    <option value="DETR">
+                                        DETR
+                                    </option>
+                                    <option value="DSIL">
+                                        DSIL
+                                    </option>
+                                </select>
+                            </td>
+                            <td class="gsl-money">
+                                {{ projet.assiette_or_cout_total|floatformat:"2g"|default:"—" }}&nbsp;€
+                                <br>
+                                &nbsp;
+                            </td>
+                            <td class="gsl-money">
+                                {{ projet.dossier_ds.demande_montant|floatformat:"2g"|default:"—" }}&nbsp;€
+                                <br>
+                                {{ projet.get_taux_de_subvention_sollicite|percent }}
+                            </td>
+                            <td class="gsl-money">
+                                <div class="fr-input-wrap fr-icon-money-euro-circle-line">
+                                    <input type="number" class="fr-input">
+                                </div>
+                            </td>
+                            <td class="gsl-money">
+                                <input type="number" inputmode="numeric" class="fr-input">
+                            </td>
+                            <td>
+                                <select class="fr-select" name="" id="">
+                                    <option value="">
+                                        {{ projet.categorie_doperation.first }}
+                                    </option>
+                                </select>
+                            </td>
+                            <td>
+                                <span class="status-{{ simu.status }}">{{ simu.get_status_display }}</span>
+                            </td>
+                            <td class="fr-cell--right gsl-nowrap">
+                                <a class="fr-btn--tertiary-no-outline gsl-no-underline"
+                                   href="{{ projet.get_absolute_url }}">
+                                    <span class="fr-sr-only">Modifier le projet {{ projet.dossier_ds.ds_number }}</span>
+                                    <span class="fr-icon-edit-fill" aria-hidden="true"></span>
+                                </a>
+                                <a class="fr-btn--tertiary-no-outline gsl-no-underline"
+                                   href="{{ projet.get_absolute_url }}">
+                                    <span class="fr-sr-only">Voir le projet {{ projet.dossier_ds.ds_number }}</span>
+                                    <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
+                                </a>
+                            </td>
+                        </tr>
+                    {% endwith %}
                 {% empty %}
                     <tr>
                         <td colspan="12">

--- a/gsl_programmation/views.py
+++ b/gsl_programmation/views.py
@@ -39,6 +39,7 @@ class SimulationDetailView(DetailView, FilterProjetsMixin):
         context["title"] = (
             f"{simulation.enveloppe.type} {simulation.enveloppe.annee} – {simulation.title}"
         )
+        context["porteur_mappings"] = self.PORTEUR_MAPPINGS
 
         context["breadcrumb_dict"] = {
             "links": [

--- a/gsl_programmation/views.py
+++ b/gsl_programmation/views.py
@@ -5,6 +5,7 @@ from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 
 from gsl_projet.models import Projet
+from gsl_projet.views import FilterProjetsMixin
 
 from .models import Simulation, SimulationProjet
 
@@ -21,7 +22,7 @@ class SimulationListView(ListView):
         return context
 
 
-class SimulationDetailView(DetailView):
+class SimulationDetailView(DetailView, FilterProjetsMixin):
     model = Simulation
 
     def get_context_data(self, **kwargs):
@@ -54,6 +55,7 @@ class SimulationDetailView(DetailView):
     def get_projet_queryset(self):
         simulation = self.get_object()
         qs = Projet.objects.filter(simulationprojet__simulation=simulation)
+        qs = self.add_filters_to_projets_qs(qs)
         qs = qs.prefetch_related(
             Prefetch(
                 "simulationprojet_set",


### PR DESCRIPTION
## 🌮 Objectif

Afficher les projets dans la liste d'une simulation, de façon à pouvoir les filtrer et les trier aisément en réutilisant le travail fait par @maximallain sur la page "liste des projets".

## 🔍 Liste des modifications

- Utilisation de `Prefetch` et `prefetch_related` sur un `queryset` de `Projet`s.

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
