### PR TITLE
Ajout du filtre sur les statuts et sur le montant accordé (uniquement pour la page Simulation)

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -169,6 +169,13 @@ ul.no-list-style li {
     padding-left: 1.5em;
 }
 
+.projets-filters-layout {
+    background: var(--background-alt-blue-france);
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
+    padding: 1rem max(calc((100vw - 1200px) / 2), 1.5rem);
+}
+
 .gsl-projet-table__select {
     text-align: right;
     padding: 4px;
@@ -205,6 +212,13 @@ ul.no-list-style li {
     justify-content: center;
 }
 
+
+/* TODO utilister des variables avec un préprocesseur ? */
+@media (max-width: 768px) {
+    .projets-filters-layout {
+        padding: 1rem;
+    }
+}
 
 .ds_state__accepte {
     color: var(--text-default-success)

--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -169,13 +169,6 @@ ul.no-list-style li {
     padding-left: 1.5em;
 }
 
-.projets-filters-layout {
-    background: var(--background-alt-blue-france);
-    margin-left: calc(-50vw + 50%);
-    margin-right: calc(-50vw + 50%);
-    padding: 1rem max(calc((100vw - 1200px) / 2), 1.5rem);
-}
-
 .gsl-projet-table__select {
     text-align: right;
     padding: 4px;
@@ -212,13 +205,6 @@ ul.no-list-style li {
     justify-content: center;
 }
 
-
-/* TODO utilister des variables avec un préprocesseur ? */
-@media (max-width: 768px) {
-    .projets-filters-layout {
-        padding: 1rem;
-    }
-}
 
 .ds_state__accepte {
     color: var(--text-default-success)
@@ -261,20 +247,4 @@ ul.no-list-style li {
 
 .blue-icon {
     color: var(--blue-france-sun-113-625);
-}
-
-/* En travaux */
-
-.ahr-todo {
-    border-image: repeating-linear-gradient(-45deg, black, black 10px, yellow 10px, yellow 20px, black 10px);
-    border-image-slice: 9;
-    border-style: solid;
-    border-width: 6px;
-    padding: .75em;
-    margin: .75em 0;
-    box-shadow: 0 0 0 1px inset, 0 0 0 1px;
-    background: #ffffb3;
-}
-.ahr-todo__check{
-    text-decoration: line-through;
 }

--- a/gsl_projet/services.py
+++ b/gsl_projet/services.py
@@ -65,6 +65,9 @@ class ProjetService:
 
     @classmethod
     def add_ordering_to_projets_qs(cls, qs, ordering):
+        default_ordering = "-dossier_ds__ds_date_depot"
+        qs = qs.order_by(default_ordering)
+
         ordering_arg = cls.get_ordering_arg(ordering)
         if ordering_arg:
             qs = qs.order_by(ordering_arg)

--- a/gsl_projet/services.py
+++ b/gsl_projet/services.py
@@ -1,4 +1,4 @@
-from django.db.models import Case, F, Q, Sum, When
+from django.db.models import Case, F, Sum, When
 from django.db.models.query import QuerySet
 
 from gsl_demarches_simplifiees.models import NaturePorteurProjet
@@ -32,52 +32,6 @@ class ProjetService:
         "EPCI": NaturePorteurProjet.EPCI_NATURES,
         "Communes": NaturePorteurProjet.COMMUNE_NATURES,
     }
-
-    @classmethod
-    def add_filters_to_projets_qs(cls, qs, filters: dict):
-        dotation = filters.get("dotation")
-        if dotation:
-            qs = qs.filter(dossier_ds__demande_dispositif_sollicite=dotation)
-
-        cout_min = filters.get("cout_min")
-        if cout_min and cout_min.isnumeric():
-            qs = qs.filter(
-                Q(assiette__isnull=False, assiette__gte=cout_min)
-                | Q(assiette__isnull=True, dossier_ds__finance_cout_total__gte=cout_min)
-            )
-
-        cout_max = filters.get("cout_max")
-        if cout_max and cout_max.isnumeric():
-            qs = qs.filter(
-                Q(assiette__isnull=False, assiette__lte=cout_max)
-                | Q(assiette__isnull=True, dossier_ds__finance_cout_total__lte=cout_max)
-            )
-
-        montant_demande_min = filters.get("montant_demande_min")
-        if montant_demande_min and montant_demande_min.isnumeric():
-            qs = qs.filter(dossier_ds__demande_montant__gte=montant_demande_min)
-
-        montant_demande_max = filters.get("montant_demande_max")
-        if montant_demande_max and montant_demande_max.isnumeric():
-            qs = qs.filter(dossier_ds__demande_montant__lte=montant_demande_max)
-
-        montant_previsionnel_min = filters.get("montant_previsionnel_min")
-        if montant_previsionnel_min and montant_previsionnel_min.isnumeric():
-            qs = qs.filter(simulationprojet__montant__gte=montant_previsionnel_min)
-
-        montant_previsionnel_max = filters.get("montant_previsionnel_max")
-        if montant_previsionnel_max and montant_previsionnel_max.isnumeric():
-            qs = qs.filter(simulationprojet__montant__lte=montant_previsionnel_max)
-
-        porteur = filters.get("porteur")
-        if porteur in cls.PORTEUR_MAPPINGS:
-            qs = qs.filter(
-                dossier_ds__porteur_de_projet_nature__label__in=cls.PORTEUR_MAPPINGS.get(
-                    porteur
-                )
-            )
-
-        return qs
 
     @classmethod
     def add_ordering_to_projets_qs(cls, qs, ordering):

--- a/gsl_projet/services.py
+++ b/gsl_projet/services.py
@@ -53,6 +53,22 @@ class ProjetService:
                 | Q(assiette__isnull=True, dossier_ds__finance_cout_total__lte=cout_max)
             )
 
+        montant_demande_min = filters.get("montant_demande_min")
+        if montant_demande_min and montant_demande_min.isnumeric():
+            qs = qs.filter(dossier_ds__demande_montant__gte=montant_demande_min)
+
+        montant_demande_max = filters.get("montant_demande_max")
+        if montant_demande_max and montant_demande_max.isnumeric():
+            qs = qs.filter(dossier_ds__demande_montant__lte=montant_demande_max)
+
+        montant_previsionnel_min = filters.get("montant_previsionnel_min")
+        if montant_previsionnel_min and montant_previsionnel_min.isnumeric():
+            qs = qs.filter(simulationprojet__montant__gte=montant_previsionnel_min)
+
+        montant_previsionnel_max = filters.get("montant_previsionnel_max")
+        if montant_previsionnel_max and montant_previsionnel_max.isnumeric():
+            qs = qs.filter(simulationprojet__montant__lte=montant_previsionnel_max)
+
         porteur = filters.get("porteur")
         if porteur in cls.PORTEUR_MAPPINGS:
             qs = qs.filter(

--- a/gsl_projet/static/css/projet_list_filters.css
+++ b/gsl_projet/static/css/projet_list_filters.css
@@ -1,5 +1,4 @@
 .projets-filters-layout,
-.projets-filters-layout,
 .projets-filters-layout .fr-select,
 .projets-filters-layout .fr-input,
 .projets-filters-layout .fr-label {
@@ -15,7 +14,12 @@
   padding: 10px;
   z-index: 1000;
   gap: 1rem;
+  --status-color-green: var(--text-default-success);
+  --status-color-blue: var(--text-default-info);
+  --status-color-orange: var(--text-default-warning);
+  --status-color-red: var(--text-default-error);
 }
+
 
 .filter-content > button {
   width: 100%;
@@ -103,19 +107,3 @@
   gap: 6px;
 }
 
-#filter-status-button label[for="id_status_0"] {
-  color: var(--text-default-success);
-}
-
-#filter-status-button label[for="id_status_1"],
-#filter-status-button label[for="id_status_2"] {
-  color: var(--text-default-info);
-}
-
-#filter-status-button label[for="id_status_3"] {
-  color: var(--text-default-error);
-}
-
-#filter-status-button label[for="id_status_4"] {
-  color: var(--text-default-warning);
-}

--- a/gsl_projet/static/css/projet_list_filters.css
+++ b/gsl_projet/static/css/projet_list_filters.css
@@ -1,3 +1,11 @@
+.projets-filters-layout,
+.projets-filters-layout,
+.projets-filters-layout .fr-select,
+.projets-filters-layout .fr-input,
+.projets-filters-layout .fr-label {
+  font-size: calc(1rem * 14 / 16);
+}
+
 .filter-content {
   display: none;
   position: absolute;
@@ -22,8 +30,8 @@
 }
 
 .amount-filter-group > label {
-  font-size: calc(1rem * 14/16);
-  flex:1
+  font-size: calc(1rem * 14 / 16);
+  flex: 1;
 }
 
 .euro-input-wrap {
@@ -37,8 +45,8 @@
 
 .euro-input-wrap > input::-webkit-outer-spin-button,
 .euro-input-wrap > input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
+  -webkit-appearance: none;
+  margin: 0;
 }
 
 .euro-input-wrap > input[type="number"] {
@@ -52,7 +60,6 @@
   transform: translateY(-50%);
   pointer-events: none; /* Ne pas interférer avec les clics */
 }
-
 
 .separator {
   display: flex;
@@ -71,7 +78,7 @@
 .separator span {
   font-size: 12px;
   font-weight: bold;
-  color: var(--text-disabled-grey)
+  color: var(--text-disabled-grey);
 }
 
 .montant-demande-checkbox-container {
@@ -81,6 +88,34 @@
 }
 
 .filter-dropdown-button-active {
-    border: 2px solid var(--artwork-major-blue-cumulus-active);
-    padding-top: 6px;
+  border: 2px solid var(--artwork-major-blue-cumulus-active);
+  padding-top: 6px;
+}
+
+#filter-status-button > button {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#filter-status-button .filter-content {
+  min-width: auto;
+  gap: 6px;
+}
+
+#filter-status-button label[for="id_status_0"] {
+  color: var(--text-default-success);
+}
+
+#filter-status-button label[for="id_status_1"],
+#filter-status-button label[for="id_status_2"] {
+  color: var(--text-default-info);
+}
+
+#filter-status-button label[for="id_status_3"] {
+  color: var(--text-default-error);
+}
+
+#filter-status-button label[for="id_status_4"] {
+  color: var(--text-default-warning);
 }

--- a/gsl_projet/static/css/projet_list_filters.css
+++ b/gsl_projet/static/css/projet_list_filters.css
@@ -107,3 +107,8 @@
   gap: 6px;
 }
 
+#filter-montant-previsionnel-button {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/gsl_projet/static/css/projet_list_filters.css
+++ b/gsl_projet/static/css/projet_list_filters.css
@@ -96,18 +96,14 @@
   padding-top: 6px;
 }
 
-#filter-status-button > button {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 #filter-status-button .filter-content {
   min-width: auto;
   gap: 6px;
 }
 
-#filter-montant-previsionnel-button {
+.filter-field > select,
+.filter-field > button,
+.filter-dropdown > button {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/gsl_projet/templates/includes/_filter_cout_total.html
+++ b/gsl_projet/templates/includes/_filter_cout_total.html
@@ -1,4 +1,4 @@
-<div class="fr-col-12 fr-col-md-4 fr-col-lg-2">
+<div class="filter-field fr-col-12 fr-col-md-4 fr-col-lg-2">
     <div class="filter-dropdown fr-mt-4w">
         <button type="button"
                 class="fr-input {% if is_cout_total_active %}filter-dropdown-button-active{% endif %}"

--- a/gsl_projet/templates/includes/_filter_dotation.html
+++ b/gsl_projet/templates/includes/_filter_dotation.html
@@ -1,4 +1,4 @@
-<div class="fr-col-12 fr-col-md-4 fr-col-lg-2">
+<div class="filter-field fr-col-12 fr-col-md-4 fr-col-lg-3">
     <label class="fr-label" for="dotation">
         Dotation
     </label>

--- a/gsl_projet/templates/includes/_filter_montant_demande.html
+++ b/gsl_projet/templates/includes/_filter_montant_demande.html
@@ -1,4 +1,4 @@
-<div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
+<div class="filter-field fr-col-12 fr-col-md-6 fr-col-lg-3">
     <div class="filter-dropdown fr-mt-4w">
         <button type="button"
                 class="fr-input {% if is_montant_demande_active %}filter-dropdown-button-active{% endif %}"

--- a/gsl_projet/templates/includes/_filter_montant_previsionnel.html
+++ b/gsl_projet/templates/includes/_filter_montant_previsionnel.html
@@ -1,0 +1,33 @@
+<div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
+    <div class="filter-dropdown fr-mt-4w">
+        <button type="button"
+                class="fr-input {% if is_montant_previsionnel_active %}filter-dropdown-button-active{% endif %}"
+                id="filter-montant-previsionnel-button">
+            Montant prévisionnel accordé
+            <span class="fr-icon-money-euro-box-fill fr-icon--sm blue-icon fr-ml-1w" />
+        </button>
+        <div class="filter-content">
+            <div class="amount-filter-group">
+                <label class="fr-label" for="id_montant_previsionnel_min">
+                    Montant minimum
+                </label>
+                <div class="euro-input-wrap">
+                    {{ filter.form.montant_previsionnel_min }}
+                    <span class="euro-input-symbol">€</span>
+                </div>
+            </div>
+            <div class="amount-filter-group">
+                <label class="fr-label" for="id_montant_previsionnel_max">
+                    Montant maximum
+                </label>
+                <div class="euro-input-wrap">
+                    {{ filter.form.montant_previsionnel_max }}
+                    <span class="euro-input-symbol">€</span>
+                </div>
+            </div>
+            <button type="submit" class="fr-btn fr-btn--sm">
+                Filtrer
+            </button>
+        </div>
+    </div>
+</div>

--- a/gsl_projet/templates/includes/_filter_montant_previsionnel.html
+++ b/gsl_projet/templates/includes/_filter_montant_previsionnel.html
@@ -1,8 +1,7 @@
-<div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
+<div class="filter-field fr-col-12 fr-col-md-6 fr-col-lg-3">
     <div class="filter-dropdown fr-mt-4w">
         <button type="button"
-                class="fr-input {% if is_montant_previsionnel_active %}filter-dropdown-button-active{% endif %}"
-                id="filter-montant-previsionnel-button">
+                class="fr-input {% if is_montant_previsionnel_active %}filter-dropdown-button-active{% endif %}">
             Montant prévisionnel accordé
             <span class="fr-icon-money-euro-box-fill fr-icon--sm blue-icon fr-ml-1w" />
         </button>

--- a/gsl_projet/templates/includes/_filter_montant_retenu.html
+++ b/gsl_projet/templates/includes/_filter_montant_retenu.html
@@ -1,4 +1,4 @@
-<div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
+<div class="filter-field fr-col-12 fr-col-md-6 fr-col-lg-3">
     <div class="filter-dropdown fr-mt-4w">
         <button type="button"
                 class="fr-input {% if is_montant_retenu_active %}filter-dropdown-button-active{% endif %}"

--- a/gsl_projet/templates/includes/_filter_porteur.html
+++ b/gsl_projet/templates/includes/_filter_porteur.html
@@ -1,4 +1,4 @@
-<div class="fr-col-12 fr-col-md-4 fr-col-lg-2">
+<div class="filter-field fr-col-12 fr-col-md-4 fr-col-lg-2">
     <label class="fr-label" for="porteur">
         Porteur de projet
     </label>

--- a/gsl_projet/templates/includes/_filter_status.html
+++ b/gsl_projet/templates/includes/_filter_status.html
@@ -1,0 +1,18 @@
+<div class="fr-col-12 fr-col-md-4 fr-col-lg-2">
+    <div class="filter-dropdown" id="filter-status-button">
+        <label class="fr-label" for="id_status">
+            Statut
+        </label>
+        <button type="button"
+                class="fr-select {% if is_status_active %}filter-dropdown-button-active{% endif %}"
+                id="filter-total-cost-button">
+            {{ is_status_placeholder }}
+        </button>
+        <div class="filter-content">
+            {{ filter.form.status }}
+            <button type="submit" class="fr-btn fr-btn--sm">
+                Filtrer
+            </button>
+        </div>
+    </div>
+</div>

--- a/gsl_projet/templates/includes/_filter_status.html
+++ b/gsl_projet/templates/includes/_filter_status.html
@@ -1,4 +1,4 @@
-<div class="fr-col-12 fr-col-md-4 fr-col-lg-2">
+<div class="filter-field fr-col-12 fr-col-md-4 fr-col-lg-2">
     <div class="filter-dropdown" id="filter-status-button">
         <label class="fr-label" for="id_status">
             Statut

--- a/gsl_projet/templates/includes/_filter_trier_par.html
+++ b/gsl_projet/templates/includes/_filter_trier_par.html
@@ -1,4 +1,4 @@
-<div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
+<div class="filter-field fr-col-12 fr-col-md-6 fr-col-lg-3">
     <label class="fr-label" for="tri">
         Trier par
     </label>

--- a/gsl_projet/templates/includes/_projet_list_filters.html
+++ b/gsl_projet/templates/includes/_projet_list_filters.html
@@ -13,6 +13,7 @@
             {% include "includes/_filter_trier_par.html" %}
             {% include "includes/_filter_dotation.html" %}
             {% include "includes/_filter_porteur.html" %}
+            {% include "includes/_filter_status.html" %}
             {% include "includes/_filter_cout_total.html" %}
             {% include "includes/_filter_montant_demande.html" %}
             {% include "includes/_filter_montant_retenu.html" %}

--- a/gsl_projet/templates/includes/_projet_list_filters.html
+++ b/gsl_projet/templates/includes/_projet_list_filters.html
@@ -11,12 +11,9 @@
     <div class="projets-filters-layout fr-container--fluid">
         <div class="fr-grid-row fr-grid-row--gutters">
             {% include "includes/_filter_trier_par.html" %}
-            {% include "includes/_filter_dotation.html" %}
-            {% include "includes/_filter_porteur.html" %}
-            {% include "includes/_filter_status.html" %}
-            {% include "includes/_filter_cout_total.html" %}
-            {% include "includes/_filter_montant_demande.html" %}
-            {% include "includes/_filter_montant_retenu.html" %}
+            {% for filter_name in filter_templates %}
+                {% include filter_name %}
+            {% endfor %}
         </div>
     </div>
 </form>

--- a/gsl_projet/tests/test_services.py
+++ b/gsl_projet/tests/test_services.py
@@ -148,36 +148,6 @@ def create_projets():
 
 
 @pytest.mark.django_db
-def test_add_filters_to_projets_qs(create_projets):
-    filters = {
-        "dispositif": "DETR",
-        "cout_min": "50",
-        "cout_max": "150",
-        "porteur": "EPCI",
-    }
-
-    qs = Projet.objects.all()
-    filtered_qs = SimulationService.add_filters_to_projets_qs(qs, filters)
-
-    assert filtered_qs.count() == 3
-    assert filtered_qs.values_list("assiette", flat=True).distinct()[0] == 50
-    assert filtered_qs.values_list("assiette", flat=True).distinct()[1] == 100
-    assert filtered_qs.values_list("assiette", flat=True).distinct()[2] == 150
-    assert (
-        filtered_qs.values_list(
-            "dossier_ds__demande_dispositif_sollicite", flat=True
-        ).distinct()[0]
-        == "DETR"
-    )
-    assert (
-        filtered_qs.values_list(
-            "dossier_ds__porteur_de_projet_nature__label", flat=True
-        ).distinct()[0]
-        == "EPCI"
-    )
-
-
-@pytest.mark.django_db
 def test_add_ordering_to_projets_qs():
     projet1 = ProjetFactory(
         dossier_ds__finance_cout_total=100,

--- a/gsl_projet/tests/test_services.py
+++ b/gsl_projet/tests/test_services.py
@@ -11,6 +11,7 @@ from gsl_projet.models import Projet
 from gsl_projet.services import ProjetService
 from gsl_projet.tests.factories import ProjetFactory
 from gsl_simulation.models import Simulation
+from gsl_simulation.services.simulation_service import SimulationService
 from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
 
 
@@ -156,7 +157,7 @@ def test_add_filters_to_projets_qs(create_projets):
     }
 
     qs = Projet.objects.all()
-    filtered_qs = ProjetService.add_filters_to_projets_qs(qs, filters)
+    filtered_qs = SimulationService.add_filters_to_projets_qs(qs, filters)
 
     assert filtered_qs.count() == 3
     assert filtered_qs.values_list("assiette", flat=True).distinct()[0] == 50

--- a/gsl_projet/tests/test_services.py
+++ b/gsl_projet/tests/test_services.py
@@ -11,7 +11,6 @@ from gsl_projet.models import Projet
 from gsl_projet.services import ProjetService
 from gsl_projet.tests.factories import ProjetFactory
 from gsl_simulation.models import Simulation
-from gsl_simulation.services.simulation_service import SimulationService
 from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
 
 

--- a/gsl_projet/tests/test_utils.py
+++ b/gsl_projet/tests/test_utils.py
@@ -1,0 +1,37 @@
+import pytest
+
+from gsl_projet.utils.utils import order_couples_tuple_by_first_value
+
+
+@pytest.fixture
+def choices():
+    return (("b", "value1"), ("a", "value2"), ("c", "value3"))
+
+
+def test_order_couples_tuple_by_first_value(choices):
+    ordered_first_values = ["a", "b", "c"]
+    expected = [("a", "value2"), ("b", "value1"), ("c", "value3")]
+    result = order_couples_tuple_by_first_value(choices, ordered_first_values)
+    assert result == expected
+
+
+def test_order_couples_tuple_by_first_value_reversed(choices):
+    ordered_first_values = ["c", "b", "a"]
+    expected = [("c", "value3"), ("b", "value1"), ("a", "value2")]
+    result = order_couples_tuple_by_first_value(choices, ordered_first_values)
+    assert result == expected
+
+
+def test_order_couples_tuple_by_first_value_missing_values(choices):
+    ordered_first_values = ["a", "b"]
+    expected = [("a", "value2"), ("b", "value1"), ("c", "value3")]
+    result = order_couples_tuple_by_first_value(choices, ordered_first_values)
+    assert result == expected
+
+
+def test_order_couples_tuple_by_first_value_empty_choices():
+    choices = ()
+    ordered_first_values = ["a", "b", "c"]
+    expected = []
+    result = order_couples_tuple_by_first_value(choices, ordered_first_values)
+    assert result == expected

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -518,10 +518,13 @@ def test_filter_by_status(req, view, projets_with_status, status, expected_count
 def test_get_status_placeholder(req, view, projets_with_status):
     request = req.get("/")
     view.request = request
-    assert view._get_status_placeholder() == "Tous"
+    assert view._get_status_placeholder(ProjetListView.STATE_MAPPINGS) == "Tous"
 
 
 def test_get_status_placeholder_with_status(req, view, projets_with_status):
     request = req.get("/?status=accepte&status=en_construction")
     view.request = request
-    assert view._get_status_placeholder() == "Accepté, En construction"
+    assert (
+        view._get_status_placeholder(ProjetListView.STATE_MAPPINGS)
+        == "Accepté, En construction"
+    )

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -13,7 +13,8 @@ from gsl_core.tests.factories import (
 from gsl_demarches_simplifiees.tests.factories import NaturePorteurProjetFactory
 from gsl_projet.models import Demandeur, Projet
 from gsl_projet.tests.factories import DemandeurFactory, ProjetFactory
-from gsl_projet.views import ProjetFilters, ProjetListView
+from gsl_projet.utils.projet_filters import ProjetFilters
+from gsl_projet.views import ProjetListView
 
 pytestmark = pytest.mark.django_db
 

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -59,8 +59,8 @@ def view() -> ProjetListView:
         ("cout_asc", ("dossier_ds__finance_cout_total",)),
         ("commune_desc", ("-address__commune__name",)),
         ("commune_asc", ("address__commune__name",)),
-        (None, ()),  # Test valeur par défaut
-        ("invalid_value", ()),  # Test valeur invalide
+        (None, ("-dossier_ds__ds_date_depot",)),  # Test valeur par défaut
+        ("invalid_value", ("-dossier_ds__ds_date_depot",)),  # Test valeur invalide
     ],
 )
 def test_get_ordering(req, view, tri_param, expected_ordering):
@@ -101,8 +101,8 @@ def projets(demandeur) -> list[Projet]:
         ("cout_asc", "0-1"),
         ("commune_desc", "1-0"),
         ("commune_asc", "0-1"),
-        ("", "0-1"),
-        ("invalid_value", "0-1"),
+        ("", "1-0"),
+        ("invalid_value", "1-0"),
     ],
 )
 def test_projets_ordering(req, view, projets, tri_param, expected_ordering):

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -15,6 +15,8 @@ from gsl_projet.models import Demandeur, Projet
 from gsl_projet.tests.factories import DemandeurFactory, ProjetFactory
 from gsl_projet.views import ProjetFilters, ProjetListView
 
+pytestmark = pytest.mark.django_db
+
 
 @pytest.fixture
 def dep_finistere() -> Departement:
@@ -48,7 +50,6 @@ def view() -> ProjetListView:
 ### Test du tri
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize(
     "tri_param,expected_ordering",
     [
@@ -91,7 +92,6 @@ def projets(demandeur) -> list[Projet]:
     return [projet0, projet1]
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize(
     "tri_param,expected_ordering",
     [
@@ -138,7 +138,6 @@ def projets_dsil(demandeur) -> list[Projet]:
     ]
 
 
-@pytest.mark.django_db
 def test_filter_by_dotation(req, view, projets_detr, projets_dsil):
     request = req.get("/?dotation=DETR")
     view.request = request
@@ -150,7 +149,6 @@ def test_filter_by_dotation(req, view, projets_detr, projets_dsil):
     assert all(p.dossier_ds.demande_dispositif_sollicite == "DETR" for p in qs)
 
 
-@pytest.mark.django_db
 def test_filter_by_dotation_dsil(req, view, projets_detr, projets_dsil):
     request = req.get("/?dotation=DSIL")
     view.request = request
@@ -162,7 +160,6 @@ def test_filter_by_dotation_dsil(req, view, projets_detr, projets_dsil):
     assert all(p.dossier_ds.demande_dispositif_sollicite == "DSIL" for p in qs)
 
 
-@pytest.mark.django_db
 def test_no_dispositif_filter(req, view, projets_detr, projets_dsil):
     request = req.get("/")
     view.request = request
@@ -221,7 +218,6 @@ def projets_unknown_projet(demandeur) -> list[Projet]:
     return projets
 
 
-@pytest.mark.django_db
 def test_filter_by_epci_porteur(
     req, view, projets_epci, projets_unknown_projet, projets_communes
 ):
@@ -232,7 +228,6 @@ def test_filter_by_epci_porteur(
     assert qs.count() == 2
 
 
-@pytest.mark.django_db
 def test_filter_by_communes_porteur(
     req, view, projets_epci, projets_unknown_projet, projets_communes
 ):
@@ -243,7 +238,6 @@ def test_filter_by_communes_porteur(
     assert qs.count() == 4
 
 
-@pytest.mark.django_db
 def test_filter_by_epci(
     req, view, projets_epci, projets_unknown_projet, projets_communes
 ):
@@ -254,7 +248,6 @@ def test_filter_by_epci(
     assert qs.count() == 9
 
 
-@pytest.mark.django_db
 def test_wrong_porteur_filter(
     req, view, projets_epci, projets_unknown_projet, projets_communes
 ):
@@ -293,7 +286,6 @@ def projets_without_assiette_but_finance_cout_total_from_dossier_ds(
     ]
 
 
-@pytest.mark.django_db
 def test_filter_by_min_cost(
     req,
     view,
@@ -308,7 +300,6 @@ def test_filter_by_min_cost(
     assert all(150000 <= p.assiette_or_cout_total for p in qs)
 
 
-@pytest.mark.django_db
 def test_filter_by_max_cost(
     req,
     view,
@@ -323,7 +314,6 @@ def test_filter_by_max_cost(
     assert all(p.assiette_or_cout_total <= 250000 for p in qs)
 
 
-@pytest.mark.django_db
 def test_filter_by_cost_range(
     req,
     view,
@@ -338,7 +328,6 @@ def test_filter_by_cost_range(
     assert all(100000 <= p.assiette_or_cout_total <= 250000 for p in qs)
 
 
-@pytest.mark.django_db
 def test_filter_with_wrong_values(
     req,
     view,
@@ -366,7 +355,6 @@ def projets_with_montant_retenu(demandeur) -> list[Projet]:
     ]
 
 
-@pytest.mark.django_db
 def test_filter_by_min_montant_retenu(
     req,
     view,
@@ -380,7 +368,6 @@ def test_filter_by_min_montant_retenu(
     assert all(100_000 <= p.dossier_ds.annotations_montant_accorde for p in qs)
 
 
-@pytest.mark.django_db
 def test_filter_by_max_montant_retenu(
     req,
     view,
@@ -394,7 +381,6 @@ def test_filter_by_max_montant_retenu(
     assert all(p.dossier_ds.annotations_montant_accorde <= 200_000 for p in qs)
 
 
-@pytest.mark.django_db
 def test_filter_by_montant_retenu_range(
     req,
     view,
@@ -410,7 +396,6 @@ def test_filter_by_montant_retenu_range(
     )
 
 
-@pytest.mark.django_db
 def test_filter_with_wrong_montant_retenu_values(
     req,
     view,
@@ -437,7 +422,6 @@ def projets_with_montant_demande(demandeur) -> list[Projet]:
     ]
 
 
-@pytest.mark.django_db
 def test_filter_by_min_montant_demande(
     req,
     view,
@@ -451,7 +435,6 @@ def test_filter_by_min_montant_demande(
     assert all(60_000 <= p.dossier_ds.demande_montant for p in qs)
 
 
-@pytest.mark.django_db
 def test_filter_by_max_montant_demande(
     req,
     view,
@@ -465,7 +448,6 @@ def test_filter_by_max_montant_demande(
     assert all(p.dossier_ds.demande_montant <= 120_000 for p in qs)
 
 
-@pytest.mark.django_db
 def test_filter_by_montant_demande_range(
     req,
     view,
@@ -479,7 +461,6 @@ def test_filter_by_montant_demande_range(
     assert all(60_000 <= p.dossier_ds.demande_montant <= 120_000 for p in qs)
 
 
-@pytest.mark.django_db
 def test_filter_with_wrong_montant_demande_values(
     req,
     view,
@@ -490,3 +471,57 @@ def test_filter_with_wrong_montant_demande_values(
     qs = view.get_filterset(ProjetFilters).qs
 
     assert qs.count() == 6
+
+
+### Test du filtre par statut
+
+
+@pytest.fixture
+def projets_with_status(demandeur) -> list[Projet]:
+    projets = []
+    for status, count in (
+        ("accepte", 1),
+        ("en_construction", 2),
+        ("en_instruction", 3),
+        ("refuse", 4),
+        ("sans_suite", 5),
+    ):
+        for _ in range(count):
+            projets.append(
+                ProjetFactory(
+                    dossier_ds__ds_state=status,
+                    demandeur=demandeur,
+                )
+            )
+    return projets
+
+
+@pytest.mark.parametrize(
+    "status,expected_count",
+    [
+        ("accepte", 1),
+        ("en_construction", 2),
+        ("en_instruction", 3),
+        ("refuse", 4),
+        ("sans_suite", 5),
+    ],
+)
+def test_filter_by_status(req, view, projets_with_status, status, expected_count):
+    request = req.get(f"/?status={status}")
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+
+    assert qs.count() == expected_count
+    assert qs.first().dossier_ds.ds_state == status
+
+
+def test_get_status_placeholder(req, view, projets_with_status):
+    request = req.get("/")
+    view.request = request
+    assert view._get_status_placeholder() == "Tous"
+
+
+def test_get_status_placeholder_with_status(req, view, projets_with_status):
+    request = req.get("/?status=accepte&status=en_construction")
+    view.request = request
+    assert view._get_status_placeholder() == "Accepté, En construction"

--- a/gsl_projet/utils/django_filters_custom_widget.py
+++ b/gsl_projet/utils/django_filters_custom_widget.py
@@ -1,0 +1,18 @@
+from django import forms
+from django.utils.safestring import mark_safe
+
+
+class CustomCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
+    def render(self, name, value, attrs=None, renderer=None):
+        """Customize how the checkboxes are displayed in the HTML output."""
+        output = []
+        for i, (option_value, option_label) in enumerate(self.choices):
+            checked = "checked" if option_value in value else ""
+            checkbox = f'<input type="checkbox" name="{name}" value="{option_value}" id="id_{name}_{i}" {checked}>'
+            label = (
+                f'<label for="id_{name}_{i}" class="fr-label">{option_label}</label>'
+            )
+            output.append(
+                f'<div class="fr-checkbox-group fr-checkbox-group--sm">{checkbox} {label}</div>'
+            )
+        return mark_safe("\n".join(output))

--- a/gsl_projet/utils/django_filters_custom_widget.py
+++ b/gsl_projet/utils/django_filters_custom_widget.py
@@ -7,7 +7,7 @@ class CustomCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
         """Customize how the checkboxes are displayed in the HTML output."""
         output = []
         for i, (option_value, option_label) in enumerate(self.choices):
-            checked = "checked" if option_value in value else ""
+            checked = "checked" if value and option_value in value else ""
             checkbox = f'<input type="checkbox" name="{name}" value="{option_value}" id="id_{name}_{i}" {checked}>'
             label = (
                 f'<label for="id_{name}_{i}" class="fr-label">{option_label}</label>'

--- a/gsl_projet/utils/django_filters_custom_widget.py
+++ b/gsl_projet/utils/django_filters_custom_widget.py
@@ -1,17 +1,33 @@
 from django import forms
 from django.utils.safestring import mark_safe
 
+from gsl_demarches_simplifiees.models import Dossier
+from gsl_simulation.models import SimulationProjet
+
 
 class CustomCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
+    def _get_color(self, option_value):
+        return {
+            SimulationProjet.STATUS_DRAFT: "",
+            SimulationProjet.STATUS_PROVISOIRE: "blue",
+            SimulationProjet.STATUS_CANCELLED: "red",
+            SimulationProjet.STATUS_VALID: "green",
+            Dossier.STATE_ACCEPTE: "green",
+            Dossier.STATE_EN_CONSTRUCTION: "blue",
+            Dossier.STATE_EN_INSTRUCTION: "blue",
+            Dossier.STATE_REFUSE: "red",
+            Dossier.STATE_SANS_SUITE: "orange",
+        }.get(option_value, "")
+
     def render(self, name, value, attrs=None, renderer=None):
         """Customize how the checkboxes are displayed in the HTML output."""
         output = []
         for i, (option_value, option_label) in enumerate(self.choices):
+            color = self._get_color(option_value)
+            style = f'style="color: var(--status-color-{color});"' if color else ""
             checked = "checked" if value and option_value in value else ""
             checkbox = f'<input type="checkbox" name="{name}" value="{option_value}" id="id_{name}_{i}" {checked}>'
-            label = (
-                f'<label for="id_{name}_{i}" class="fr-label">{option_label}</label>'
-            )
+            label = f'<label for="id_{name}_{i}" class="fr-label" {style}>{option_label}</label>'
             output.append(
                 f'<div class="fr-checkbox-group fr-checkbox-group--sm">{checkbox} {label}</div>'
             )

--- a/gsl_projet/utils/filter_utils.py
+++ b/gsl_projet/utils/filter_utils.py
@@ -1,0 +1,36 @@
+from gsl_demarches_simplifiees.models import Dossier
+
+
+class FilterUtils:
+    DS_STATE_MAPPINGS = {key: value for key, value in Dossier.DS_STATE_VALUES}
+
+    def enrich_context_with_filter_utils(self, context):
+        context["is_status_active"] = self._get_is_one_field_active(["status"])
+        context["is_status_placeholder"] = self._get_status_placeholder()
+        context["is_cout_total_active"] = self._get_is_one_field_active(
+            ["cout_min", "cout_max"]
+        )
+        context["is_montant_demande_active"] = self._get_is_one_field_active(
+            ["montant_demande_min", "montant_demande_max"]
+        )
+        context["is_montant_retenu_active"] = self._get_is_one_field_active(
+            ["montant_retenu_min", "montant_retenu_max"]
+        )
+
+        return context
+
+    def _get_status_placeholder(self):
+        if self.request.GET.get("status") in (None, "", []):
+            return "Tous"
+        return ", ".join(
+            [
+                self.DS_STATE_MAPPINGS[status]
+                for status in self.request.GET.getlist("status")
+            ]
+        )
+
+    def _get_is_one_field_active(self, field_names):
+        for field_name in field_names:
+            if self.request.GET.get(field_name) not in (None, ""):
+                return True
+        return False

--- a/gsl_projet/utils/filter_utils.py
+++ b/gsl_projet/utils/filter_utils.py
@@ -1,8 +1,4 @@
-from gsl_demarches_simplifiees.models import Dossier
-
-
 class FilterUtils:
-    DS_STATE_MAPPINGS = {key: value for key, value in Dossier.DS_STATE_VALUES}
     FILTER_TEMPLATE_MAPPINGS = {
         "dotation": "includes/_filter_dotation.html",
         "porteur": "includes/_filter_porteur.html",
@@ -12,9 +8,9 @@ class FilterUtils:
         "montant_retenu": "includes/_filter_montant_retenu.html",
     }
 
-    def enrich_context_with_filter_utils(self, context):
+    def enrich_context_with_filter_utils(self, context, state_mappings):
         context["is_status_active"] = self._get_is_one_field_active(["status"])
-        context["is_status_placeholder"] = self._get_status_placeholder()
+        context["is_status_placeholder"] = self._get_status_placeholder(state_mappings)
         context["is_cout_total_active"] = self._get_is_one_field_active(
             ["cout_min", "cout_max"]
         )
@@ -36,14 +32,11 @@ class FilterUtils:
         except AttributeError:  # no filterset => we display all filters
             return self.FILTER_TEMPLATE_MAPPINGS.values()
 
-    def _get_status_placeholder(self):
+    def _get_status_placeholder(self, state_mappings):
         if self.request.GET.get("status") in (None, "", []):
             return "Tous"
         return ", ".join(
-            [
-                self.DS_STATE_MAPPINGS[status]
-                for status in self.request.GET.getlist("status")
-            ]
+            [state_mappings[status] for status in self.request.GET.getlist("status")]
         )
 
     def _get_is_one_field_active(self, field_names):

--- a/gsl_projet/utils/filter_utils.py
+++ b/gsl_projet/utils/filter_utils.py
@@ -6,10 +6,10 @@ class FilterUtils:
     FILTER_TEMPLATE_MAPPINGS = {
         "dotation": "includes/_filter_dotation.html",
         "porteur": "includes/_filter_porteur.html",
+        "status": "includes/_filter_status.html",
         "cout_total": "includes/_filter_cout_total.html",
         "montant_demande": "includes/_filter_montant_demande.html",
         "montant_retenu": "includes/_filter_montant_retenu.html",
-        "status": "includes/_filter_status.html",
     }
 
     def enrich_context_with_filter_utils(self, context):
@@ -25,11 +25,16 @@ class FilterUtils:
             ["montant_retenu_min", "montant_retenu_max"]
         )
 
-        filters = self.get_filterset(self.filterset_class).filterset
-        context["filter_templates"] = (
-            self.FILTER_TEMPLATE_MAPPINGS[filter] for filter in filters
-        )
+        context["filter_templates"] = self._get_filter_templates()
+
         return context
+
+    def _get_filter_templates(self):
+        try:
+            filters = self.get_filterset(self.filterset_class).filterset
+            return (self.FILTER_TEMPLATE_MAPPINGS[filter] for filter in filters)
+        except AttributeError:  # no filterset => we display all filters
+            return self.FILTER_TEMPLATE_MAPPINGS.values()
 
     def _get_status_placeholder(self):
         if self.request.GET.get("status") in (None, "", []):

--- a/gsl_projet/utils/filter_utils.py
+++ b/gsl_projet/utils/filter_utils.py
@@ -3,6 +3,14 @@ from gsl_demarches_simplifiees.models import Dossier
 
 class FilterUtils:
     DS_STATE_MAPPINGS = {key: value for key, value in Dossier.DS_STATE_VALUES}
+    FILTER_TEMPLATE_MAPPINGS = {
+        "dotation": "includes/_filter_dotation.html",
+        "porteur": "includes/_filter_porteur.html",
+        "cout_total": "includes/_filter_cout_total.html",
+        "montant_demande": "includes/_filter_montant_demande.html",
+        "montant_retenu": "includes/_filter_montant_retenu.html",
+        "status": "includes/_filter_status.html",
+    }
 
     def enrich_context_with_filter_utils(self, context):
         context["is_status_active"] = self._get_is_one_field_active(["status"])
@@ -17,6 +25,10 @@ class FilterUtils:
             ["montant_retenu_min", "montant_retenu_max"]
         )
 
+        filters = self.get_filterset(self.filterset_class).filterset
+        context["filter_templates"] = (
+            self.FILTER_TEMPLATE_MAPPINGS[filter] for filter in filters
+        )
         return context
 
     def _get_status_placeholder(self):

--- a/gsl_projet/utils/filter_utils.py
+++ b/gsl_projet/utils/filter_utils.py
@@ -40,7 +40,9 @@ class FilterUtils:
         if self.request.GET.get("status") in (None, "", []):
             return "Tous"
         return ", ".join(
-            [state_mappings[status] for status in self.request.GET.getlist("status")]
+            state_mappings[status]
+            for status in self.request.GET.getlist("status")
+            if status in state_mappings
         )
 
     def _get_is_one_field_active(self, field_names):

--- a/gsl_projet/utils/filter_utils.py
+++ b/gsl_projet/utils/filter_utils.py
@@ -46,7 +46,7 @@ class FilterUtils:
         )
 
     def _get_is_one_field_active(self, field_names):
-        for field_name in field_names:
-            if self.request.GET.get(field_name) not in (None, ""):
-                return True
-        return False
+        return any(
+            self.request.GET.get(field_name) not in (None, "")
+            for field_name in field_names
+        )

--- a/gsl_projet/utils/filter_utils.py
+++ b/gsl_projet/utils/filter_utils.py
@@ -6,6 +6,7 @@ class FilterUtils:
         "cout_total": "includes/_filter_cout_total.html",
         "montant_demande": "includes/_filter_montant_demande.html",
         "montant_retenu": "includes/_filter_montant_retenu.html",
+        "montant_previsionnel": "includes/_filter_montant_previsionnel.html",
     }
 
     def enrich_context_with_filter_utils(self, context, state_mappings):
@@ -19,6 +20,9 @@ class FilterUtils:
         )
         context["is_montant_retenu_active"] = self._get_is_one_field_active(
             ["montant_retenu_min", "montant_retenu_max"]
+        )
+        context["is_montant_previsionnel_active"] = self._get_is_one_field_active(
+            ["montant_previsionnel_min", "montant_previsionnel_max"]
         )
 
         context["filter_templates"] = self._get_filter_templates()

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -24,7 +24,6 @@ class ProjetFilters(FilterSet):
                 "placeholder": "Toutes les dotations",
             }
         ),
-        template_name="includes/_filter_dotation.html",
     )
 
     porteur = ChoiceFilter(
@@ -41,7 +40,6 @@ class ProjetFilters(FilterSet):
                 "placeholder": "Tous les porteurs",
             },
         ),
-        template_name="includes/_filter_porteur.html",
     )
 
     def filter_porteur(self, queryset, _name, value):
@@ -56,7 +54,6 @@ class ProjetFilters(FilterSet):
         widget=NumberInput(
             attrs={"class": "fr-input", "min": "0"},
         ),
-        template_name="includes/_filter_cout_total.html",
     )
 
     def filter_cout_min(self, queryset, _name, value):
@@ -70,7 +67,6 @@ class ProjetFilters(FilterSet):
         widget=NumberInput(
             attrs={"class": "fr-input", "min": "0"},
         ),
-        template_name="includes/_filter_cout_total.html",
     )
 
     def filter_cout_max(self, queryset, _name, value):
@@ -85,7 +81,6 @@ class ProjetFilters(FilterSet):
         widget=NumberInput(
             attrs={"class": "fr-input", "min": "0"},
         ),
-        template_name="includes/_filter_montant_demande.html",
     )
 
     montant_demande_min = NumberFilter(
@@ -102,7 +97,6 @@ class ProjetFilters(FilterSet):
         widget=NumberInput(
             attrs={"class": "fr-input", "min": "0"},
         ),
-        template_name="includes/_filter_montant_retenu.html",
     )
 
     montant_retenu_max = NumberFilter(
@@ -111,14 +105,12 @@ class ProjetFilters(FilterSet):
         widget=NumberInput(
             attrs={"class": "fr-input", "min": "0"},
         ),
-        template_name="includes/_filter_montant_retenu.html",
     )
 
     status = MultipleChoiceFilter(
         field_name="dossier_ds__ds_state",
         choices=Dossier.DS_STATE_VALUES,
         widget=CustomCheckboxSelectMultiple(),
-        template_name="includes/_filter_status.html",
     )
 
     class Meta:

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -1,0 +1,143 @@
+from django.db.models import Q
+from django.forms import NumberInput, Select
+from django_filters import (
+    ChoiceFilter,
+    FilterSet,
+    MultipleChoiceFilter,
+    NumberFilter,
+)
+
+from gsl_demarches_simplifiees.models import Dossier
+from gsl_projet.models import Projet
+from gsl_projet.services import ProjetService
+from gsl_projet.utils.django_filters_custom_widget import CustomCheckboxSelectMultiple
+
+
+class ProjetFilters(FilterSet):
+    dotation = ChoiceFilter(
+        field_name="dossier_ds__demande_dispositif_sollicite",
+        choices=Dossier.DEMANDE_DISPOSITIF_SOLLICITE_VALUES,
+        widget=Select(
+            attrs={
+                "class": "fr-select",
+                "onchange": "this.form.submit()",
+                "placeholder": "Toutes les dotations",
+            }
+        ),
+        template_name="includes/_filter_dotation.html",
+    )
+
+    porteur = ChoiceFilter(
+        field_name="dossier_ds__porteur_de_projet_nature__label__in",
+        choices=(
+            ("EPCI", "EPCI"),
+            ("Communes", "Communes"),
+        ),
+        method="filter_porteur",
+        widget=Select(
+            attrs={
+                "class": "fr-select",
+                "onchange": "this.form.submit()",
+                "placeholder": "Tous les porteurs",
+            },
+        ),
+        template_name="includes/_filter_porteur.html",
+    )
+
+    def filter_porteur(self, queryset, _name, value):
+        return queryset.filter(
+            dossier_ds__porteur_de_projet_nature__label__in=ProjetService.PORTEUR_MAPPINGS.get(
+                value
+            )
+        )
+
+    cout_min = NumberFilter(
+        method="filter_cout_min",
+        widget=NumberInput(
+            attrs={"class": "fr-input", "min": "0"},
+        ),
+        template_name="includes/_filter_cout_total.html",
+    )
+
+    def filter_cout_min(self, queryset, _name, value):
+        return queryset.filter(
+            Q(assiette__isnull=False, assiette__gte=value)
+            | Q(assiette__isnull=True, dossier_ds__finance_cout_total__gte=value)
+        )
+
+    cout_max = NumberFilter(
+        method="filter_cout_max",
+        widget=NumberInput(
+            attrs={"class": "fr-input", "min": "0"},
+        ),
+        template_name="includes/_filter_cout_total.html",
+    )
+
+    def filter_cout_max(self, queryset, _name, value):
+        return queryset.filter(
+            Q(assiette__isnull=False, assiette__lte=value)
+            | Q(assiette__isnull=True, dossier_ds__finance_cout_total__lte=value)
+        )
+
+    montant_demande_max = NumberFilter(
+        field_name="dossier_ds__demande_montant",
+        lookup_expr="lte",
+        widget=NumberInput(
+            attrs={"class": "fr-input", "min": "0"},
+        ),
+        template_name="includes/_filter_montant_demande.html",
+    )
+
+    montant_demande_min = NumberFilter(
+        field_name="dossier_ds__demande_montant",
+        lookup_expr="gte",
+        widget=NumberInput(
+            attrs={"class": "fr-input", "min": "0"},
+        ),
+    )
+
+    montant_retenu_min = NumberFilter(
+        field_name="dossier_ds__annotations_montant_accorde",
+        lookup_expr="gte",
+        widget=NumberInput(
+            attrs={"class": "fr-input", "min": "0"},
+        ),
+        template_name="includes/_filter_montant_retenu.html",
+    )
+
+    montant_retenu_max = NumberFilter(
+        field_name="dossier_ds__annotations_montant_accorde",
+        lookup_expr="lte",
+        widget=NumberInput(
+            attrs={"class": "fr-input", "min": "0"},
+        ),
+        template_name="includes/_filter_montant_retenu.html",
+    )
+
+    status = MultipleChoiceFilter(
+        field_name="dossier_ds__ds_state",
+        choices=Dossier.DS_STATE_VALUES,
+        widget=CustomCheckboxSelectMultiple(),
+        template_name="includes/_filter_status.html",
+    )
+
+    class Meta:
+        model = Projet
+        fields = (
+            "dotation",
+            "porteur",
+            "cout_min",
+            "cout_max",
+            "montant_demande_min",
+            "montant_demande_max",
+            "montant_retenu_min",
+            "montant_retenu_max",
+            "status",
+        )
+
+    @property
+    def qs(self):
+        self.queryset = Projet.objects.all()
+        qs = super().qs
+        qs = ProjetService.add_ordering_to_projets_qs(qs, self.request.GET.get("tri"))
+        return qs

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -21,9 +21,9 @@ class ProjetFilters(FilterSet):
             attrs={
                 "class": "fr-select",
                 "onchange": "this.form.submit()",
-                "placeholder": "Toutes les dotations",
             }
         ),
+        empty_label="Toutes les dotations",
     )
 
     porteur = ChoiceFilter(
@@ -37,9 +37,9 @@ class ProjetFilters(FilterSet):
             attrs={
                 "class": "fr-select",
                 "onchange": "this.form.submit()",
-                "placeholder": "Tous les porteurs",
             },
         ),
+        empty_label="Tous les porteurs",
     )
 
     def filter_porteur(self, queryset, _name, value):

--- a/gsl_projet/utils/utils.py
+++ b/gsl_projet/utils/utils.py
@@ -1,8 +1,8 @@
-# TODO : test
-
-
 def order_couples_tuple_by_first_value(
     choices: tuple[tuple[str, str]], ordered_first_values: list[str]
 ):
     order_dict = {status: index for index, status in enumerate(ordered_first_values)}
-    return sorted(choices, key=lambda x: order_dict[x[0]])
+    return sorted(
+        choices,
+        key=lambda x: order_dict[x[0]] if x[0] in order_dict else 1,
+    )

--- a/gsl_projet/utils/utils.py
+++ b/gsl_projet/utils/utils.py
@@ -1,0 +1,8 @@
+# TODO : test
+
+
+def order_couples_tuple_by_first_value(
+    choices: tuple[tuple[str, str]], ordered_first_values: list[str]
+):
+    order_dict = {status: index for index, status in enumerate(ordered_first_values)}
+    return sorted(choices, key=lambda x: order_dict[x[0]])

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -4,6 +4,7 @@ from django.views.decorators.http import require_GET
 from django.views.generic import ListView
 from django_filters.views import FilterView
 
+from gsl_demarches_simplifiees.models import Dossier
 from gsl_projet.services import ProjetService
 from gsl_projet.utils.filter_utils import FilterUtils
 from gsl_projet.utils.projet_filters import ProjetFilters
@@ -98,6 +99,7 @@ class ProjetListView(FilterView, ListView, FilterUtils):
     paginate_by = 25
     filterset_class = ProjetListViewFilters
     template_name = "gsl_projet/projet_list.html"
+    STATE_MAPPINGS = {key: value for key, value in Dossier.DS_STATE_VALUES}
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -108,6 +110,6 @@ class ProjetListView(FilterView, ListView, FilterUtils):
         context["total_cost"] = ProjetService.get_total_cost(qs)
         context["total_amount_asked"] = ProjetService.get_total_amount_asked(qs)
         context["total_amount_granted"] = 0  # TODO
-        self.enrich_context_with_filter_utils(context)
+        self.enrich_context_with_filter_utils(context, self.STATE_MAPPINGS)
 
         return context

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -205,6 +205,13 @@ class ProjetFilters(FilterSet):
         qs = qs.for_user(self.request.user)
         qs = qs.for_current_year()
         qs = ProjetService.add_ordering_to_projets_qs(qs, self.request.GET.get("tri"))
+        qs = qs.select_related(
+            "address",
+            "address__commune",
+        ).prefetch_related(
+            "dossier_ds__demande_eligibilite_detr",
+            "dossier_ds__demande_eligibilite_dsil",
+        )
         return qs
 
 

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -1,21 +1,12 @@
-from django.db.models import Q
-from django.forms import NumberInput, Select
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.views.decorators.http import require_GET
 from django.views.generic import ListView
-from django_filters import (
-    ChoiceFilter,
-    FilterSet,
-    MultipleChoiceFilter,
-    NumberFilter,
-)
 from django_filters.views import FilterView
 
-from gsl_demarches_simplifiees.models import Dossier
 from gsl_projet.services import ProjetService
-from gsl_projet.utils.django_filters_custom_widget import CustomCheckboxSelectMultiple
 from gsl_projet.utils.filter_utils import FilterUtils
+from gsl_projet.utils.projet_filters import ProjetFilters
 
 from .models import Projet
 
@@ -86,130 +77,7 @@ def get_projet(request, projet_id):
     return render(request, "gsl_projet/projet.html", context)
 
 
-class ProjetFilters(FilterSet):
-    dotation = ChoiceFilter(
-        field_name="dossier_ds__demande_dispositif_sollicite",
-        choices=Dossier.DEMANDE_DISPOSITIF_SOLLICITE_VALUES,
-        widget=Select(
-            attrs={
-                "class": "fr-select",
-                "onchange": "this.form.submit()",
-                "placeholder": "Toutes les dotations",
-            }
-        ),
-    )
-
-    porteur = ChoiceFilter(
-        field_name="dossier_ds__porteur_de_projet_nature__label__in",
-        choices=(
-            ("EPCI", "EPCI"),
-            ("Communes", "Communes"),
-        ),
-        method="filter_porteur",
-        widget=Select(
-            attrs={
-                "class": "fr-select",
-                "onchange": "this.form.submit()",
-                "placeholder": "Tous les porteurs",
-            },
-        ),
-    )
-
-    def filter_porteur(self, queryset, _name, value):
-        return queryset.filter(
-            dossier_ds__porteur_de_projet_nature__label__in=ProjetService.PORTEUR_MAPPINGS.get(
-                value
-            )
-        )
-
-    cout_min = NumberFilter(
-        method="filter_cout_min",
-        widget=NumberInput(
-            attrs={"class": "fr-input", "min": "0"},
-        ),
-    )
-
-    def filter_cout_min(self, queryset, _name, value):
-        return queryset.filter(
-            Q(assiette__isnull=False, assiette__gte=value)
-            | Q(assiette__isnull=True, dossier_ds__finance_cout_total__gte=value)
-        )
-
-    cout_max = NumberFilter(
-        method="filter_cout_max",
-        widget=NumberInput(
-            attrs={"class": "fr-input", "min": "0"},
-        ),
-    )
-
-    def filter_cout_max(self, queryset, _name, value):
-        return queryset.filter(
-            Q(assiette__isnull=False, assiette__lte=value)
-            | Q(assiette__isnull=True, dossier_ds__finance_cout_total__lte=value)
-        )
-
-    montant_demande_max = NumberFilter(
-        field_name="dossier_ds__demande_montant",
-        lookup_expr="lte",
-        widget=NumberInput(
-            attrs={"class": "fr-input", "min": "0"},
-        ),
-    )
-
-    montant_demande_min = NumberFilter(
-        field_name="dossier_ds__demande_montant",
-        lookup_expr="gte",
-        widget=NumberInput(
-            attrs={"class": "fr-input", "min": "0"},
-        ),
-    )
-
-    montant_retenu_min = NumberFilter(
-        field_name="dossier_ds__annotations_montant_accorde",
-        lookup_expr="gte",
-        widget=NumberInput(
-            attrs={"class": "fr-input", "min": "0"},
-        ),
-    )
-
-    montant_retenu_max = NumberFilter(
-        field_name="dossier_ds__annotations_montant_accorde",
-        lookup_expr="lte",
-        widget=NumberInput(
-            attrs={"class": "fr-input", "min": "0"},
-        ),
-    )
-
-    status = MultipleChoiceFilter(
-        field_name="dossier_ds__ds_state",
-        choices=Dossier.DS_STATE_VALUES,
-        widget=CustomCheckboxSelectMultiple(),
-    )
-
-    class Meta:
-        model = Projet
-        fields = (
-            "dotation",
-            "porteur",
-            "cout_min",
-            "cout_max",
-            "montant_demande_min",
-            "montant_demande_max",
-            "montant_retenu_min",
-            "montant_retenu_max",
-            "status",
-        )
-
-    @property
-    def qs(self):
-        self.queryset = Projet.objects.all()
-        qs = super().qs
-        qs = ProjetService.add_ordering_to_projets_qs(qs, self.request.GET.get("tri"))
-        return qs
-
-
-# TODO : rename this class
-class ProjetFiltersFils(ProjetFilters):
+class ProjetListViewFilters(ProjetFilters):
     @property
     def qs(self):
         qs = super().qs
@@ -228,7 +96,7 @@ class ProjetFiltersFils(ProjetFilters):
 class ProjetListView(FilterView, ListView, FilterUtils):
     model = Projet
     paginate_by = 25
-    filterset_class = ProjetFiltersFils
+    filterset_class = ProjetListViewFilters
     template_name = "gsl_projet/projet_list.html"
 
     def get_context_data(self, **kwargs):

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -103,7 +103,7 @@ class ProjetListView(FilterView, ListView, FilterUtils):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        qs = self.get_queryset()  # TODO => is this linked to the filterset_class ???
+        qs = context["object_list"]
         context["title"] = "Projets 2025"
         context["porteur_mappings"] = ProjetService.PORTEUR_MAPPINGS
         context["breadcrumb_dict"] = {"current": "Liste des projets"}

--- a/gsl_simulation/services/simulation_service.py
+++ b/gsl_simulation/services/simulation_service.py
@@ -1,10 +1,12 @@
 from datetime import date
 from typing import Any
 
+from django.db.models import Q
 from django.utils.text import slugify
 
 from gsl_core.models import Perimetre
 from gsl_programmation.models import Enveloppe
+from gsl_projet.services import ProjetService
 from gsl_simulation.models import Simulation
 
 
@@ -45,3 +47,58 @@ class SimulationService:
                 incremented_slug = slugify(slug + f"-{i}")
             return incremented_slug
         return slug
+
+    @classmethod
+    def add_filters_to_projets_qs(cls, qs, filters: dict, simulation: Simulation):
+        cout_min = filters.get("cout_min")
+        if cout_min and cout_min.isnumeric():
+            qs = qs.filter(
+                Q(assiette__isnull=False, assiette__gte=cout_min)
+                | Q(assiette__isnull=True, dossier_ds__finance_cout_total__gte=cout_min)
+            )
+
+        cout_max = filters.get("cout_max")
+        if cout_max and cout_max.isnumeric():
+            qs = qs.filter(
+                Q(assiette__isnull=False, assiette__lte=cout_max)
+                | Q(assiette__isnull=True, dossier_ds__finance_cout_total__lte=cout_max)
+            )
+
+        montant_demande_min = filters.get("montant_demande_min")
+        if montant_demande_min and montant_demande_min.isnumeric():
+            qs = qs.filter(dossier_ds__demande_montant__gte=montant_demande_min)
+
+        montant_demande_max = filters.get("montant_demande_max")
+        if montant_demande_max and montant_demande_max.isnumeric():
+            qs = qs.filter(dossier_ds__demande_montant__lte=montant_demande_max)
+
+        montant_previsionnel_min = filters.get("montant_previsionnel_min")
+        if montant_previsionnel_min and montant_previsionnel_min.isnumeric():
+            qs = qs.filter(
+                simulationprojet__simulation=simulation,
+                simulationprojet__montant__gte=montant_previsionnel_min,
+            )
+
+        montant_previsionnel_max = filters.get("montant_previsionnel_max")
+        if montant_previsionnel_max and montant_previsionnel_max.isnumeric():
+            qs = qs.filter(
+                simulationprojet__simulation=simulation,
+                simulationprojet__montant__lte=montant_previsionnel_max,
+            )
+
+        status = filters.get("status")
+        if status:
+            qs = qs.filter(
+                simulationprojet__simulation=simulation,
+                simulationprojet__status__in=status,
+            )
+
+        porteur = filters.get("porteur")
+        if porteur in ProjetService.PORTEUR_MAPPINGS:
+            qs = qs.filter(
+                dossier_ds__porteur_de_projet_nature__label__in=ProjetService.PORTEUR_MAPPINGS.get(
+                    porteur
+                )
+            )
+
+        return qs

--- a/gsl_simulation/services/simulation_service.py
+++ b/gsl_simulation/services/simulation_service.py
@@ -1,12 +1,10 @@
 from datetime import date
 from typing import Any
 
-from django.db.models import Q
 from django.utils.text import slugify
 
 from gsl_core.models import Perimetre
 from gsl_programmation.models import Enveloppe
-from gsl_projet.services import ProjetService
 from gsl_simulation.models import Simulation
 
 
@@ -47,61 +45,3 @@ class SimulationService:
                 incremented_slug = slugify(slug + f"-{i}")
             return incremented_slug
         return slug
-
-    # C'est une duplication de la logique instanciée par ProjetFilters.
-    # L'idée serait de ne plus se servir de cette méthode en instanciant ProjetFilters avec les bons filtres.
-    @classmethod
-    def add_filters_to_projets_qs(cls, qs, filters: dict, simulation: Simulation):
-        cout_min = filters.get("cout_min")
-        if cout_min and cout_min.isnumeric():
-            qs = qs.filter(
-                Q(assiette__isnull=False, assiette__gte=cout_min)
-                | Q(assiette__isnull=True, dossier_ds__finance_cout_total__gte=cout_min)
-            )
-
-        cout_max = filters.get("cout_max")
-        if cout_max and cout_max.isnumeric():
-            qs = qs.filter(
-                Q(assiette__isnull=False, assiette__lte=cout_max)
-                | Q(assiette__isnull=True, dossier_ds__finance_cout_total__lte=cout_max)
-            )
-
-        montant_demande_min = filters.get("montant_demande_min")
-        if montant_demande_min and montant_demande_min.isnumeric():
-            qs = qs.filter(dossier_ds__demande_montant__gte=montant_demande_min)
-
-        montant_demande_max = filters.get("montant_demande_max")
-        if montant_demande_max and montant_demande_max.isnumeric():
-            qs = qs.filter(dossier_ds__demande_montant__lte=montant_demande_max)
-
-        montant_previsionnel_min = filters.get("montant_previsionnel_min")
-        if montant_previsionnel_min and montant_previsionnel_min.isnumeric():
-            qs = qs.filter(
-                simulationprojet__simulation=simulation,
-                simulationprojet__montant__gte=montant_previsionnel_min,
-            )
-
-        montant_previsionnel_max = filters.get("montant_previsionnel_max")
-        if montant_previsionnel_max and montant_previsionnel_max.isnumeric():
-            qs = qs.filter(
-                simulationprojet__simulation=simulation,
-                simulationprojet__montant__lte=montant_previsionnel_max,
-            )
-
-        status = filters.get("status")
-        if status:
-            status = status if isinstance(status, list) else [status]
-            qs = qs.filter(
-                simulationprojet__simulation=simulation,
-                simulationprojet__status__in=status,
-            )
-
-        porteur = filters.get("porteur")
-        if porteur in ProjetService.PORTEUR_MAPPINGS:
-            qs = qs.filter(
-                dossier_ds__porteur_de_projet_nature__label__in=ProjetService.PORTEUR_MAPPINGS.get(
-                    porteur
-                )
-            )
-
-        return qs

--- a/gsl_simulation/services/simulation_service.py
+++ b/gsl_simulation/services/simulation_service.py
@@ -1,12 +1,10 @@
 from datetime import date
 from typing import Any
 
-from django.db.models import QuerySet
 from django.utils.text import slugify
 
 from gsl_core.models import Perimetre
 from gsl_programmation.models import Enveloppe
-from gsl_projet.models import Projet
 from gsl_simulation.models import Simulation
 
 
@@ -47,15 +45,3 @@ class SimulationService:
                 incremented_slug = slugify(slug + f"-{i}")
             return incremented_slug
         return slug
-
-    # TODO : remove ??
-    @classmethod
-    def get_projets_from_simulation(cls, simulation: Simulation):
-        return Projet.objects.filter(simulationprojet__simulation=simulation)
-
-    # TODO : remove ??
-    @classmethod
-    def filter_projets_from_simulation(
-        cls, qs: QuerySet[Projet], simulation: Simulation
-    ) -> QuerySet[Projet]:
-        return qs.filter(simulationprojet__simulation=simulation)

--- a/gsl_simulation/services/simulation_service.py
+++ b/gsl_simulation/services/simulation_service.py
@@ -90,6 +90,7 @@ class SimulationService:
 
         status = filters.get("status")
         if status:
+            status = status if isinstance(status, list) else [status]
             qs = qs.filter(
                 simulationprojet__simulation=simulation,
                 simulationprojet__status__in=status,

--- a/gsl_simulation/services/simulation_service.py
+++ b/gsl_simulation/services/simulation_service.py
@@ -48,6 +48,8 @@ class SimulationService:
             return incremented_slug
         return slug
 
+    # C'est une duplication de la logique instanciée par ProjetFilters.
+    # L'idée serait de ne plus se servir de cette méthode en instanciant ProjetFilters avec les bons filtres.
     @classmethod
     def add_filters_to_projets_qs(cls, qs, filters: dict, simulation: Simulation):
         cout_min = filters.get("cout_min")

--- a/gsl_simulation/services/simulation_service.py
+++ b/gsl_simulation/services/simulation_service.py
@@ -1,6 +1,7 @@
 from datetime import date
 from typing import Any
 
+from django.db.models import QuerySet
 from django.utils.text import slugify
 
 from gsl_core.models import Perimetre
@@ -47,6 +48,14 @@ class SimulationService:
             return incremented_slug
         return slug
 
+    # TODO : remove ??
     @classmethod
     def get_projets_from_simulation(cls, simulation: Simulation):
         return Projet.objects.filter(simulationprojet__simulation=simulation)
+
+    # TODO : remove ??
+    @classmethod
+    def filter_projets_from_simulation(
+        cls, qs: QuerySet[Projet], simulation: Simulation
+    ) -> QuerySet[Projet]:
+        return qs.filter(simulationprojet__simulation=simulation)

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -11,8 +11,8 @@
     </h1>
     {% include "includes/_status_summary.html" %}
     {% include "includes/_enveloppe_summary.html" %}
+    {% include "includes/_projet_list_filters.html" %}
 
-    {% include "includes/_simulation_projet_list_filters.html" %}
     <div class="fr-table--lg gsl-projet-table">
         <table>
             <thead>

--- a/gsl_simulation/templates/htmx/projet_update.html
+++ b/gsl_simulation/templates/htmx/projet_update.html
@@ -1,7 +1,7 @@
 {% load gsl_filters %}
 
 {% include "includes/_status_summary.html" with hx_swap_oob="true" %}
-{% comment %} <span hx-swap-oob="innerHTML" id="total-amount-granted">{{ total_amount_granted | euro }}</span> {% endcomment %}
+<span hx-swap-oob="innerHTML" id="total-amount-granted">{{ total_amount_granted | euro }}</span>
 <table>
     {% include "includes/_simulation_detail_row.html" %}
 </table>

--- a/gsl_simulation/templates/htmx/projet_update.html
+++ b/gsl_simulation/templates/htmx/projet_update.html
@@ -1,7 +1,7 @@
 {% load gsl_filters %}
 
 {% include "includes/_status_summary.html" with hx_swap_oob="true" %}
-<span hx-swap-oob="innerHTML" id="total-amount-granted">{{ total_amount_granted | euro }}</span>
+{% comment %} <span hx-swap-oob="innerHTML" id="total-amount-granted">{{ total_amount_granted | euro }}</span> {% endcomment %}
 <table>
     {% include "includes/_simulation_detail_row.html" %}
 </table>

--- a/gsl_simulation/tests/services/test_simulation_services.py
+++ b/gsl_simulation/tests/services/test_simulation_services.py
@@ -8,10 +8,6 @@ from gsl_core.tests.factories import (
     PerimetreDepartementalFactory,
     PerimetreRegionalFactory,
 )
-from gsl_demarches_simplifiees.tests.factories import (
-    DossierFactory,
-    NaturePorteurProjetFactory,
-)
 from gsl_programmation.models import Enveloppe
 from gsl_programmation.tests.factories import (
     DetrEnveloppeFactory,
@@ -19,7 +15,7 @@ from gsl_programmation.tests.factories import (
 )
 from gsl_simulation.models import Simulation
 from gsl_simulation.services.simulation_service import SimulationService
-from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
+from gsl_simulation.tests.factories import SimulationFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -122,38 +118,3 @@ def test_slug_generation():
 
     slug = SimulationService.get_slug("Other test 1")
     assert slug == "other-test-1-1"
-
-
-@pytest.fixture
-def simulation():
-    return SimulationFactory(enveloppe=DetrEnveloppeFactory())
-
-
-@pytest.fixture
-def create_projets(simulation):
-    epci_nature = NaturePorteurProjetFactory(label="EPCI")
-    commune_nature = NaturePorteurProjetFactory(label="Communes")
-
-    for status in ("valid", "draft", "cancelled"):
-        for cout in (49, 50, 100, 150, 151):
-            for montant_previsionnel in (100, 150, 151):
-                SimulationProjetFactory(
-                    simulation=simulation,
-                    status=status,
-                    montant=montant_previsionnel,
-                    projet__assiette=cout,
-                    projet__dossier_ds=DossierFactory(
-                        demande_dispositif_sollicite="DETR",
-                        porteur_de_projet_nature=epci_nature,
-                    ),
-                )
-                SimulationProjetFactory(
-                    simulation=simulation,
-                    status=status,
-                    montant=montant_previsionnel,
-                    projet__assiette=cout,
-                    projet__dossier_ds=DossierFactory(
-                        demande_dispositif_sollicite="DETR",
-                        porteur_de_projet_nature=commune_nature,
-                    ),
-                )

--- a/gsl_simulation/tests/services/test_simulation_services.py
+++ b/gsl_simulation/tests/services/test_simulation_services.py
@@ -1,4 +1,5 @@
 from datetime import date
+from decimal import Decimal
 
 import pytest
 
@@ -8,14 +9,19 @@ from gsl_core.tests.factories import (
     PerimetreDepartementalFactory,
     PerimetreRegionalFactory,
 )
+from gsl_demarches_simplifiees.tests.factories import (
+    DossierFactory,
+    NaturePorteurProjetFactory,
+)
 from gsl_programmation.models import Enveloppe
 from gsl_programmation.tests.factories import (
     DetrEnveloppeFactory,
     DsilEnveloppeFactory,
 )
+from gsl_projet.models import Projet
 from gsl_simulation.models import Simulation
 from gsl_simulation.services.simulation_service import SimulationService
-from gsl_simulation.tests.factories import SimulationFactory
+from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -118,3 +124,90 @@ def test_slug_generation():
 
     slug = SimulationService.get_slug("Other test 1")
     assert slug == "other-test-1-1"
+
+
+@pytest.fixture
+def simulation():
+    return SimulationFactory(enveloppe=DetrEnveloppeFactory())
+
+
+@pytest.fixture
+def create_projets(simulation):
+    epci_nature = NaturePorteurProjetFactory(label="EPCI")
+    commune_nature = NaturePorteurProjetFactory(label="Communes")
+
+    for status in ("valid", "draft", "cancelled"):
+        for cout in (49, 50, 100, 150, 151):
+            for montant_previsionnel in (100, 150, 151):
+                SimulationProjetFactory(
+                    simulation=simulation,
+                    status=status,
+                    montant=montant_previsionnel,
+                    projet__assiette=cout,
+                    projet__dossier_ds=DossierFactory(
+                        demande_dispositif_sollicite="DETR",
+                        porteur_de_projet_nature=epci_nature,
+                    ),
+                )
+                SimulationProjetFactory(
+                    simulation=simulation,
+                    status=status,
+                    montant=montant_previsionnel,
+                    projet__assiette=cout,
+                    projet__dossier_ds=DossierFactory(
+                        demande_dispositif_sollicite="DETR",
+                        porteur_de_projet_nature=commune_nature,
+                    ),
+                )
+
+
+@pytest.mark.django_db
+def test_add_filters_to_projets_qs(simulation, create_projets):
+    filters = {
+        "cout_min": "50",
+        "cout_max": "150",
+        "porteur": "EPCI",
+        "montant_previsionnel_min": "100",
+        "montant_previsionnel_max": "150",
+        "status": ["valid"],
+    }
+
+    qs = Projet.objects.all()
+    filtered_qs = SimulationService.add_filters_to_projets_qs(qs, filters, simulation)
+
+    assert filtered_qs.count() == 6
+    cout_distinct = filtered_qs.values_list("assiette", flat=True).distinct()
+    assert len(cout_distinct) == 3
+    assert cout_distinct[0] == Decimal("50.0")
+    assert cout_distinct[1] == Decimal("100.0")
+    assert cout_distinct[2] == Decimal("150.0")
+
+    montants = filtered_qs.values_list(
+        "simulationprojet__montant", flat=True
+    ).distinct()
+    assert len(montants) == 2
+    assert montants[0] == Decimal("100.0")
+    assert montants[1] == Decimal("150.0")
+
+    dotations = filtered_qs.values_list(
+        "dossier_ds__demande_dispositif_sollicite", flat=True
+    ).distinct()
+    assert len(dotations) == 1
+    assert dotations[0] == "DETR"
+
+    porteur = filtered_qs.values_list(
+        "dossier_ds__porteur_de_projet_nature__label", flat=True
+    ).distinct()
+    assert len(porteur) == 1
+    assert porteur[0] == "EPCI"
+
+    assert (
+        filtered_qs.values_list(
+            "dossier_ds__porteur_de_projet_nature__label", flat=True
+        ).distinct()[0]
+        == "EPCI"
+    )
+
+    status = filtered_qs.values_list("simulationprojet__status", flat=True).distinct()
+    assert len(status) == 1
+    assert status[0] == "valid"

--- a/gsl_simulation/tests/test_utils.py
+++ b/gsl_simulation/tests/test_utils.py
@@ -1,7 +1,6 @@
 import pytest
 
 from gsl_simulation.utils import (
-    get_filters_dict_from_params,
     replace_comma_by_dot,
 )
 
@@ -19,18 +18,3 @@ from gsl_simulation.utils import (
 )
 def test_replace_comma_by_dot(input_str, expected_float):
     assert replace_comma_by_dot(input_str) == expected_float
-
-
-@pytest.mark.parametrize(
-    "filter_params, expected_result",
-    [
-        ("key1=value1", {"key1": "value1"}),
-        ("key1=value1&key1=value2", {"key1": ["value1", "value2"]}),
-        ("key1=value1&key2=value2&key3=", {"key1": "value1", "key2": "value2"}),
-        ("", {}),
-        ("key1=", {}),
-    ],
-)
-def test_get_filters_dict_from_params(filter_params, expected_result):
-    result = get_filters_dict_from_params(filter_params)
-    assert result == expected_result

--- a/gsl_simulation/utils.py
+++ b/gsl_simulation/utils.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import parse_qs
 
 
 def replace_comma_by_dot(value: str | None) -> float | None:
@@ -20,10 +19,3 @@ def replace_comma_by_dot(value: str | None) -> float | None:
         return round(float(value), 2)
     except ValueError:
         return 0.0
-
-
-def get_filters_dict_from_params(filter_params):
-    return {
-        key: value[0] if len(value) == 1 else value
-        for key, value in parse_qs(filter_params).items()
-    }

--- a/gsl_simulation/views.py
+++ b/gsl_simulation/views.py
@@ -78,6 +78,7 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
 
     def get(self, request, *args, **kwargs):
         # Ensure the object is retrieved
+        # TODO simplify this ??
         self.simulation = self.get_object()
         self.object = self.simulation
         return super().get(request, *args, **kwargs)

--- a/gsl_simulation/views.py
+++ b/gsl_simulation/views.py
@@ -9,13 +9,16 @@ from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
+from django_filters import MultipleChoiceFilter
 from django_filters.views import FilterView
 
 from gsl_demarches_simplifiees.models import Dossier
 from gsl_programmation.services.enveloppe_service import EnveloppeService
 from gsl_projet.models import Projet
 from gsl_projet.services import ProjetService
+from gsl_projet.utils.django_filters_custom_widget import CustomCheckboxSelectMultiple
 from gsl_projet.utils.filter_utils import FilterUtils
+from gsl_projet.utils.utils import get_status_choices
 from gsl_projet.views import ProjetFilters
 from gsl_simulation.forms import SimulationForm
 from gsl_simulation.models import Simulation, SimulationProjet
@@ -69,6 +72,19 @@ class SimulationProjetListViewFilters(ProjetFilters):
             "montant_retenu_max",
             "status",
         )
+
+    ordered_status = (
+        SimulationProjet.STATUS_DRAFT,
+        SimulationProjet.STATUS_PROVISOIRE,
+        SimulationProjet.STATUS_CANCELLED,
+        SimulationProjet.STATUS_VALID,
+    )
+
+    status = MultipleChoiceFilter(
+        field_name="status",
+        choices=get_status_choices(SimulationProjet.STATUS_CHOICES, ordered_status),
+        widget=CustomCheckboxSelectMultiple(),
+    )
 
 
 class SimulationDetailView(FilterView, DetailView, FilterUtils):

--- a/gsl_simulation/views.py
+++ b/gsl_simulation/views.py
@@ -49,9 +49,31 @@ class SimulationListView(ListView):
         ).order_by("-created_at")
 
 
+class SimulationProjetListViewFilters(ProjetFilters):
+    filterset = (
+        "porteur",
+        "status",
+        "cout_total",
+        "montant_demande",
+        "montant_retenu",
+    )
+
+    class Meta(ProjetFilters.Meta):
+        fields = (
+            "porteur",
+            "cout_min",
+            "cout_max",
+            "montant_demande_min",
+            "montant_demande_max",
+            "montant_retenu_min",
+            "montant_retenu_max",
+            "status",
+        )
+
+
 class SimulationDetailView(FilterView, DetailView, FilterUtils):
     model = Simulation
-    filterset_class = ProjetFilters
+    filterset_class = SimulationProjetListViewFilters
     template_name = "gsl_simulation/simulation_detail.html"
 
     def get(self, request, *args, **kwargs):
@@ -61,7 +83,6 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
-        # Use self.object instead of calling get_object() again
         qs = self.get_projet_queryset()
         context = super().get_context_data(**kwargs)
         paginator = Paginator(qs, 25)  # TODO try with paginate_by

--- a/gsl_simulation/views.py
+++ b/gsl_simulation/views.py
@@ -61,7 +61,7 @@ class SimulationProjetListViewFilters(ProjetFilters):
         "montant_retenu",
     )
 
-    class Meta(ProjetFilters.Meta):
+    class Meta(ProjetFilters.Meta):  # TODO utile ?
         fields = (
             "porteur",
             "cout_min",
@@ -86,7 +86,16 @@ class SimulationProjetListViewFilters(ProjetFilters):
             SimulationProjet.STATUS_CHOICES, ordered_status
         ),
         widget=CustomCheckboxSelectMultiple(),
+        method="filter_status",
     )
+
+    def filter_status(self, queryset, name, value):
+        return queryset.filter(
+            simulationprojet__simulation=Simulation.objects.get(
+                slug=self.request.resolver_match.kwargs.get("slug")
+            ),
+            simulationprojet__status__in=value,
+        )
 
 
 class SimulationDetailView(FilterView, DetailView, FilterUtils):

--- a/gsl_simulation/views.py
+++ b/gsl_simulation/views.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.core.cache import cache
 from django.core.paginator import Paginator
 from django.db.models import Prefetch, Sum
 from django.forms import NumberInput
@@ -70,18 +69,6 @@ class SimulationProjetListViewFilters(ProjetFilters):
         "montant_demande",
         "montant_previsionnel",
     )
-
-    class Meta(ProjetFilters.Meta):  # TODO utile ?
-        fields = (
-            "porteur",
-            "cout_min",
-            "cout_max",
-            "montant_demande_min",
-            "montant_demande_max",
-            "montant_previsionnel_min",
-            "montant_previsionnel_max",
-            "status",
-        )
 
     ordered_status = (
         SimulationProjet.STATUS_DRAFT,
@@ -271,7 +258,6 @@ def redirect_to_simulation_projet(request, simulation_projet):
             },
         )
 
-    cache.clear()
     url = reverse(
         "simulation:simulation-detail",
         kwargs={"slug": simulation_projet.simulation.slug},

--- a/gsl_simulation/views.py
+++ b/gsl_simulation/views.py
@@ -141,10 +141,10 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
-        self.simulation = self.object
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
+        simulation = self.get_object()
         qs = self.get_projet_queryset()
         context = super().get_context_data(**kwargs)
         paginator = Paginator(qs, 25)
@@ -153,16 +153,16 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
         context["simulations_paginator"] = current_page
         context["simulations_list"] = current_page.object_list
         context["title"] = (
-            f"{self.simulation.enveloppe.type} {self.simulation.enveloppe.annee} – {self.simulation.title}"
+            f"{simulation.enveloppe.type} {simulation.enveloppe.annee} – {simulation.title}"
         )
         context["porteur_mappings"] = ProjetService.PORTEUR_MAPPINGS
-        context["status_summary"] = self.simulation.get_projet_status_summary()
+        context["status_summary"] = simulation.get_projet_status_summary()
         context["total_cost"] = ProjetService.get_total_cost(qs)
         context["total_amount_asked"] = ProjetService.get_total_amount_asked(qs)
         context["total_amount_granted"] = ProjetService.get_total_amount_granted(qs)
         context["available_states"] = SimulationProjet.STATUS_CHOICES
         context["filter_params"] = self.request.GET.urlencode()
-        context["enveloppe"] = self.get_enveloppe_data(self.simulation)
+        context["enveloppe"] = self.get_enveloppe_data(simulation)
         self.enrich_context_with_filter_utils(context, self.STATE_MAPPINGS)
 
         context["breadcrumb_dict"] = {
@@ -172,7 +172,7 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
                     "title": "Mes simulations de programmation",
                 }
             ],
-            "current": self.simulation.title,
+            "current": simulation.title,
         }
 
         return context

--- a/gsl_simulation/views.py
+++ b/gsl_simulation/views.py
@@ -99,22 +99,6 @@ class SimulationProjetListViewFilters(ProjetFilters):
         method="filter_status",
     )
 
-    montant_previsionnel_min = NumberFilter(
-        field_name="simulationprojet__montant",
-        lookup_expr="gte",
-        widget=NumberInput(
-            attrs={"class": "fr-input", "min": "0"},
-        ),
-    )
-
-    montant_previsionnel_max = NumberFilter(
-        field_name="simulationprojet__montant",
-        lookup_expr="lte",
-        widget=NumberInput(
-            attrs={"class": "fr-input", "min": "0"},
-        ),
-    )
-
     def filter_status(self, queryset, name, value):
         return queryset.filter(
             # Cette ligne est utile pour qu'on ait un "ET", cad, on filtre les projets de la simulation en cours ET sur les statuts sélectionnés.
@@ -125,6 +109,40 @@ class SimulationProjetListViewFilters(ProjetFilters):
                 "slug"
             ),
             simulationprojet__status__in=value,
+        )
+
+    montant_previsionnel_min = NumberFilter(
+        field_name="simulationprojet__montant",
+        lookup_expr="gte",
+        widget=NumberInput(
+            attrs={"class": "fr-input", "min": "0"},
+        ),
+        method="filter_montant_previsionnel_min",
+    )
+
+    montant_previsionnel_max = NumberFilter(
+        field_name="simulationprojet__montant",
+        lookup_expr="lte",
+        widget=NumberInput(
+            attrs={"class": "fr-input", "min": "0"},
+        ),
+        method="filter_montant_previsionnel_max",
+    )
+
+    def filter_montant_previsionnel_min(self, queryset, name, value):
+        return queryset.filter(
+            simulationprojet__simulation__slug=self.request.resolver_match.kwargs.get(
+                "slug"
+            ),
+            simulationprojet__montant__gte=value,
+        )
+
+    def filter_montant_previsionnel_max(self, queryset, name, value):
+        return queryset.filter(
+            simulationprojet__simulation__slug=self.request.resolver_match.kwargs.get(
+                "slug"
+            ),
+            simulationprojet__montant__lte=value,
         )
 
 

--- a/gsl_simulation/views.py
+++ b/gsl_simulation/views.py
@@ -150,7 +150,7 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
     def get_projet_queryset(self):
         simulation = self.get_object()
         qs = self.get_filterset(self.filterset_class).qs
-        qs = SimulationService.filter_projets_from_simulation(qs, simulation)
+        qs = qs.filter(simulationprojet__simulation=simulation)
         qs = qs.select_related("address", "address__commune")
         qs = qs.prefetch_related(
             Prefetch(
@@ -201,6 +201,7 @@ def redirect_to_simulation_projet(request, simulation_projet):
         )
         filter_params = QueryDict(request.body).get("filter_params")
         filters_dict = get_filters_dict_from_params(filter_params)
+        # TODO : add filters to projets_of_simulation
         filtered_projets_of_simulation = ProjetService.add_filters_to_projets_qs(
             projets_of_simulation,
             filters_dict,


### PR DESCRIPTION
## 🌮 Objectif

- Ajout du filtre sur les statuts sur la page de la liste des projets et la page d'une simulation
- Ajout des "nouveaux" filtres sur la page d'une simulation


## 🖼️ Images

![image](https://github.com/user-attachments/assets/69ca79fd-bba3-4b61-91eb-e9ea1b897e30)


## A Noter
- Je n'ai pas réussi à réutiliser la logique du `ProjetFilters` pour la vue renvoyée par htmx (fonction `redirect_to_simulation_projet`)
- Il n'y a pas de tests sur les valeurs renvoyées par la vue SimulationDetail