### PR TITLE
Remplissage de l'arrondissement du demandeur

### DIFF
--- a/gsl_demarches_simplifiees/tests/factories.py
+++ b/gsl_demarches_simplifiees/tests/factories.py
@@ -5,8 +5,16 @@ import factory.fuzzy
 from django.db.models.signals import post_save
 
 from gsl_core.tests.factories import AdresseFactory
+from gsl_core.tests.factories import ArrondissementFactory as CoreArrondissementFactory
 
-from ..models import Demarche, Dossier, NaturePorteurProjet, PersonneMorale
+from ..models import Arrondissement as DsArrondissement
+from ..models import (
+    Demarche,
+    Dossier,
+    DsChoiceLibelle,
+    NaturePorteurProjet,
+    PersonneMorale,
+)
 
 
 class DemarcheFactory(factory.django.DjangoModelFactory):
@@ -28,6 +36,20 @@ class PersonneMoraleFactory(factory.django.DjangoModelFactory):
     address = factory.SubFactory(AdresseFactory)
 
 
+class DsLibelleFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = DsChoiceLibelle
+
+    label = factory.Sequence(lambda n: f"dslibelle-{n}")
+
+
+class DsArrondissementFactory(DsLibelleFactory):
+    class Meta:
+        model = DsArrondissement
+
+    core_arrondissement = factory.SubFactory(CoreArrondissementFactory)
+
+
 class NaturePorteurProjetFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = NaturePorteurProjet
@@ -45,6 +67,7 @@ class DossierFactory(factory.django.DjangoModelFactory):
     ds_number = factory.Faker("random_int", min=1000000, max=9999999)
     ds_state = Dossier.STATE_EN_INSTRUCTION
     ds_demandeur = factory.SubFactory(PersonneMoraleFactory)
+    porteur_de_projet_arrondissement = factory.SubFactory(DsArrondissementFactory)
     ds_date_depot = factory.Faker(
         "date_time_this_year", before_now=True, tzinfo=timezone.utc
     )

--- a/gsl_demarches_simplifiees/tests/test_factories.py
+++ b/gsl_demarches_simplifiees/tests/test_factories.py
@@ -1,6 +1,7 @@
 import pytest
 
 from gsl_demarches_simplifiees.models import (
+    Arrondissement,
     Demarche,
     Dossier,
     NaturePorteurProjet,
@@ -10,6 +11,7 @@ from gsl_demarches_simplifiees.models import (
 from .factories import (
     DemarcheFactory,
     DossierFactory,
+    DsArrondissementFactory,
     NaturePorteurProjetFactory,
     PersonneMoraleFactory,
 )
@@ -20,6 +22,7 @@ test_data = (
     (DemarcheFactory, Demarche),
     (DossierFactory, Dossier),
     (NaturePorteurProjetFactory, NaturePorteurProjet),
+    (DsArrondissementFactory, Arrondissement),
     (PersonneMoraleFactory, PersonneMorale),
 )
 

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -8,6 +8,7 @@ from .models import Demandeur, Projet
 @admin.register(Demandeur)
 class DemandeurAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     raw_id_fields = ("address", "arrondissement", "departement")
+    list_display = ("name", "departement", "arrondissement")
 
 
 @admin.register(Projet)

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -16,8 +16,16 @@ class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     raw_id_fields = ("address", "departement", "demandeur", "dossier_ds")
     list_display = ("__str__", "dossier_ds__ds_state", "address", "departement")
     list_filter = ("departement", "dossier_ds__ds_state")
+    actions = ("refresh_from_dossier",)
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         qs = qs.select_related("address").select_related("departement")
         return qs
+
+    @admin.action(description="Rafraîchir depuis le dossier DS")
+    def refresh_from_dossier(self, request, queryset):
+        from gsl_projet.tasks import update_projet_from_dossier
+
+        for projet in queryset.select_related("dossier_ds"):
+            update_projet_from_dossier.delay(projet.dossier_ds.ds_number)

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -157,24 +157,27 @@ class Projet(models.Model):
                 dossier_ds=ds_dossier,
             )
         projet.address = ds_dossier.projet_adresse
+
+        projet_departement = (
+            ds_dossier.ds_demandeur.address.commune.departement
+            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement.departement
+        )
+        projet_arrondissement = (
+            ds_dossier.ds_demandeur.address.commune.arrondissement
+            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement
+        )
         projet.demandeur, _ = Demandeur.objects.get_or_create(
             siret=ds_dossier.ds_demandeur.siret,
             defaults={
                 "name": ds_dossier.ds_demandeur.raison_sociale,
                 "address": ds_dossier.ds_demandeur.address,
-                "departement": ds_dossier.ds_demandeur.address.commune.departement
-                or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement.departement,
+                "departement": projet_departement,
+                "arrondissement": projet_arrondissement,
             },
         )
 
-        projet.demandeur.departement = (
-            ds_dossier.ds_demandeur.address.commune.departement
-            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement.departement
-        )
-        projet.demandeur.arrondissement = (
-            ds_dossier.ds_demandeur.address.commune.arrondissement
-            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement
-        )
+        projet.demandeur.arrondissement = projet_arrondissement
+        projet.demandeur.departement = projet_departement
         projet.demandeur.save()
 
         if projet.address is not None and projet.address.commune is not None:

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -163,6 +163,7 @@ class Projet(models.Model):
                 "name": ds_dossier.ds_demandeur.raison_sociale,
                 "address": ds_dossier.ds_demandeur.address,
                 "departement": ds_dossier.ds_demandeur.address.commune.departement,
+                "arrondissement": ds_dossier.porteur_de_projet_arrondissement.core_arrondissement,
             },
         )
         if projet.address is not None and projet.address.commune is not None:

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -162,10 +162,21 @@ class Projet(models.Model):
             defaults={
                 "name": ds_dossier.ds_demandeur.raison_sociale,
                 "address": ds_dossier.ds_demandeur.address,
-                "departement": ds_dossier.ds_demandeur.address.commune.departement,
-                "arrondissement": ds_dossier.porteur_de_projet_arrondissement.core_arrondissement,
+                "departement": ds_dossier.ds_demandeur.address.commune.departement
+                or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement.departement,
             },
         )
+
+        projet.demandeur.departement = (
+            ds_dossier.ds_demandeur.address.commune.departement
+            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement.departement
+        )
+        projet.demandeur.arrondissement = (
+            ds_dossier.ds_demandeur.address.commune.arrondissement
+            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement
+        )
+        projet.demandeur.save()
+
         if projet.address is not None and projet.address.commune is not None:
             projet.departement = projet.address.commune.departement
 

--- a/gsl_projet/tests/test_model_projet.py
+++ b/gsl_projet/tests/test_model_projet.py
@@ -4,7 +4,7 @@ from datetime import timezone as tz
 import pytest
 from django.db import connection
 
-from gsl_core.models import Departement
+from gsl_core.models import Arrondissement, Departement
 from gsl_core.tests.factories import (
     AdresseFactory,
     ArrondissementFactory,
@@ -59,10 +59,7 @@ def test_create_projet_from_dossier():
     assert projet.address == dossier.projet_adresse
 
     assert projet.demandeur is not None
-    assert (
-        projet.demandeur.arrondissement
-        == dossier.porteur_de_projet_arrondissement.core_arrondissement
-    )
+    assert isinstance(projet.demandeur.arrondissement, Arrondissement)
     other_projet = Projet.get_or_create_from_ds_dossier(dossier)
     assert other_projet == projet
 

--- a/gsl_projet/tests/test_model_projet.py
+++ b/gsl_projet/tests/test_model_projet.py
@@ -58,6 +58,11 @@ def test_create_projet_from_dossier():
     assert projet.address.commune == dossier.projet_adresse.commune
     assert projet.address == dossier.projet_adresse
 
+    assert projet.demandeur is not None
+    assert (
+        projet.demandeur.arrondissement
+        == dossier.porteur_de_projet_arrondissement.core_arrondissement
+    )
     other_projet = Projet.get_or_create_from_ds_dossier(dossier)
     assert other_projet == projet
 


### PR DESCRIPTION
## 🌮 Objectif

L'arrondissement est une donnée importante pour la programmation des subventions, or on ne la faisait pas descendre correctement au niveau du projet.

Là on stocke un arrondissement sur le demandeur : soit l'arrondissement extrait de son adresse, s'il est fourni ; soit l'arrondissement fourni manuellement par le demandeur lors de la complétion du formulaire.

## 🔍 Liste des modifications

- Dev
- Mise à jour des tests

Et aussi : 

- Affichage des infos pertinentes sur les demandeurs dans l'admin
- Ajout de la possibilité de "rafraîchir" un projet donné depuis son dossier DS

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

<img width="424" alt="Liste déroulante indiquant « rafraîchir depuis le dossier DS »" src="https://github.com/user-attachments/assets/1cff13f0-7406-4584-9c4f-470020272aea" />
<img width="934" alt="Liste de demandeurs indiquant que certains ont un arrondissement rattaché" src="https://github.com/user-attachments/assets/a151c9d4-a688-4268-8eb7-1eae78e7e8ca" />

