### PR TITLE
Rétablissement du déploiement sur Scalingo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "django-json-widget",
     "gunicorn",
     "mozilla-django-oidc",
-    "psycopg2-binary",
+    "psycopg[binary]",
     "python-dotenv",
     "redis",
     "sentry-sdk",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -179,8 +179,10 @@ prompt-toolkit==3.0.48
     # via
     #   click-repl
     #   ipython
-psycopg2-binary==2.9.9
+psycopg[binary]==3.2.4
     # via gsl (pyproject.toml)
+psycopg-binary==3.2.4
+    # via psycopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
@@ -262,6 +264,7 @@ typing-extensions==4.12.2
     # via
     #   dj-database-url
     #   faker
+    #   psycopg
 tzdata==2024.2
     # via
     #   celery

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,8 +93,10 @@ packaging==24.1
     # via gunicorn
 prompt-toolkit==3.0.48
     # via click-repl
-psycopg2-binary==2.9.9
+psycopg[binary]==3.2.4
     # via gsl (pyproject.toml)
+psycopg-binary==3.2.4
+    # via psycopg
 pycparser==2.22
     # via cffi
 pyopenssl==24.2.1
@@ -122,7 +124,9 @@ sqlparse==0.5.1
 tablib==3.7.0
     # via django-import-export
 typing-extensions==4.12.2
-    # via dj-database-url
+    # via
+    #   dj-database-url
+    #   psycopg
 tzdata==2024.2
     # via
     #   celery


### PR DESCRIPTION
## 🌮 Objectif

Le déploiement sur Scalingo (plateforme de production et préproduction) ne fonctionne pas, il échoue avec une erreur relative à psycopg (le module de code permettant de discuter avec la base de données).

Le déploiement fonctionne si on remplace le module psycopg2 par psycopg (qui est en fait psycopg version 3, comme son nom ne l'indique pas).


