### PR TITLE
Management visuel dans l'interface d'admin, pour différencier les environnements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,8 @@ PROCONNECT_SESSION_END="https://fca.integ01.dev-agentconnect.fr/session/end"
 # Sentry
 SENTRY_DSN=
 SENTRY_ENV=dev
+
+# Visual management
+VIMA_ENV_NAME = "[Local] "
+VIMA_ENV_BG_COLOR = "purple"
+VIMA_ENV_FG_COLOR = "#fff"

--- a/gsl/admin.py
+++ b/gsl/admin.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+from django.contrib import admin
+
+
+class GslAdminSite(admin.AdminSite):
+    site_title = "Admin GSL"
+    site_header = f"{settings.VIMA_ENV_NAME} GSL - Administration"

--- a/gsl/apps.py
+++ b/gsl/apps.py
@@ -1,0 +1,5 @@
+from django.contrib.admin.apps import AdminConfig
+
+
+class GslAdminConfig(AdminConfig):
+    default_site = "gsl.admin.GslAdminSite"

--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -56,7 +56,7 @@ if SENTRY_DSN:
 # Application definition
 
 INSTALLED_APPS = [
-    "django.contrib.admin",
+    "gsl.apps.GslAdminConfig",
     "django.contrib.auth",
     "mozilla_django_oidc",
     "django.contrib.contenttypes",
@@ -114,7 +114,7 @@ LANGUAGE_CODE = "fr"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -230,3 +230,9 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_TIMEZONE = "Europe/Paris"
 CELERY_RESULT_BACKEND = "django-db"
 CELERY_RESULT_EXTENDED = True
+
+# Visual management
+
+VIMA_ENV_NAME = os.getenv("VIMA_ENV_NAME", "")
+VIMA_ENV_BG_COLOR = os.getenv("VIMA_ENV_BG_COLOR", "#fff")
+VIMA_ENV_FG_COLOR = os.getenv("VIMA_ENV_FG_COLOR", "#000")


### PR DESCRIPTION
## 🌮 Objectif

Éviter "tiens mais pourquoi donc mes modifs ne se voient pas ? Ah flûte j'étais en prod."

## 🔍 Liste des modifications

- [x] Afficher le nom de l'environnement dans l'en-tête de l'admin ;
- [ ] Afficher un élément coloré au login et dans l'admin à partir des variables de config VIMA_XX_COLOR

## ⚠️ Informations supplémentaires

Il faudra ajouter quelques variables d'env sur chaque environnement.


## 🖼️ Images

TODO
