### PR TITLE
Amélioration de la perf sur la vue "Simulation de programmation"

### DIFF
--- a/gsl_programmation/admin.py
+++ b/gsl_programmation/admin.py
@@ -17,3 +17,4 @@ class SimulationAdmin(admin.ModelAdmin):
 class SimulationProjetAdmin(admin.ModelAdmin):
     list_display = ("__str__", "projet__dossier_ds__projet_intitule")
     search_fields = ("projet__dossier_ds__projet_intitule",)
+    raw_id_fields = ("projet",)

--- a/gsl_programmation/views.py
+++ b/gsl_programmation/views.py
@@ -57,6 +57,7 @@ class SimulationDetailView(DetailView, FilterProjetsMixin):
         simulation = self.get_object()
         qs = Projet.objects.filter(simulationprojet__simulation=simulation)
         qs = self.add_filters_to_projets_qs(qs)
+        qs = qs.select_related("address").select_related("address__commune")
         qs = qs.prefetch_related(
             Prefetch(
                 "simulationprojet_set",


### PR DESCRIPTION
## 🌮 Objectif

Maxime a constaté l'existence de requêtes dupliquées sur la page simulation de programmation : 

<img width="702" alt="Capture d’écran 2025-01-09 à 11 23 57" src="https://github.com/user-attachments/assets/49292252-02a7-4d02-a50f-79b599893790" />

C'est dû à l'affichage des adresses et de la commune qui demandent des requêtes SQL supplémentaires. On parle d'un problème "N+1", c'est assez classique.

## 🔍 Liste des modifications

Utilisation de `select_related` pour récupérer les données des modèles liés en une seule requête.

(`prefetch_related` donne le même résultat en faisant une requête à part, ndlr)

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
