### PR TITLE
Formulaire de connexion sans ProConnect

### DIFF
--- a/gsl_oidc/templates/registration/login.html
+++ b/gsl_oidc/templates/registration/login.html
@@ -134,10 +134,6 @@
                                                             <label class="fr-password__checkbox fr-label" for="password-1758-show">
                                                                 Afficher
                                                             </label>
-                                                            <div class="fr-messages-group"
-                                                                 id="password-1758-show-messages"
-                                                                 aria-live="assertive">
-                                                            </div>
                                                         </div>
                                                         {% comment %}
                                                         <p>
@@ -146,10 +142,6 @@
                                                         </p>
                                                         {% endcomment %}
                                                     </div>
-                                                </div>
-                                                <div class="fr-messages-group"
-                                                     id="credentials-messages"
-                                                     aria-live="assertive">
                                                 </div>
                                             </fieldset>
                                         </div>
@@ -162,10 +154,6 @@
                                                 <label class="fr-label" for="remember-1759">
                                                     Se souvenir de moi
                                                 </label>
-                                                <div class="fr-messages-group"
-                                                     id="remember-1759-messages"
-                                                     aria-live="assertive">
-                                                </div>
                                             </div>
                                         </div>
                                         <div class="fr-fieldset__element">
@@ -176,10 +164,6 @@
                                                     </button>
                                                 </li>
                                             </ul>
-                                        </div>
-                                        <div class="fr-messages-group"
-                                             id="login-1760-fieldset-messages"
-                                             aria-live="assertive">
                                         </div>
                                     </fieldset>
                                 </form>

--- a/gsl_oidc/templates/registration/login.html
+++ b/gsl_oidc/templates/registration/login.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static dsfr_tags %}
 {% block content %}
 
     <div class="fr-container fr-container--fluid fr-mb-md-14v">
@@ -36,20 +36,34 @@
                                     </p>
                                 </div>
                             </div>
-                            {% comment %}
-                            <p class="fr-hr-or">ou</p>
+                            <p class="fr-hr-or">
+                                ou
+                            </p>
                             <div>
                                 <form id="login-1760" action="{% url "login" %}" method="POST">
                                     {% csrf_token %}
-                                    <fieldset class="fr-fieldset" id="login-1760-fieldset" aria-labelledby="login-1760-fieldset-legend">
+                                    <fieldset class="fr-fieldset"
+                                              id="login-1760-fieldset"
+                                              aria-labelledby="login-1760-fieldset-legend">
                                         <legend class="fr-fieldset__legend" id="login-1760-fieldset-legend">
-                                            <h2>Se connecter avec son compte</h2>
+                                            <h2>
+                                                Se connecter avec son compte
+                                            </h2>
                                         </legend>
                                         <!--<div class="fr-fieldset__element">
-                                            <p class="fr-text--sm"></p>
-                                        </div>-->
+                                        <p class="fr-text--sm"></p>
+                                    </div>-->
                                         <div class="fr-fieldset__element">
-                                            <fieldset class="fr-fieldset" id="credentials" aria-labelledby="credentials-messages">
+                                            <fieldset class="fr-fieldset"
+                                                      id="credentials"
+                                                      aria-labelledby="credentials-messages">
+                                                {% if form.non_field_errors %}
+                                                    <div class="non-field-errors">
+                                                        {% for err in form.non_field_errors %}
+                                                            {% dsfr_alert content=err extra_classes="fr-alert-sm" type="error" %}
+                                                        {% endfor %}
+                                                    </div>
+                                                {% endif %}
                                                 <div class="fr-fieldset__element">
                                                     <span class="fr-hint-text">Sauf mention contraire, tous les champs sont obligatoires.</span>
                                                 </div>
@@ -59,9 +73,20 @@
                                                             Adresse e-mail
                                                             <span class="fr-hint-text">Format attendu : nom@domaine.fr</span>
                                                         </label>
-                                                        <input class="fr-input" autocomplete="username" aria-required="true" aria-describedby="username-1757-messages" name="username" id="username-1757" type="text">
-                                                        <div class="fr-messages-group" id="username-1757-messages" aria-live="assertive">
-                                                        </div>
+                                                        <input class="fr-input"
+                                                               autocomplete="username"
+                                                               aria-required="true"
+                                                               aria-describedby="username-1757-messages"
+                                                               name="username"
+                                                               id="username-1757"
+                                                               type="text">
+                                                        {% for err in form.errors.username %}
+                                                            <div class="fr-messages-group"
+                                                                 id="username-1757-messages"
+                                                                 aria-live="assertive">
+                                                                {{ err }}
+                                                            </div>
+                                                        {% endfor %}
                                                     </div>
                                                 </div>
                                                 <div class="fr-fieldset__element">
@@ -70,34 +95,55 @@
                                                             Mot de passe
                                                         </label>
                                                         <div class="fr-input-wrap">
-                                                            <input class="fr-password__input fr-input" aria-describedby="password-1758-input-messages" aria-required="true" name="password" autocomplete="current-password" id="password-1758-input" type="password">
+                                                            <input class="fr-password__input fr-input"
+                                                                   aria-describedby="password-1758-input-messages"
+                                                                   aria-required="true"
+                                                                   name="password"
+                                                                   autocomplete="current-password"
+                                                                   id="password-1758-input"
+                                                                   type="password">
                                                         </div>
-                                                        <div class="fr-messages-group" id="password-1758-input-messages" aria-live="assertive">
+                                                        <div class="fr-messages-group"
+                                                             id="password-1758-input-messages"
+                                                             aria-live="assertive">
                                                         </div>
                                                         <div class="fr-password__checkbox fr-checkbox-group fr-checkbox-group--sm">
-                                                            <input aria-label="Afficher le mot de passe" id="password-1758-show" type="checkbox" aria-describedby="password-1758-show-messages">
+                                                            <input aria-label="Afficher le mot de passe"
+                                                                   id="password-1758-show"
+                                                                   type="checkbox"
+                                                                   aria-describedby="password-1758-show-messages">
                                                             <label class="fr-password__checkbox fr-label" for="password-1758-show">
                                                                 Afficher
                                                             </label>
-                                                            <div class="fr-messages-group" id="password-1758-show-messages" aria-live="assertive">
+                                                            <div class="fr-messages-group"
+                                                                 id="password-1758-show-messages"
+                                                                 aria-live="assertive">
                                                             </div>
                                                         </div>
                                                         <p>
-                                                            <a href="{% url 'password_reset' %}" class="fr-link">Mot de passe oublié ?</a>
+                                                            <a href="{% url 'password_reset' %}" class="fr-link">Mot de
+                                                            passe oublié ?</a>
                                                         </p>
                                                     </div>
                                                 </div>
-                                                <div class="fr-messages-group" id="credentials-messages" aria-live="assertive">
+                                                <div class="fr-messages-group"
+                                                     id="credentials-messages"
+                                                     aria-live="assertive">
                                                 </div>
                                             </fieldset>
                                         </div>
                                         <div class="fr-fieldset__element">
                                             <div class="fr-checkbox-group fr-checkbox-group--sm">
-                                                <input name="remember" id="remember-1759" type="checkbox" aria-describedby="remember-1759-messages">
+                                                <input name="remember"
+                                                       id="remember-1759"
+                                                       type="checkbox"
+                                                       aria-describedby="remember-1759-messages">
                                                 <label class="fr-label" for="remember-1759">
                                                     Se souvenir de moi
                                                 </label>
-                                                <div class="fr-messages-group" id="remember-1759-messages" aria-live="assertive">
+                                                <div class="fr-messages-group"
+                                                     id="remember-1759-messages"
+                                                     aria-live="assertive">
                                                 </div>
                                             </div>
                                         </div>
@@ -110,12 +156,13 @@
                                                 </li>
                                             </ul>
                                         </div>
-                                        <div class="fr-messages-group" id="login-1760-fieldset-messages" aria-live="assertive">
+                                        <div class="fr-messages-group"
+                                             id="login-1760-fieldset-messages"
+                                             aria-live="assertive">
                                         </div>
                                     </fieldset>
                                 </form>
                             </div>
-                            {% endcomment %}
 
                             {% comment %}
                             <hr>

--- a/gsl_oidc/templates/registration/login.html
+++ b/gsl_oidc/templates/registration/login.html
@@ -1,7 +1,18 @@
 {% extends "base.html" %}
 {% load static dsfr_tags %}
-{% block content %}
 
+{% block title %}
+    <title>
+        {% if form.errors %}
+            Erreur de connexion
+        {% else %}
+            Se connecter avec ProConnect ou une adresse e-mail
+        {% endif %}
+        — {{ SITE_CONFIG.site_title }}
+    </title>
+{% endblock title %}
+
+{% block content %}
     <div class="fr-container fr-container--fluid fr-mb-md-14v">
         <div class="fr-grid-row fr-grid-row-gutters fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
@@ -120,10 +131,12 @@
                                                                  aria-live="assertive">
                                                             </div>
                                                         </div>
+                                                        {% comment %}
                                                         <p>
                                                             <a href="{% url 'password_reset' %}" class="fr-link">Mot de
                                                             passe oublié ?</a>
                                                         </p>
+                                                        {% endcomment %}
                                                     </div>
                                                 </div>
                                                 <div class="fr-messages-group"

--- a/gsl_oidc/templates/registration/login.html
+++ b/gsl_oidc/templates/registration/login.html
@@ -61,9 +61,6 @@
                                                 Se connecter avec son compte
                                             </h2>
                                         </legend>
-                                        <!--<div class="fr-fieldset__element">
-                                        <p class="fr-text--sm"></p>
-                                    </div>-->
                                         <div class="fr-fieldset__element">
                                             <fieldset class="fr-fieldset"
                                                       id="credentials"
@@ -91,13 +88,17 @@
                                                                name="username"
                                                                id="username-1757"
                                                                type="text">
-                                                        {% for err in form.errors.username %}
+                                                        {% if form.errors.username %}
                                                             <div class="fr-messages-group"
                                                                  id="username-1757-messages"
                                                                  aria-live="assertive">
-                                                                {{ err }}
+                                                                {% for err in form.errors.username %}
+                                                                    <p class="fr-message fr-message--error">
+                                                                        {{ err }}
+                                                                    </p>
+                                                                {% endfor %}
                                                             </div>
-                                                        {% endfor %}
+                                                        {% endif %}
                                                     </div>
                                                 </div>
                                                 <div class="fr-fieldset__element">
@@ -114,10 +115,17 @@
                                                                    id="password-1758-input"
                                                                    type="password">
                                                         </div>
-                                                        <div class="fr-messages-group"
-                                                             id="password-1758-input-messages"
-                                                             aria-live="assertive">
-                                                        </div>
+                                                        {% if form.errors.password %}
+                                                            <div class="fr-messages-group"
+                                                                 id="password-1757-messages"
+                                                                 aria-live="assertive">
+                                                                {% for err in form.errors.password %}
+                                                                    <p class="fr-message fr-message--error">
+                                                                        {{ err }}
+                                                                    </p>
+                                                                {% endfor %}
+                                                            </div>
+                                                        {% endif %}
                                                         <div class="fr-password__checkbox fr-checkbox-group fr-checkbox-group--sm">
                                                             <input aria-label="Afficher le mot de passe"
                                                                    id="password-1758-show"


### PR DESCRIPTION
## 🌮 Objectif

Permettre aux agents instructeurs de se connecter, même si ProConnect n'est pas encore prêt pour la production de notre côté.


## 🖼️ Images

<details><summary>Formulaire vide</summary>
<img src="https://github.com/user-attachments/assets/588ec33b-1842-4f7d-8cbd-2238a91e6deb" alt="">
</details>

<details><summary>Formulaire avec erreurs</summary>
<img width="627" alt="Capture d’écran 2025-01-22 à 14 08 16" src="https://github.com/user-attachments/assets/26aee7c9-3439-496f-9c1f-fd9ca9d48639" />
<img width="525" alt="Capture d’écran 2025-01-22 à 14 12 07" src="https://github.com/user-attachments/assets/236c9568-aa9c-41b3-a237-9b6c986130d6" />
</details>
