### PR TITLE
Import des enveloppes depuis un fichier tableur

### DIFF
--- a/gsl_programmation/admin.py
+++ b/gsl_programmation/admin.py
@@ -1,20 +1,24 @@
 from django.contrib import admin
+from import_export.admin import ImportExportMixin
+
+from gsl_core.admin import AllPermsForStaffUser
 
 from .models import Enveloppe, Simulation, SimulationProjet
+from .resources import EnveloppeDETRResource, EnveloppeDSILResource
 
 
 @admin.register(Enveloppe)
-class EnveloppeAdmin(admin.ModelAdmin):
-    pass
+class EnveloppeAdmin(AllPermsForStaffUser, ImportExportMixin, admin.ModelAdmin):
+    resource_classes = (EnveloppeDETRResource, EnveloppeDSILResource)
 
 
 @admin.register(Simulation)
-class SimulationAdmin(admin.ModelAdmin):
+class SimulationAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     pass
 
 
 @admin.register(SimulationProjet)
-class SimulationProjetAdmin(admin.ModelAdmin):
+class SimulationProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     list_display = ("__str__", "projet__dossier_ds__projet_intitule")
     search_fields = ("projet__dossier_ds__projet_intitule",)
     raw_id_fields = ("projet",)

--- a/gsl_programmation/admin.py
+++ b/gsl_programmation/admin.py
@@ -10,6 +10,8 @@ from .resources import EnveloppeDETRResource, EnveloppeDSILResource
 @admin.register(Enveloppe)
 class EnveloppeAdmin(AllPermsForStaffUser, ImportExportMixin, admin.ModelAdmin):
     resource_classes = (EnveloppeDETRResource, EnveloppeDSILResource)
+    list_display = ("__str__", "montant", "type", "annee")
+    list_filter = ("type", "annee")
 
 
 @admin.register(Simulation)

--- a/gsl_programmation/resources.py
+++ b/gsl_programmation/resources.py
@@ -1,0 +1,60 @@
+import random
+
+from import_export import resources
+from import_export.fields import Field
+from import_export.widgets import ForeignKeyWidget
+
+from gsl_core.models import Departement, Perimetre
+
+from .models import Enveloppe
+
+
+class EnveloppeDETRResource(resources.ModelResource):
+    # type = models.CharField("Type", choices=TYPE_CHOICES) # hardcodé
+    montant = Field(attribute="montant")
+    annee = Field(attribute="annee")
+    perimetre = Field(
+        attribute="perimetre",
+        widget=ForeignKeyWidget(Perimetre),
+    )
+    enveloppe_id = Field(attribute="id")
+
+    def before_import(self, dataset, **kwargs):
+        # mimic a 'dynamic field'
+        dataset.headers.append("enveloppe_id")
+        dataset.headers.append("type")
+        super().before_import(dataset, **kwargs)
+
+    def before_import_row(self, row, **kwargs):
+        row["enveloppe_id"] = None
+        row["type"] = Enveloppe.TYPE_DETR
+        provided_departement_number = row["perimetre"]
+        departement = Departement.objects.get(insee_code=provided_departement_number)
+        perimetre, _ = Perimetre.objects.get_or_create(
+            departement=departement,
+            arrondissement__isnull=True,
+            defaults={
+                "departement": departement,
+                "region": departement.region,
+            },
+        )
+        row["perimetre"] = perimetre.id
+
+        enveloppe_qs = Enveloppe.objects.filter(
+            perimetre=perimetre, type=row["type"], annee=row["annee"]
+        )
+        if enveloppe_qs.exists():
+            row["enveloppe_id"] = enveloppe_qs.get().id
+
+    class Meta:
+        model = Enveloppe
+        import_id_fields = ("enveloppe_id",)
+        fields = ("enveloppe_id", "montant", "annee", "perimetre", "type")
+
+
+class EnveloppeDSILResource(EnveloppeDETRResource):
+    def before_import_row(self, row, **kwargs):
+        # author_name = row["author"]
+        # Author.objects.get_or_create(name=author_name, defaults={"name": author_name})
+        row["type"] = Enveloppe.TYPE_DSIL
+        row["enveloppe_id"] = random.choice((1, 2, 2, 3, 4))


### PR DESCRIPTION
## 🌮 Objectif

Saisir manuellement toutes les données DETR, ça fait _beaucoup_ de clics.

Dans la mesure où les agents de la DGCL ont un tableur avec tous les montants, donnons-leur la possibilité de les importer.

## 🔍 Liste des modifications

- Deux classes `Resource` pour importer respectivement les enveloppes DETR et DSIL
- De l'amélioration de l'interface d'admin

## ⚠️ Informations supplémentaires

Le fichier a besoin des en-têtes suivants : 

- `perimetre` contenant soit le code INSEE du département, soit le code INSEE de la région
- `montant` contenant le montant de la dotation, sans signe euro, sans espaces, sans virgules
- `annee` contenant l'année (ici 2024 ou 2025)

J'ai rencontré des problèmes avec les départements suivants qui n'étaient pas correctement sauvegardés dans ma base après l'import INSEE, à creuser : 

- 975
- 986
- 987
- 988

## 🖼️ Images

Le formulaire d'importation : 

<img width="405" alt="Capture d’écran 2025-01-22 à 16 50 26" src="https://github.com/user-attachments/assets/59ee97a8-b96c-4c9f-bd62-8b8e9ffccd22" />

<details><summary>Mes écrans "Enveloppes" après mes imports</summary>
<img width="1436" alt="Capture d’écran 2025-01-22 à 16 50 01" src="https://github.com/user-attachments/assets/390758c1-9aa6-44ad-b56b-844f89bd6852" />
<img width="1438" alt="Capture d’écran 2025-01-22 à 16 50 14" src="https://github.com/user-attachments/assets/406ebac8-3d5c-4cde-9ab5-c0237e4a4fce" />
</details>