### PR TITLE
Correction du bug de création de simulation DSIL lorsqu'on a un périmètre départemental

### DIFF
--- a/gsl_programmation/services/enveloppe_service.py
+++ b/gsl_programmation/services/enveloppe_service.py
@@ -1,5 +1,3 @@
-from django.db.models import Q
-
 from gsl_core.models import Collegue, Perimetre
 from gsl_programmation.models import Enveloppe
 
@@ -22,22 +20,17 @@ class EnveloppeService:
         if perimetre.type == Perimetre.TYPE_REGION:
             return Enveloppe.objects.filter(
                 perimetre__region=perimetre.region,
-                perimetre__departement=None,
-                perimetre__arrondissement=None,
                 type=Enveloppe.TYPE_DSIL,
             )
 
+        if perimetre.type == Perimetre.TYPE_DEPARTEMENT:
+            return Enveloppe.objects.filter(
+                perimetre__region=perimetre.region,
+                perimetre__departement=perimetre.departement,
+            )
+
         return Enveloppe.objects.filter(
-            Q(
-                perimetre__region=perimetre.region,
-                perimetre__departement=perimetre.departement,
-                perimetre__arrondissement=None,
-                type=Enveloppe.TYPE_DETR,
-            )
-            | Q(
-                perimetre__region=perimetre.region,
-                perimetre__departement=perimetre.departement,
-                perimetre__arrondissement=None,
-                type=Enveloppe.TYPE_DSIL,
-            )
+            perimetre__region=perimetre.region,
+            perimetre__departement=perimetre.departement,
+            perimetre__arrondissement=perimetre.arrondissement,
         )

--- a/gsl_programmation/tests/services/test_enveloppe_service.py
+++ b/gsl_programmation/tests/services/test_enveloppe_service.py
@@ -2,9 +2,11 @@ import pytest
 
 from gsl_core.tests.factories import (
     CollegueFactory,
+    PerimetreArrondissementFactory,
     PerimetreDepartementalFactory,
     PerimetreRegionalFactory,
 )
+from gsl_programmation.models import Enveloppe
 from gsl_programmation.services.enveloppe_service import EnveloppeService
 from gsl_programmation.tests.factories import (
     DetrEnveloppeFactory,
@@ -26,59 +28,134 @@ def simulations(enveloppes):
 
 
 @pytest.mark.parametrize(
-    "is_staff, is_superuser, with_perimetre, expected_count",
+    "is_superuser, is_staff, with_perimetre, expected_count",
     [
         (True, False, False, 10),
-        (False, True, True, 1),
         (False, True, False, 10),
+        (True, False, True, 1),
         (False, True, True, 1),
-        (False, False, False, 0),
         (False, False, True, 1),
+        (False, False, False, 0),
     ],
 )
 def test_get_enveloppes_visible_for_a_user(
-    is_staff, is_superuser, with_perimetre, expected_count, enveloppes
+    is_superuser, is_staff, with_perimetre, expected_count, enveloppes
 ):
     super_user = CollegueFactory(
-        is_staff=is_staff,
         is_superuser=is_superuser,
+        is_staff=is_staff,
         perimetre=None if not with_perimetre else enveloppes[0].perimetre,
     )
     visible_enveloppes = EnveloppeService.get_enveloppes_visible_for_a_user(super_user)
     assert visible_enveloppes.count() == expected_count
 
 
-def test_get_enveloppes_from_departement_perimetre():
-    departemental_perimetre = PerimetreDepartementalFactory()
-    other_departemental_perimetre = PerimetreDepartementalFactory()
-    DetrEnveloppeFactory(perimetre=departemental_perimetre)
-    DetrEnveloppeFactory(perimetre=other_departemental_perimetre)
-
-    regional_perimetre = PerimetreRegionalFactory(region=departemental_perimetre.region)
-    regional_dsil_enveloppe = DsilEnveloppeFactory(perimetre=regional_perimetre)
-    DsilEnveloppeFactory(
-        perimetre=departemental_perimetre, deleguee_by=regional_dsil_enveloppe
+@pytest.fixture
+def perimetres():
+    arrondissement_A = PerimetreArrondissementFactory()
+    arrondissement_B = PerimetreArrondissementFactory()
+    departemental_A = PerimetreDepartementalFactory(
+        departement=arrondissement_A.departement
     )
+    departemental_B = PerimetreDepartementalFactory(
+        departement=arrondissement_B.departement
+    )
+    regional_A = PerimetreRegionalFactory(region=departemental_A.region)
+    regional_B = PerimetreRegionalFactory(region=departemental_B.region)
+    return {
+        "arrondissements": [arrondissement_A, arrondissement_B],
+        "departements": [departemental_A, departemental_B],
+        "regions": [regional_A, regional_B],
+    }
 
-    enveloppes = EnveloppeService.get_enveloppes_from_perimetre(departemental_perimetre)
+
+@pytest.fixture
+def enveloppes_from_perimetre(perimetres):
+    enveloppes = {
+        "regions": {"dsil": []},
+        "departements": {"detr": [], "dsil": []},
+        "arrondissements": {"detr": [], "dsil": []},
+    }
+    for region in perimetres["regions"]:
+        enveloppes["regions"]["dsil"].append(DsilEnveloppeFactory(perimetre=region))
+    for departement in perimetres["departements"]:
+        enveloppes["departements"]["detr"].append(
+            DetrEnveloppeFactory(perimetre=departement)
+        )
+        enveloppes["departements"]["dsil"].append(
+            DsilEnveloppeFactory(
+                perimetre=departement,
+                deleguee_by=Enveloppe.objects.get(
+                    type=Enveloppe.TYPE_DSIL, perimetre__region=departement.region
+                ),
+            )
+        )
+    for arrondissement in perimetres["arrondissements"]:
+        enveloppes["arrondissements"]["detr"].append(
+            DetrEnveloppeFactory(
+                perimetre=arrondissement,
+                deleguee_by=Enveloppe.objects.get(
+                    type=Enveloppe.TYPE_DETR,
+                    perimetre__departement=arrondissement.departement,
+                ),
+            )
+        )
+        enveloppes["arrondissements"]["dsil"].append(
+            DsilEnveloppeFactory(
+                perimetre=arrondissement,
+                deleguee_by=Enveloppe.objects.get(
+                    type=Enveloppe.TYPE_DSIL,
+                    perimetre__departement=arrondissement.departement,
+                ),
+            )
+        )
+    return enveloppes
+
+
+def test_get_enveloppes_from_region_perimetre(perimetres, enveloppes_from_perimetre):
+    enveloppes = EnveloppeService.get_enveloppes_from_perimetre(
+        perimetres["regions"][0]
+    )
+    assert len(enveloppes) == 3
+    assert enveloppes.filter(type="DETR").count() == 0
+    assert enveloppes.filter(type="DSIL").count() == 3
+    assert enveloppes.filter(perimetre__arrondissement__isnull=True).count() == 2
+    assert enveloppes.filter(perimetre__departement__isnull=True).count() == 1
+    for enveloppe in enveloppes:
+        assert (
+            perimetres["regions"][0] == enveloppe.perimetre
+            or perimetres["regions"][0].contains(enveloppe.perimetre) is True
+        )
+
+
+def test_get_enveloppes_from_departement_perimetre(
+    perimetres, enveloppes_from_perimetre
+):
+    enveloppes = EnveloppeService.get_enveloppes_from_perimetre(
+        perimetres["departements"][0]
+    )
+    assert len(enveloppes) == 4
+    assert enveloppes.filter(type="DETR").count() == 2
+    assert enveloppes.filter(type="DSIL").count() == 2
+    assert enveloppes.filter(perimetre__arrondissement__isnull=True).count() == 2
+    assert enveloppes.filter(perimetre__arrondissement__isnull=False).count() == 2
+    assert enveloppes.filter(perimetre__departement__isnull=True).count() == 0
+    for enveloppe in enveloppes:
+        assert (
+            perimetres["departements"][0] == enveloppe.perimetre
+            or perimetres["departements"][0].contains(enveloppe.perimetre) is True
+        )
+
+
+def test_get_enveloppes_from_arrondissement_perimetre(
+    perimetres, enveloppes_from_perimetre
+):
+    enveloppes = EnveloppeService.get_enveloppes_from_perimetre(
+        perimetres["arrondissements"][0]
+    )
     assert len(enveloppes) == 2
-    assert enveloppes.filter(deleguee_by=regional_dsil_enveloppe).count() == 1
-
-
-def test_get_enveloppes_from_regional_perimetre():
-    departemental_perimetre = PerimetreDepartementalFactory()
-    other_departemental_perimetre = PerimetreDepartementalFactory()
-    DetrEnveloppeFactory(perimetre=departemental_perimetre)
-    DetrEnveloppeFactory(perimetre=other_departemental_perimetre)
-
-    regional_perimetre = PerimetreRegionalFactory(region=departemental_perimetre.region)
-    regional_dsil_enveloppe = DsilEnveloppeFactory(perimetre=regional_perimetre)
-    DsilEnveloppeFactory(
-        perimetre=departemental_perimetre, deleguee_by=regional_dsil_enveloppe
-    )
-
-    other_regional_perimetre = PerimetreRegionalFactory()
-    DsilEnveloppeFactory(perimetre=other_regional_perimetre)
-
-    enveloppes = EnveloppeService.get_enveloppes_from_perimetre(regional_perimetre)
-    assert enveloppes.count() == 1
+    assert enveloppes.filter(type="DETR").count() == 1
+    assert enveloppes.filter(type="DSIL").count() == 1
+    assert enveloppes.filter(perimetre__arrondissement__isnull=True).count() == 0
+    for enveloppe in enveloppes:
+        assert perimetres["arrondissements"][0] == enveloppe.perimetre

--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -34,7 +34,7 @@ class SimulationForm(DsfrBaseForm):
         if dotation == "DETR":
             if self.user.perimetre.type == Perimetre.TYPE_REGION:
                 raise ValidationError(
-                    f"Votre compte n’est pas associé à un périmètre départemental ({self.user.perimetre}). Contactez l’équipe."
+                    f"Votre compte est associé à un périmètre régional ({self.user.perimetre}), vous ne pouvez pas créer une simulation de programmation pour un fonds de dotation DETR."
                 )
 
         return cleaned_data

--- a/gsl_simulation/services/simulation_service.py
+++ b/gsl_simulation/services/simulation_service.py
@@ -12,31 +12,20 @@ from gsl_simulation.models import Simulation
 class SimulationService:
     @classmethod
     def create_simulation(cls, user: Any, title: str, dotation: str):
-        perimetre = user.perimetre
-        if perimetre is None:
+        user_perimetre = user.perimetre
+        if user_perimetre is None:
             raise ValueError("User has no perimetre")
 
         if dotation == Enveloppe.TYPE_DETR:
-            if perimetre.type == Perimetre.TYPE_REGION:
-                raise ValueError("User has no departement")
-
-            perimetre_to_find = Perimetre.objects.get(
-                departement=perimetre.departement,
-                arrondissement=None,
-            )
-        else:
-            perimetre_to_find = Perimetre.objects.get(
-                region=perimetre.region,
-                departement=None,
-                arrondissement=None,
-            )
+            if user_perimetre.type == Perimetre.TYPE_REGION:
+                raise ValueError("For a DETR simulation, user must have a departement")
 
         enveloppe, _ = Enveloppe.objects.get_or_create(
-            perimetre=perimetre_to_find,
+            perimetre=user_perimetre,
             type=dotation,
             annee=date.today().year,
             defaults={"montant": 0},
-        )
+        )  # TODO: handle deleguee_by if needed
         slug = SimulationService.get_slug(title)
         simulation = Simulation.objects.create(
             title=title,

--- a/gsl_simulation/tests/services/test_simulation_services.py
+++ b/gsl_simulation/tests/services/test_simulation_services.py
@@ -4,6 +4,7 @@ import pytest
 
 from gsl_core.tests.factories import (
     CollegueFactory,
+    PerimetreArrondissementFactory,
     PerimetreDepartementalFactory,
     PerimetreRegionalFactory,
 )
@@ -24,17 +25,19 @@ def test_user_with_department_and_ask_for_dsil_simulation():
     perimetre_regional = PerimetreRegionalFactory(region=perimetre_departemental.region)
     user = CollegueFactory(perimetre=perimetre_departemental)
     DetrEnveloppeFactory(perimetre=perimetre_departemental)
-    enveloppe_dsil = DsilEnveloppeFactory(
-        perimetre=perimetre_regional, annee=date.today().year
-    )
+    DsilEnveloppeFactory(perimetre=perimetre_regional, annee=date.today().year)
     DsilEnveloppeFactory(perimetre=perimetre_regional, annee=2024)
 
     SimulationService.create_simulation(user, "Test", "DSIL")
 
-    simulation = Simulation.objects.get(enveloppe=enveloppe_dsil)
-    assert simulation.enveloppe == enveloppe_dsil
-    assert simulation.enveloppe.type == Enveloppe.TYPE_DSIL
-    assert simulation.enveloppe.montant == enveloppe_dsil.montant
+    enveloppe_dsil_deleguee = Enveloppe.objects.get(
+        perimetre=perimetre_departemental,
+        type=Enveloppe.TYPE_DSIL,
+        annee=date.today().year,
+    )
+
+    simulation = Simulation.objects.get(enveloppe=enveloppe_dsil_deleguee)
+    assert simulation.enveloppe.montant == 0
     assert simulation.slug == "test"
 
 
@@ -73,7 +76,7 @@ def test_user_without_department_and_ask_for_detr_simulation():
         SimulationService.create_simulation(user, "test", "DETR")
 
 
-def test_user_without_department_and_ask_for_dsil_simulation():
+def test_user_with_region_and_ask_for_dsil_simulation():
     perimetre_regional = PerimetreRegionalFactory()
     user = CollegueFactory(perimetre=perimetre_regional)
     enveloppe_dsil = DsilEnveloppeFactory(perimetre=perimetre_regional)
@@ -81,10 +84,21 @@ def test_user_without_department_and_ask_for_dsil_simulation():
     SimulationService.create_simulation(user, "Test    avec ce titre !!", "DSIL")
 
     simulation = Simulation.objects.get(enveloppe=enveloppe_dsil)
-    assert simulation.enveloppe == enveloppe_dsil
-    assert simulation.enveloppe.type == Enveloppe.TYPE_DSIL
-    assert simulation.enveloppe.montant == enveloppe_dsil.montant
     assert simulation.slug == "test-avec-ce-titre"
+
+
+def test_user_with_arrondissement_and_ask_for_dsil_simulation():
+    perimetre_arrondissement = PerimetreArrondissementFactory()
+    user = CollegueFactory(perimetre=perimetre_arrondissement)
+
+    SimulationService.create_simulation(
+        user, 'Test   &é"@ avec ces caractères !!', "DSIL"
+    )
+
+    simulation = Simulation.objects.get(enveloppe__perimetre=perimetre_arrondissement)
+    assert simulation.enveloppe.type == Enveloppe.TYPE_DSIL
+    assert simulation.enveloppe.montant == 0
+    assert simulation.slug == "test-avec-ces-caracteres"
 
 
 def test_slug_generation():

--- a/gsl_simulation/views.py
+++ b/gsl_simulation/views.py
@@ -41,7 +41,9 @@ class SimulationListView(ListView):
         visible_by_user_enveloppes = EnveloppeService.get_enveloppes_visible_for_a_user(
             self.request.user
         )
-        return Simulation.objects.filter(enveloppe__in=visible_by_user_enveloppes)
+        return Simulation.objects.filter(
+            enveloppe__in=visible_by_user_enveloppes
+        ).order_by("-created_at")
 
 
 class SimulationDetailView(DetailView):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,7 @@ dev = [
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "gsl.settings"
-addopts = "--ruff"
-
+addopts = "--ruff --reuse-db"
 
 [tool.ruff.lint]
 exclude = ["**/migrations/*.py"]


### PR DESCRIPTION
## 🌮 Objectif

Rajout des règles métiers liés aux enveloppes : 
- DETR régional impossible
- un utilisateur régional voit toutes les enveloppes DSIL de sa région
- un utilisateur départemental voit toutes les enveloppes DETR et DSIL de son département
- un utilisateur de périmètre arrondissement voit toutes les enveloppes DETR et DSIL de son arrondissement
