### PR TITLE
Ajout du nombre de projets et de demandeurs dans le résumé d'une enveloppe

### DIFF
--- a/gsl_demarches_simplifiees/tests/factories.py
+++ b/gsl_demarches_simplifiees/tests/factories.py
@@ -1,5 +1,4 @@
 from datetime import timezone
-from random import choice
 
 import factory
 from django.db.models.signals import post_save
@@ -52,7 +51,7 @@ class DossierFactory(factory.django.DjangoModelFactory):
         "date_time_this_year", before_now=True, tzinfo=timezone.utc
     )
     porteur_de_projet_nature = factory.SubFactory(NaturePorteurProjetFactory)
-    demande_dispositif_sollicite = choice(
+    demande_dispositif_sollicite = factory.Iterator(
         [
             Dossier.DEMANDE_DISPOSITIF_SOLLICITE_VALUES[0][0],
             Dossier.DEMANDE_DISPOSITIF_SOLLICITE_VALUES[1][0],

--- a/gsl_demarches_simplifiees/tests/factories.py
+++ b/gsl_demarches_simplifiees/tests/factories.py
@@ -1,4 +1,5 @@
 from datetime import timezone
+from random import choice
 
 import factory
 from django.db.models.signals import post_save
@@ -51,3 +52,9 @@ class DossierFactory(factory.django.DjangoModelFactory):
         "date_time_this_year", before_now=True, tzinfo=timezone.utc
     )
     porteur_de_projet_nature = factory.SubFactory(NaturePorteurProjetFactory)
+    demande_dispositif_sollicite = choice(
+        [
+            Dossier.DEMANDE_DISPOSITIF_SOLLICITE_VALUES[0][0],
+            Dossier.DEMANDE_DISPOSITIF_SOLLICITE_VALUES[1][0],
+        ]
+    )

--- a/gsl_demarches_simplifiees/tests/factories.py
+++ b/gsl_demarches_simplifiees/tests/factories.py
@@ -1,6 +1,7 @@
 from datetime import timezone
 
 import factory
+import factory.fuzzy
 from django.db.models.signals import post_save
 
 from gsl_core.tests.factories import AdresseFactory
@@ -51,7 +52,7 @@ class DossierFactory(factory.django.DjangoModelFactory):
         "date_time_this_year", before_now=True, tzinfo=timezone.utc
     )
     porteur_de_projet_nature = factory.SubFactory(NaturePorteurProjetFactory)
-    demande_dispositif_sollicite = factory.Iterator(
+    demande_dispositif_sollicite = factory.fuzzy.FuzzyChoice(
         [
             Dossier.DEMANDE_DISPOSITIF_SOLLICITE_VALUES[0][0],
             Dossier.DEMANDE_DISPOSITIF_SOLLICITE_VALUES[1][0],

--- a/gsl_programmation/static/css/enveloppe_summary.css
+++ b/gsl_programmation/static/css/enveloppe_summary.css
@@ -47,3 +47,11 @@
 .enveloppe-summary .color-blue {
   color: var(--text-label-blue-france);
 }
+
+.enveloppe-summary .color-green-archipel {
+  background-color: var(--artwork-background-green-archipel);
+}
+
+.enveloppe-summary .color-green-bourgeon {
+  background-color: var(--artwork-background-green-bourgeon);
+}

--- a/gsl_programmation/tasks.py
+++ b/gsl_programmation/tasks.py
@@ -22,7 +22,7 @@ def add_enveloppe_projets_to_simulation(simulation_id):
     selected_projets = Projet.objects.for_perimetre(simulation_perimetre).filter(
         dossier_ds__demande_dispositif_sollicite=simulation_dotation
     )
-    selected_projets = selected_projets.to_deal_with_this_year()
+    selected_projets = selected_projets.for_current_year()
 
     for projet in selected_projets:
         asked_amount = projet.dossier_ds.demande_montant or 0

--- a/gsl_programmation/templates/includes/_enveloppe_summary.html
+++ b/gsl_programmation/templates/includes/_enveloppe_summary.html
@@ -53,23 +53,23 @@
                 <td>
                     {{ enveloppe.montant | euro }}
                 </td>
-                <td>
+                <td class="color-green-archipel">
+                    {{ enveloppe.montant_asked | euro }}
+                </td>
+                <td class="color-green-bourgeon">
                     {{ enveloppe.montant_accepte | euro }}
                 </td>
-                <td>
-                    {{ enveloppe.montant_accepte | euro }}
+                <td class="color-success fr-text--sm">
+                    {{ enveloppe.validated_projets_count }}
                 </td>
-                <td class="color-success">
-                    <b>-</b>
+                <td class="color-error fr-text--sm">
+                    {{ enveloppe.refused_projets_count }}
                 </td>
-                <td class="color-error">
-                    <b>-</b>
+                <td class="color-blue fr-text--sm">
+                    {{ enveloppe.demandeurs }}
                 </td>
-                <td class="color-blue">
-                    <b>{{ enveloppe.demandeurs }}</b>
-                </td>
-                <td class="color-blue">
-                    <b>{{ enveloppe.projets_count }}</b>
+                <td class="color-blue fr-text--sm">
+                    {{ enveloppe.projets_count }}
                 </td>
             </tr>
         </tbody>

--- a/gsl_programmation/templates/includes/_enveloppe_summary.html
+++ b/gsl_programmation/templates/includes/_enveloppe_summary.html
@@ -66,10 +66,10 @@
                     <b>-</b>
                 </td>
                 <td class="color-blue">
-                    <b>-</b>
+                    <b>{{ enveloppe.demandeurs }}</b>
                 </td>
                 <td class="color-blue">
-                    <b>-</b>
+                    <b>{{ enveloppe.projets_count }}</b>
                 </td>
             </tr>
         </tbody>

--- a/gsl_programmation/tests/test_views.py
+++ b/gsl_programmation/tests/test_views.py
@@ -54,8 +54,9 @@ def simulation(perimetre_departemental):
 
 @pytest.fixture
 def projets(simulation, perimetre_departemental):
+    other_perimeter = PerimetreDepartementalFactory()
     projets = []
-    for perimetre in [perimetre_departemental, PerimetreDepartementalFactory()]:
+    for perimetre in [perimetre_departemental, other_perimeter]:
         for type in ("DETR", "DSIL"):
             demandeur = DemandeurFactory(departement=perimetre.departement)
             for state in (

--- a/gsl_programmation/tests/test_views.py
+++ b/gsl_programmation/tests/test_views.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 import pytest
 from django.urls import reverse
 
@@ -6,8 +8,16 @@ from gsl_core.tests.factories import (
     PerimetreDepartementalFactory,
     RequestFactory,
 )
-from gsl_programmation.tests.factories import DetrEnveloppeFactory, SimulationFactory
-from gsl_programmation.views import SimulationListView
+from gsl_demarches_simplifiees.models import Dossier
+from gsl_demarches_simplifiees.tests.factories import DossierFactory
+from gsl_programmation.tests.factories import (
+    DetrEnveloppeFactory,
+    ProjetFactory,
+    SimulationFactory,
+)
+from gsl_programmation.views import SimulationDetailView, SimulationListView
+from gsl_projet.models import Projet
+from gsl_projet.tests.factories import DemandeurFactory
 
 
 @pytest.fixture
@@ -34,6 +44,78 @@ def simulations(perimetre_departemental):
     SimulationFactory()
 
 
+@pytest.fixture
+def simulation(perimetre_departemental):
+    enveloppe = DetrEnveloppeFactory(
+        perimetre=perimetre_departemental, annee=2024, montant=1_000_000
+    )
+    return SimulationFactory(enveloppe=enveloppe)
+
+
+@pytest.fixture
+def projets(simulation, perimetre_departemental):
+    projets = []
+    for perimetre in [perimetre_departemental, PerimetreDepartementalFactory()]:
+        for type in ["DETR", "DSIL"]:
+            demandeur = DemandeurFactory(departement=perimetre.departement)
+            for state in [
+                Dossier.STATE_ACCEPTE,
+                Dossier.STATE_REFUSE,
+                Dossier.STATE_SANS_SUITE,
+            ]:
+                dossier_2024 = DossierFactory(
+                    ds_state=state,
+                    ds_date_depot=datetime(2023, 10, 1, tzinfo=UTC),
+                    ds_date_traitement=datetime(2024, 1, 1, tzinfo=UTC),
+                    annotations_montant_accorde=150_000,
+                    demande_montant=200_000,
+                    demande_dispositif_sollicite=type,
+                )
+                projet_2024 = ProjetFactory(
+                    dossier_ds=dossier_2024, demandeur=demandeur
+                )
+                projets.append(projet_2024)
+
+                dossier_2025 = DossierFactory(
+                    ds_state=state,
+                    ds_date_traitement=datetime(2025, 1, 1, tzinfo=UTC),
+                    demande_montant=300_000,
+                    annotations_montant_accorde=120_000,
+                    demande_dispositif_sollicite=type,
+                )
+                projet_2025 = ProjetFactory(
+                    dossier_ds=dossier_2025, demandeur=demandeur
+                )
+                projets.append(projet_2025)
+
+            demandeur = DemandeurFactory(departement=perimetre.departement)
+            for state in [Dossier.STATE_EN_CONSTRUCTION, Dossier.STATE_EN_INSTRUCTION]:
+                dossier_2024 = DossierFactory(
+                    ds_state=state,
+                    ds_date_depot=datetime(2024, 2, 12, tzinfo=UTC),
+                    ds_date_traitement=None,
+                    demande_dispositif_sollicite=type,
+                    demande_montant=400_000,
+                )
+                projet_2024 = ProjetFactory(
+                    dossier_ds=dossier_2024, demandeur=demandeur
+                )
+                projets.append(projet_2024)
+
+                dossier_2025 = DossierFactory(
+                    ds_state=state,
+                    ds_date_depot=datetime(2025, 2, 12, tzinfo=UTC),
+                    ds_date_traitement=None,
+                    demande_dispositif_sollicite=type,
+                    demande_montant=500_000,
+                )
+                projet_2025 = ProjetFactory(
+                    dossier_ds=dossier_2025, demandeur=demandeur
+                )
+                projets.append(projet_2025)
+    return projets
+
+
 @pytest.mark.django_db
 def test_simulation_view_status_code(req, view, simulations):
     url = reverse("programmation:simulation_list")
@@ -41,3 +123,42 @@ def test_simulation_view_status_code(req, view, simulations):
     view.request = req.get(url)
 
     assert view.get_queryset().count() == 2
+
+
+@pytest.mark.django_db
+def test_get_enveloppe_data(req, simulation, projets, perimetre_departemental):
+    view = SimulationDetailView()
+    view.request = req.get(
+        reverse("programmation:simulation_detail", kwargs={"slug": simulation.slug})
+    )
+    view.object = simulation
+    enveloppe_data = view.get_enveloppe_data(simulation)
+
+    assert Projet.objects.count() == 40
+
+    projet_filter_by_perimetre = Projet.objects.for_perimetre(perimetre_departemental)
+    assert projet_filter_by_perimetre.count() == 20
+
+    projet_filter_by_perimetre_and_type = projet_filter_by_perimetre.filter(
+        dossier_ds__demande_dispositif_sollicite="DETR"
+    )
+    assert projet_filter_by_perimetre_and_type.count() == 10
+
+    projet_qs_submitted_before_the_end_of_the_year = (
+        projet_filter_by_perimetre_and_type.filter(
+            dossier_ds__ds_date_depot__lt=datetime(
+                simulation.enveloppe.annee + 1, 1, 1, tzinfo=UTC
+            ),
+        )
+    )
+    assert projet_qs_submitted_before_the_end_of_the_year.count() == 5
+
+    assert enveloppe_data["type"] == "DETR"
+    assert enveloppe_data["montant"] == 1_000_000
+    assert enveloppe_data["perimetre"] == perimetre_departemental
+    assert enveloppe_data["validated_projets_count"] == 1
+    assert enveloppe_data["refused_projets_count"] == 1
+    assert enveloppe_data["projets_count"] == 5
+    assert enveloppe_data["demandeurs"] == 2
+    assert enveloppe_data["montant_asked"] == 200_000 * 3 + 400_000 * 2
+    assert enveloppe_data["montant_accepte"] == 150_000

--- a/gsl_programmation/tests/test_views.py
+++ b/gsl_programmation/tests/test_views.py
@@ -56,13 +56,13 @@ def simulation(perimetre_departemental):
 def projets(simulation, perimetre_departemental):
     projets = []
     for perimetre in [perimetre_departemental, PerimetreDepartementalFactory()]:
-        for type in ["DETR", "DSIL"]:
+        for type in ("DETR", "DSIL"):
             demandeur = DemandeurFactory(departement=perimetre.departement)
-            for state in [
+            for state in (
                 Dossier.STATE_ACCEPTE,
                 Dossier.STATE_REFUSE,
                 Dossier.STATE_SANS_SUITE,
-            ]:
+            ):
                 dossier_2024 = DossierFactory(
                     ds_state=state,
                     ds_date_depot=datetime(2023, 10, 1, tzinfo=UTC),
@@ -89,7 +89,7 @@ def projets(simulation, perimetre_departemental):
                 projets.append(projet_2025)
 
             demandeur = DemandeurFactory(departement=perimetre.departement)
-            for state in [Dossier.STATE_EN_CONSTRUCTION, Dossier.STATE_EN_INSTRUCTION]:
+            for state in (Dossier.STATE_EN_CONSTRUCTION, Dossier.STATE_EN_INSTRUCTION):
                 dossier_2024 = DossierFactory(
                     ds_state=state,
                     ds_date_depot=datetime(2024, 2, 12, tzinfo=UTC),

--- a/gsl_programmation/views.py
+++ b/gsl_programmation/views.py
@@ -66,11 +66,7 @@ class SimulationDetailView(DetailView):
         context["total_amount_granted"] = ProjetService.get_total_amount_granted(qs)
         context["available_states"] = SimulationProjet.STATUS_CHOICES
         context["filter_params"] = self.request.GET.urlencode()
-        context["enveloppe"] = {
-            "type": simulation.enveloppe.type,
-            "montant": simulation.enveloppe.montant,
-            "perimetre": simulation.enveloppe.perimetre,
-        }
+        context["enveloppe"] = self.get_enveloppe_data(simulation)
 
         context["breadcrumb_dict"] = {
             "links": [
@@ -100,6 +96,18 @@ class SimulationDetailView(DetailView):
         )
         qs.distinct()
         return qs
+
+    def get_enveloppe_data(self, simulation):
+        enveloppe = simulation.enveloppe
+        enveloppe_projets = Projet.objects.included_in_enveloppe(enveloppe)
+
+        return {
+            "type": simulation.enveloppe.type,
+            "montant": simulation.enveloppe.montant,
+            "perimetre": simulation.enveloppe.perimetre,
+            "demandeurs": enveloppe_projets.distinct("demandeur").count(),
+            "projets_count": enveloppe_projets.count(),
+        }
 
 
 def redirect_to_simulation_projet(request, simulation_projet):

--- a/gsl_programmation/views.py
+++ b/gsl_programmation/views.py
@@ -107,6 +107,12 @@ class SimulationDetailView(DetailView):
             Sum("dossier_ds__demande_montant")
         )["dossier_ds__demande_montant__sum"]
 
+        montant_accepte = enveloppe_projets_processed.filter(
+            dossier_ds__ds_state=Dossier.STATE_ACCEPTE
+        ).aggregate(Sum("dossier_ds__annotations_montant_accorde"))[
+            "dossier_ds__annotations_montant_accorde__sum"
+        ]
+
         return {
             "type": simulation.enveloppe.type,
             "montant": simulation.enveloppe.montant,
@@ -115,9 +121,7 @@ class SimulationDetailView(DetailView):
             "validated_projets_count": enveloppe_projets_processed.filter(
                 dossier_ds__ds_state=Dossier.STATE_ACCEPTE
             ).count(),
-            "montant_accepte": enveloppe_projets_processed.aggregate(
-                Sum("dossier_ds__annotations_montant_accorde")
-            )["dossier_ds__annotations_montant_accorde__sum"],
+            "montant_accepte": montant_accepte,
             "refused_projets_count": enveloppe_projets_processed.filter(
                 dossier_ds__ds_state=Dossier.STATE_REFUSE
             ).count(),

--- a/gsl_programmation/views.py
+++ b/gsl_programmation/views.py
@@ -115,7 +115,9 @@ class SimulationDetailView(DetailView):
             "validated_projets_count": enveloppe_projets_processed.filter(
                 dossier_ds__ds_state=Dossier.STATE_ACCEPTE
             ).count(),
-            "montant_accepte": None,
+            "montant_accepte": enveloppe_projets_processed.aggregate(
+                Sum("dossier_ds__annotations_montant_accorde")
+            )["dossier_ds__annotations_montant_accorde__sum"],
             "refused_projets_count": enveloppe_projets_processed.filter(
                 dossier_ds__ds_state=Dossier.STATE_REFUSE
             ).count(),

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -91,6 +91,32 @@ class ProjetQuerySet(models.QuerySet):
         )
         return projet_qs_not_processed_before_the_start_of_the_year
 
+    def processed_in_enveloppe(self, enveloppe: "Enveloppe"):
+        projet_qs = self.for_perimetre(enveloppe.perimetre)
+        projet_qs_with_the_right_type = projet_qs.filter(
+            dossier_ds__demande_dispositif_sollicite=enveloppe.type,
+        )
+        projet_qs_with_a_processed_state = projet_qs_with_the_right_type.filter(
+            dossier_ds__ds_state__in=[
+                Dossier.STATE_ACCEPTE,
+                Dossier.STATE_REFUSE,
+                Dossier.STATE_SANS_SUITE,
+            ]
+        )
+        projet_qs_processed_during_the_year = projet_qs_with_a_processed_state.filter(
+            Q(
+                dossier_ds__ds_date_traitement__gte=datetime(
+                    enveloppe.annee, 1, 1, tzinfo=UTC
+                )
+            )
+            & Q(
+                dossier_ds__ds_date_traitement__lt=datetime(
+                    enveloppe.annee + 1, 1, 1, tzinfo=UTC
+                )
+            )
+        )
+        return projet_qs_processed_during_the_year
+
 
 class ProjetManager(models.Manager.from_queryset(ProjetQuerySet)):
     def get_queryset(self):

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -1,11 +1,15 @@
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from datetime import timezone as tz
+from typing import TYPE_CHECKING
 
 from django.db import models
 from django.db.models import Q
 
 from gsl_core.models import Adresse, Arrondissement, Collegue, Departement, Perimetre
 from gsl_demarches_simplifiees.models import Dossier
+
+if TYPE_CHECKING:
+    from gsl_programmation.models import Enveloppe
 
 
 class Demandeur(models.Model):
@@ -41,7 +45,7 @@ class ProjetQuerySet(models.QuerySet):
         if perimetre.region:
             return self.filter(demandeur__departement__region=perimetre.region)
 
-    def to_deal_with_this_year(self):
+    def for_current_year(self):
         return self.filter(
             Q(
                 dossier_ds__ds_state__in=[
@@ -60,6 +64,32 @@ class ProjetQuerySet(models.QuerySet):
                 ),
             )
         )
+
+    def included_in_enveloppe(self, enveloppe: "Enveloppe"):
+        projet_qs = self.for_perimetre(enveloppe.perimetre)
+        projet_qs_with_the_right_type = projet_qs.filter(
+            dossier_ds__demande_dispositif_sollicite=enveloppe.type,
+        )
+        projet_qs_submitted_before_the_end_of_the_year = (
+            projet_qs_with_the_right_type.filter(
+                dossier_ds__ds_date_depot__lt=datetime(
+                    enveloppe.annee + 1, 1, 1, tzinfo=UTC
+                ),
+            )
+        )
+        projet_qs_not_processed_before_the_start_of_the_year = (
+            projet_qs_submitted_before_the_end_of_the_year.filter(
+                Q(
+                    dossier_ds__ds_date_traitement__gte=datetime(
+                        enveloppe.annee, 1, 1, tzinfo=UTC
+                    )
+                )
+                | Q(
+                    dossier_ds__ds_date_traitement__isnull=True,
+                )
+            )
+        )
+        return projet_qs_not_processed_before_the_start_of_the_year
 
 
 class ProjetManager(models.Manager.from_queryset(ProjetQuerySet)):

--- a/gsl_projet/tests/factories.py
+++ b/gsl_projet/tests/factories.py
@@ -46,6 +46,6 @@ class ProcessedProjetFactory(ProjetFactory):
     dossier_ds = factory.SubFactory(
         DossierFactory,
         ds_state=choice(
-            [Dossier.STATE_ACCEPTE, Dossier.STATE_REFUSE, Dossier.STATE_SANS_SUITE]
+            (Dossier.STATE_ACCEPTE, Dossier.STATE_REFUSE, Dossier.STATE_SANS_SUITE)
         ),
     )

--- a/gsl_projet/tests/factories.py
+++ b/gsl_projet/tests/factories.py
@@ -1,3 +1,5 @@
+from random import choice
+
 import factory
 
 from gsl_core.tests.factories import (
@@ -36,16 +38,14 @@ class ProjetFactory(factory.django.DjangoModelFactory):
 class SubmittedProjetFactory(ProjetFactory):
     dossier_ds = factory.SubFactory(
         DossierFactory,
-        ds_state=factory.Iterator(
-            (Dossier.STATE_EN_CONSTRUCTION, Dossier.STATE_EN_TRAITEMENT)
-        ),
+        ds_state=choice((Dossier.STATE_EN_CONSTRUCTION, Dossier.STATE_EN_INSTRUCTION)),
     )
 
 
 class ProcessedProjetFactory(ProjetFactory):
     dossier_ds = factory.SubFactory(
         DossierFactory,
-        ds_state=factory.Iterator(
+        ds_state=choice(
             [Dossier.STATE_ACCEPTE, Dossier.STATE_REFUSE, Dossier.STATE_SANS_SUITE]
         ),
     )

--- a/gsl_projet/tests/factories.py
+++ b/gsl_projet/tests/factories.py
@@ -1,5 +1,3 @@
-from random import choice
-
 import factory
 
 from gsl_core.tests.factories import (
@@ -38,14 +36,16 @@ class ProjetFactory(factory.django.DjangoModelFactory):
 class SubmittedProjetFactory(ProjetFactory):
     dossier_ds = factory.SubFactory(
         DossierFactory,
-        ds_state=choice((Dossier.STATE_EN_CONSTRUCTION, Dossier.STATE_EN_INSTRUCTION)),
+        ds_state=factory.fuzzy.FuzzyChoice(
+            (Dossier.STATE_EN_CONSTRUCTION, Dossier.STATE_EN_INSTRUCTION)
+        ),
     )
 
 
 class ProcessedProjetFactory(ProjetFactory):
     dossier_ds = factory.SubFactory(
         DossierFactory,
-        ds_state=choice(
+        ds_state=factory.fuzzy.FuzzyChoice(
             (Dossier.STATE_ACCEPTE, Dossier.STATE_REFUSE, Dossier.STATE_SANS_SUITE)
         ),
     )

--- a/gsl_projet/tests/factories.py
+++ b/gsl_projet/tests/factories.py
@@ -5,6 +5,7 @@ from gsl_core.tests.factories import (
     ArrondissementFactory,
     DepartementFactory,
 )
+from gsl_demarches_simplifiees.models import Dossier
 from gsl_demarches_simplifiees.tests.factories import DossierFactory
 
 from ..models import Demandeur, Projet
@@ -30,3 +31,21 @@ class ProjetFactory(factory.django.DjangoModelFactory):
     address = factory.SubFactory(AdresseFactory)
     departement = factory.SubFactory(DepartementFactory)
     demandeur = factory.SubFactory(DemandeurFactory)
+
+
+class SubmittedProjetFactory(ProjetFactory):
+    dossier_ds = factory.SubFactory(
+        DossierFactory,
+        ds_state=factory.Iterator(
+            (Dossier.STATE_EN_CONSTRUCTION, Dossier.STATE_EN_TRAITEMENT)
+        ),
+    )
+
+
+class ProcessedProjetFactory(ProjetFactory):
+    dossier_ds = factory.SubFactory(
+        DossierFactory,
+        ds_state=factory.Iterator(
+            [Dossier.STATE_ACCEPTE, Dossier.STATE_REFUSE, Dossier.STATE_SANS_SUITE]
+        ),
+    )

--- a/gsl_projet/tests/test_factories.py
+++ b/gsl_projet/tests/test_factories.py
@@ -4,13 +4,20 @@ from ..models import (
     Demandeur,
     Projet,
 )
-from .factories import DemandeurFactory, ProjetFactory
+from .factories import (
+    DemandeurFactory,
+    ProcessedProjetFactory,
+    ProjetFactory,
+    SubmittedProjetFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
 test_data = (
     (DemandeurFactory, Demandeur),
     (ProjetFactory, Projet),
+    (SubmittedProjetFactory, Projet),
+    (ProcessedProjetFactory, Projet),
 )
 
 

--- a/gsl_projet/tests/test_model_projet.py
+++ b/gsl_projet/tests/test_model_projet.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from datetime import timezone as tz
 
 import pytest
@@ -145,93 +145,7 @@ def test_for_normal_user_with_perimetre(departement, projets):
     assert Projet.objects.for_user(user_with_perimetre).get() == projets[0]
 
 
-# Test for_enveloppe
-
-
-## Type
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "projet_type, enveloppe_type, count",
-    [
-        ("DSIL", "DSIL", 1),
-        ("DSIL", "DETR", 0),
-        ("DETR", "DSIL", 0),
-        ("DETR", "DETR", 1),
-    ],
-)
-def test_for_enveloppe_with_projet_type_and_enveloppe_type(
-    projet_type, enveloppe_type, count
-):
-    enveloppe = (
-        DetrEnveloppeFactory if enveloppe_type == "DETR" else DsilEnveloppeFactory
-    )
-    ProjetFactory(
-        dossier_ds__demande_dispositif_sollicite=projet_type,
-    )
-
-    qs = Projet.objects.included_in_enveloppe(enveloppe=enveloppe)
-
-    assert qs.count() == count
-
-
-## Date
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "submitted_year, count",
-    [
-        (2023, 1),
-        (2024, 1),
-        (2025, 0),
-    ],
-)
-def test_for_year_2024_and_for_not_processed_states(year, count):
-    enveloppe = DetrEnveloppeFactory(annee=2024)
-    projet = SubmittedProjetFactory(
-        dossier_ds=DossierFactory(
-            dossier_ds__demande_dispositif_sollicite=enveloppe.type,
-            ds_date_depot=datetime(year, 12, 31, tzinfo=tz.utc),
-        ),
-    )
-    print(f"Test with {projet.dossier_ds.ds_state}")
-
-    qs = Projet.objects.for_enveloppe(enveloppe)
-
-    assert qs.count() == count
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "submitted_year, processed_year, count",
-    [
-        (2023, 2023, 0),
-        (2023, 2024, 1),
-        (2023, 2025, 1),
-        (2024, 2024, 1),
-        (2024, 2025, 1),
-        (2025, 2025, 0),
-    ],
-)
-def test_for_year_2024_and_for_processed_states(year, count):
-    enveloppe = DetrEnveloppeFactory(annee=2024)
-    projet = ProcessedProjetFactory(
-        dossier_ds=DossierFactory(
-            dossier_ds__demande_dispositif_sollicite=enveloppe.type,
-            ds_date_depot=datetime(year, 12, 31, tzinfo=tz.utc),
-            ds_date_traitement=datetime(year, 12, 31, tzinfo=tz.utc),
-        ),
-    )
-    print(f"Test with {projet.dossier_ds.ds_state}")
-
-    qs = Projet.objects.for_enveloppe(enveloppe)
-
-    assert qs.count() == count
-
-
-# Test for_current_year
+# Test included_in_enveloppe
 
 
 @pytest.mark.django_db
@@ -305,3 +219,123 @@ def for_year_with_projet_to_display(state, ds_date_traitement):
     qs = qs.for_year(date.today().year)
 
     assert qs.count() == 1
+
+
+# Test for_enveloppe
+
+
+## Type
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "projet_type, enveloppe_type, count",
+    [
+        ("DSIL", "DSIL", 1),
+        ("DSIL", "DETR", 0),
+        ("DETR", "DSIL", 0),
+        ("DETR", "DETR", 1),
+    ],
+)
+def test_for_enveloppe_with_projet_type_and_enveloppe_type(
+    projet_type, enveloppe_type, count
+):
+    perimetre = PerimetreDepartementalFactory()
+    enveloppe_factory = (
+        DetrEnveloppeFactory if enveloppe_type == "DETR" else DsilEnveloppeFactory
+    )
+    enveloppe = enveloppe_factory(annee=2024, perimetre=perimetre)
+    ProjetFactory(
+        demandeur__departement=perimetre.departement,
+        dossier_ds__ds_date_depot=datetime(2024, 3, 1, tzinfo=UTC),
+        dossier_ds__demande_dispositif_sollicite=projet_type,
+    )
+
+    qs = Projet.objects.included_in_enveloppe(enveloppe=enveloppe)
+
+    assert qs.count() == count
+
+
+## Date
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "submitted_year, count",
+    [
+        (2023, 1),
+        (2024, 1),
+        (2025, 0),
+    ],
+)
+def test_for_year_2024_and_for_not_processed_states(submitted_year, count):
+    perimetre = PerimetreDepartementalFactory()
+    enveloppe = DetrEnveloppeFactory(annee=2024, perimetre=perimetre)
+    projet = SubmittedProjetFactory(
+        dossier_ds__demande_dispositif_sollicite=enveloppe.type,
+        dossier_ds__ds_date_depot=datetime(submitted_year, 12, 31, tzinfo=tz.utc),
+        demandeur__departement=perimetre.departement,
+    )
+    print(f"Test with {projet.dossier_ds.ds_state}")
+
+    qs = Projet.objects.included_in_enveloppe(enveloppe)
+
+    assert qs.count() == count
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "submitted_year, processed_year, count",
+    [
+        (2023, 2023, 0),
+        (2023, 2024, 1),
+        (2023, 2025, 1),
+        (2024, 2024, 1),
+        (2024, 2025, 1),
+        (2025, 2025, 0),
+    ],
+)
+def test_for_year_2024_and_for_processed_states(submitted_year, processed_year, count):
+    perimetre = PerimetreDepartementalFactory()
+    enveloppe = DetrEnveloppeFactory(annee=2024, perimetre=perimetre)
+    projet = ProcessedProjetFactory(
+        dossier_ds__demande_dispositif_sollicite=enveloppe.type,
+        dossier_ds__ds_date_depot=datetime(submitted_year, 12, 31, tzinfo=tz.utc),
+        dossier_ds__ds_date_traitement=datetime(processed_year, 12, 31, tzinfo=tz.utc),
+        demandeur__departement=perimetre.departement,
+    )
+    print(f"Test with {projet.dossier_ds.ds_state}")
+
+    qs = Projet.objects.included_in_enveloppe(enveloppe)
+
+    assert qs.count() == count
+
+
+# Test processed_in_enveloppe
+
+## Date
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "processed_year, count",
+    [
+        (2023, 0),
+        (2024, 1),
+        (2025, 0),
+    ],
+)
+@pytest.mark.django_db
+def test_processed_in_enveloppe_with_different_processed_dates(processed_year, count):
+    perimetre = PerimetreDepartementalFactory()
+    enveloppe = DetrEnveloppeFactory(annee=2024, perimetre=perimetre)
+    projet = ProcessedProjetFactory(
+        dossier_ds__demande_dispositif_sollicite=enveloppe.type,
+        dossier_ds__ds_date_traitement=datetime(processed_year, 1, 1, tzinfo=tz.utc),
+        demandeur__departement=perimetre.departement,
+    )
+    print(f"Test with {projet.dossier_ds.ds_state}")
+
+    qs = Projet.objects.processed_in_enveloppe(enveloppe)
+
+    assert qs.count() == count

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -92,7 +92,7 @@ class ProjetListView(ListView):
 
     def get_queryset(self):
         qs = Projet.objects.for_user(self.request.user)
-        qs = qs.to_deal_with_this_year()
+        qs = qs.for_current_year()
         qs = ProjetService.add_filters_to_projets_qs(qs, self.request.GET)
         qs = ProjetService.add_ordering_to_projets_qs(qs, self.request.GET.get("tri"))
         return qs

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE = gsl.settings
-python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
## 🌮 Objectif

Ajout du nombre de projets et de demandeurs dans le résumé d'une enveloppe


## 🔍 Liste des modifications

- _Liste des modifications_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
