### PR TITLE
Évitons une succession sans fin d'appels à Démarches Simplifiées

### DIFF
--- a/gsl_demarches_simplifiees/ds_client.py
+++ b/gsl_demarches_simplifiees/ds_client.py
@@ -68,6 +68,9 @@ class DsClient:
         ]
         while has_next_page:
             end_cursor = result["data"]["demarche"]["dossiers"]["pageInfo"]["endCursor"]
+            has_next_page = result["data"]["demarche"]["dossiers"]["pageInfo"][
+                "hasNextPage"
+            ]
             variables["after"] = end_cursor
             result = self.launch_graphql_query("getDemarche", variables=variables)
             yield from result["data"]["demarche"]["dossiers"]["nodes"]


### PR DESCRIPTION
## 🌮 Objectif

Lors des analyses de données des démarches existantes, j'ai constaté un comportement étrange sur mon poste : on se retrouvait à traiter les informations de certains dossiers plusieurs centaines de fois, sans que rien dans mon attitude ne puisse l'expliquer.

Après examen de la situation : oui, il y avait un bug. Une boucle sans fin.

## 🔍 Liste des modifications

- Mise à jour de la condition de sortie de boucle


## 🖼️ Images

Le morceau d'interface qui m'a mis la puce à l'oreille : 

![1033018 résultats dans l'historique de Celery](https://github.com/user-attachments/assets/33b20efe-1d23-47aa-9879-3f0d07d06be1)

