### PR TITLE
Résolution de problèmes à la création de projets depuis les dossiers DS

### DIFF
--- a/gsl_projet/apps.py
+++ b/gsl_projet/apps.py
@@ -6,3 +6,6 @@ class GslProjetConfig(AppConfig):
     name = "gsl_projet"
 
     verbose_name = "3. Projets"
+
+    def ready(self):
+        import gsl_projet.signals  # noqa F401

--- a/gsl_projet/signals.py
+++ b/gsl_projet/signals.py
@@ -8,6 +8,6 @@ from .tasks import update_projet_from_dossier
 
 @receiver(post_save, sender=Dossier, dispatch_uid="create_projet")
 def create_projet_from_valid_dossier(sender, instance: Dossier, *args, **kwargs):
-    if not instance.ds_state or instance.ds_state == Dossier.STATE_EN_CONSTRUCTION:
+    if not instance.ds_state:
         return
     update_projet_from_dossier.delay(instance.ds_number)

--- a/gsl_projet/tasks.py
+++ b/gsl_projet/tasks.py
@@ -13,8 +13,6 @@ def update_projet_from_dossier(ds_dossier_number):
 
 @shared_task
 def create_all_projets_from_dossiers():
-    dossiers = Dossier.objects.exclude(ds_state=Dossier.STATE_EN_CONSTRUCTION).exclude(
-        ds_state=""
-    )
+    dossiers = Dossier.objects.exclude(ds_state="")
     for dossier in dossiers.all():
         update_projet_from_dossier.delay(dossier.ds_number)

--- a/gsl_projet/tests/test_signals.py
+++ b/gsl_projet/tests/test_signals.py
@@ -13,7 +13,7 @@ def test_dont_create_projets_from_incomplete_data():
     with mock.patch("gsl_projet.tasks.update_projet_from_dossier.delay") as task_mock:
         d = DossierFactory(ds_state=Dossier.STATE_EN_CONSTRUCTION)
         d.save()
-        task_mock.assert_not_called()
+        task_mock.assert_called_once_with(d.ds_number)
     with mock.patch("gsl_projet.tasks.update_projet_from_dossier.delay") as task_mock:
         d = DossierFactory(ds_state="")
         d.save()

--- a/gsl_projet/tests/test_tasks.py
+++ b/gsl_projet/tests/test_tasks.py
@@ -12,8 +12,8 @@ pytestmark = pytest.mark.django_db
 
 
 def test_create_all_projets():
-    DossierFactory(ds_state=Dossier.STATE_EN_CONSTRUCTION)
-    dossier_en_instruction = DossierFactory(ds_state=Dossier.STATE_EN_INSTRUCTION)
+    dossier_en_construction = DossierFactory(ds_state=Dossier.STATE_EN_CONSTRUCTION)
+    DossierFactory(ds_state="")
     with mock.patch("gsl_projet.tasks.update_projet_from_dossier.delay") as task_mock:
         create_all_projets_from_dossiers()
-        task_mock.assert_called_once_with(dossier_en_instruction.ds_number)
+        task_mock.assert_called_once_with(dossier_en_construction.ds_number)


### PR DESCRIPTION
## 🌮 Objectif

Résoudre deux problèmes : 

1. On ignorait les dossiers "en construction", or en réalité on veut importer tous les dossiers "bien structurés" et seulement par la suite filtrer plus finement selon le statut.
2. le petit système qui ajoutait automatiquement les objets Projet à partir des dossiers était tout bonnement débranché.

## 🔍 Liste des modifications

1. Ne plus ignorer les dossiers en construction.
2. Brancher le système en question (un _signal_ en jargon Django).
