### PR TITLE
fix: if no perimetre, return all enveloppes

### DIFF
--- a/gsl_programmation/service/enveloppe_service.py
+++ b/gsl_programmation/service/enveloppe_service.py
@@ -7,6 +7,9 @@ from gsl_programmation.models import Enveloppe
 class EnveloppeService:
     @classmethod
     def get_enveloppes_from_perimetre(cls, perimetre: Perimetre):
+        if perimetre is None:
+            return Enveloppe.objects.all()
+
         if perimetre.type == Perimetre.TYPE_REGION:
             return Enveloppe.objects.filter(
                 perimetre__region=perimetre.region,


### PR DESCRIPTION
## 🌮 Objectif

Bug fix : si pas de périmètre associé à l'utilisateur => on renvoie toutes les simulations.