### PR TITLE
Correction du différentiel entre le nombre de projets d'une simulation et celui d'une enveloppe

### DIFF
--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -46,6 +46,9 @@ class ProjetQuerySet(models.QuerySet):
             return self.filter(demandeur__departement__region=perimetre.region)
 
     def for_current_year(self):
+        return self.not_processed_before_the_start_of_the_year(date.today().year)
+
+    def not_processed_before_the_start_of_the_year(self, year: int):
         return self.filter(
             Q(
                 dossier_ds__ds_state__in=[
@@ -60,7 +63,7 @@ class ProjetQuerySet(models.QuerySet):
                     Dossier.STATE_REFUSE,
                 ],
                 dossier_ds__ds_date_traitement__gte=datetime(
-                    date.today().year, 1, 1, 0, 0, tzinfo=tz.utc
+                    year, 1, 1, 0, 0, tzinfo=tz.utc
                 ),
             )
         )
@@ -77,17 +80,8 @@ class ProjetQuerySet(models.QuerySet):
                 ),
             )
         )
-        projet_qs_not_processed_before_the_start_of_the_year = (
-            projet_qs_submitted_before_the_end_of_the_year.filter(
-                Q(
-                    dossier_ds__ds_date_traitement__gte=datetime(
-                        enveloppe.annee, 1, 1, tzinfo=UTC
-                    )
-                )
-                | Q(
-                    dossier_ds__ds_date_traitement__isnull=True,
-                )
-            )
+        projet_qs_not_processed_before_the_start_of_the_year = projet_qs_submitted_before_the_end_of_the_year.not_processed_before_the_start_of_the_year(
+            enveloppe.annee
         )
         return projet_qs_not_processed_before_the_start_of_the_year
 

--- a/gsl_projet/tests/test_model_projet.py
+++ b/gsl_projet/tests/test_model_projet.py
@@ -248,6 +248,7 @@ def test_for_enveloppe_with_projet_type_and_enveloppe_type(
     ProjetFactory(
         demandeur__departement=perimetre.departement,
         dossier_ds__ds_date_depot=datetime(2024, 3, 1, tzinfo=UTC),
+        dossier_ds__ds_date_traitement=datetime(2024, 5, 1, tzinfo=UTC),
         dossier_ds__demande_dispositif_sollicite=projet_type,
     )
 
@@ -274,6 +275,7 @@ def test_for_year_2024_and_for_not_processed_states(submitted_year, count):
     projet = SubmittedProjetFactory(
         dossier_ds__demande_dispositif_sollicite=enveloppe.type,
         dossier_ds__ds_date_depot=datetime(submitted_year, 12, 31, tzinfo=tz.utc),
+        dossier_ds__ds_date_traitement=datetime(submitted_year + 1, 5, 1, tzinfo=UTC),
         demandeur__departement=perimetre.departement,
     )
     print(f"Test with {projet.dossier_ds.ds_state}")


### PR DESCRIPTION
## 🌮 Objectif

Nous avions deux méthodes de sélections des projets : l'un pour une enveloppe afin de définir la synthèse de celle-ci, l'autre pour sélectionner les projets à inclure dans une simulation.

=> La différence s'explique parce que la date de traitement du Dossier DS peut être non nulle quand bien même on a un projet En Construction ou En Instruction.