### PR TITLE
Suppression de champs inutilisés sur la classe Projet

### DIFF
--- a/gsl_demarches_simplifiees/tests/factories.py
+++ b/gsl_demarches_simplifiees/tests/factories.py
@@ -5,8 +5,16 @@ import factory.fuzzy
 from django.db.models.signals import post_save
 
 from gsl_core.tests.factories import AdresseFactory
+from gsl_core.tests.factories import ArrondissementFactory as CoreArrondissementFactory
 
-from ..models import Demarche, Dossier, NaturePorteurProjet, PersonneMorale
+from ..models import Arrondissement as DsArrondissement
+from ..models import (
+    Demarche,
+    Dossier,
+    DsChoiceLibelle,
+    NaturePorteurProjet,
+    PersonneMorale,
+)
 
 
 class DemarcheFactory(factory.django.DjangoModelFactory):
@@ -28,6 +36,20 @@ class PersonneMoraleFactory(factory.django.DjangoModelFactory):
     address = factory.SubFactory(AdresseFactory)
 
 
+class DsLibelleFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = DsChoiceLibelle
+
+    label = factory.Sequence(lambda n: f"dslibelle-{n}")
+
+
+class DsArrondissementFactory(DsLibelleFactory):
+    class Meta:
+        model = DsArrondissement
+
+    core_arrondissement = factory.SubFactory(CoreArrondissementFactory)
+
+
 class NaturePorteurProjetFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = NaturePorteurProjet
@@ -45,6 +67,7 @@ class DossierFactory(factory.django.DjangoModelFactory):
     ds_number = factory.Faker("random_int", min=1000000, max=9999999)
     ds_state = Dossier.STATE_EN_INSTRUCTION
     ds_demandeur = factory.SubFactory(PersonneMoraleFactory)
+    porteur_de_projet_arrondissement = factory.SubFactory(DsArrondissementFactory)
     ds_date_depot = factory.Faker(
         "date_time_this_year", before_now=True, tzinfo=timezone.utc
     )

--- a/gsl_demarches_simplifiees/tests/test_factories.py
+++ b/gsl_demarches_simplifiees/tests/test_factories.py
@@ -1,12 +1,18 @@
 import pytest
 
 from gsl_demarches_simplifiees.models import (
+    Arrondissement,
     Demarche,
     Dossier,
     NaturePorteurProjet,
 )
 
-from .factories import DemarcheFactory, DossierFactory, NaturePorteurProjetFactory
+from .factories import (
+    DemarcheFactory,
+    DossierFactory,
+    DsArrondissementFactory,
+    NaturePorteurProjetFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -14,6 +20,7 @@ test_data = (
     (DemarcheFactory, Demarche),
     (DossierFactory, Dossier),
     (NaturePorteurProjetFactory, NaturePorteurProjet),
+    (DsArrondissementFactory, Arrondissement),
 )
 
 

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -8,6 +8,7 @@ from .models import Demandeur, Projet
 @admin.register(Demandeur)
 class DemandeurAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     raw_id_fields = ("address", "arrondissement", "departement")
+    list_display = ("name", "departement", "arrondissement")
 
 
 @admin.register(Projet)

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -13,14 +13,24 @@ class DemandeurAdmin(AllPermsForStaffUser, admin.ModelAdmin):
 
 @admin.register(Projet)
 class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
-    raw_id_fields = ("address", "departement", "demandeur", "dossier_ds")
-    list_display = ("__str__", "dossier_ds__ds_state", "address", "departement")
-    list_filter = ("departement", "dossier_ds__ds_state")
+    raw_id_fields = ("address", "demandeur", "dossier_ds")
+    list_display = (
+        "__str__",
+        "dossier_ds__ds_state",
+        "demandeur__departement",
+        "demandeur__arrondissement",
+    )
+    list_filter = ("demandeur__departement", "dossier_ds__ds_state")
     actions = ("refresh_from_dossier",)
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        qs = qs.select_related("address").select_related("departement")
+        qs = (
+            qs.select_related("address")
+            .select_related("demandeur")
+            .select_related("demandeur__departement")
+            .select_related("demandeur__arrondissement")
+        )
         return qs
 
     @admin.action(description="Rafraîchir depuis le dossier DS")

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -16,8 +16,16 @@ class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     raw_id_fields = ("address", "departement", "demandeur", "dossier_ds")
     list_display = ("__str__", "dossier_ds__ds_state", "address", "departement")
     list_filter = ("departement", "dossier_ds__ds_state")
+    actions = ("refresh_from_dossier",)
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         qs = qs.select_related("address").select_related("departement")
         return qs
+
+    @admin.action(description="Rafraîchir depuis le dossier DS")
+    def refresh_from_dossier(self, request, queryset):
+        from gsl_projet.tasks import update_projet_from_dossier
+
+        for projet in queryset.select_related("dossier_ds"):
+            update_projet_from_dossier.delay(projet.dossier_ds.ds_number)

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -122,7 +122,6 @@ class Projet(models.Model):
     demandeur = models.ForeignKey(Demandeur, on_delete=models.PROTECT, null=True)
 
     address = models.ForeignKey(Adresse, on_delete=models.PROTECT, null=True)
-    departement = models.ForeignKey(Departement, on_delete=models.PROTECT, null=True)
 
     assiette = models.DecimalField(
         "Assiette subventionnable",

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -157,24 +157,27 @@ class Projet(models.Model):
                 dossier_ds=ds_dossier,
             )
         projet.address = ds_dossier.projet_adresse
+
+        projet_departement = (
+            ds_dossier.ds_demandeur.address.commune.departement
+            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement.departement
+        )
+        projet_arrondissement = (
+            ds_dossier.ds_demandeur.address.commune.arrondissement
+            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement
+        )
         projet.demandeur, _ = Demandeur.objects.get_or_create(
             siret=ds_dossier.ds_demandeur.siret,
             defaults={
                 "name": ds_dossier.ds_demandeur.raison_sociale,
                 "address": ds_dossier.ds_demandeur.address,
-                "departement": ds_dossier.ds_demandeur.address.commune.departement
-                or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement.departement,
+                "departement": projet_departement,
+                "arrondissement": projet_arrondissement,
             },
         )
 
-        projet.demandeur.departement = (
-            ds_dossier.ds_demandeur.address.commune.departement
-            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement.departement
-        )
-        projet.demandeur.arrondissement = (
-            ds_dossier.ds_demandeur.address.commune.arrondissement
-            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement
-        )
+        projet.demandeur.arrondissement = projet_arrondissement
+        projet.demandeur.departement = projet_departement
         projet.demandeur.save()
 
         if projet.address is not None and projet.address.commune is not None:

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -163,6 +163,7 @@ class Projet(models.Model):
                 "name": ds_dossier.ds_demandeur.raison_sociale,
                 "address": ds_dossier.ds_demandeur.address,
                 "departement": ds_dossier.ds_demandeur.address.commune.departement,
+                "arrondissement": ds_dossier.porteur_de_projet_arrondissement.core_arrondissement,
             },
         )
         if projet.address is not None and projet.address.commune is not None:

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -162,10 +162,21 @@ class Projet(models.Model):
             defaults={
                 "name": ds_dossier.ds_demandeur.raison_sociale,
                 "address": ds_dossier.ds_demandeur.address,
-                "departement": ds_dossier.ds_demandeur.address.commune.departement,
-                "arrondissement": ds_dossier.porteur_de_projet_arrondissement.core_arrondissement,
+                "departement": ds_dossier.ds_demandeur.address.commune.departement
+                or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement.departement,
             },
         )
+
+        projet.demandeur.departement = (
+            ds_dossier.ds_demandeur.address.commune.departement
+            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement.departement
+        )
+        projet.demandeur.arrondissement = (
+            ds_dossier.ds_demandeur.address.commune.arrondissement
+            or ds_dossier.porteur_de_projet_arrondissement.core_arrondissement
+        )
+        projet.demandeur.save()
+
         if projet.address is not None and projet.address.commune is not None:
             projet.departement = projet.address.commune.departement
 

--- a/gsl_projet/tests/test_model_projet.py
+++ b/gsl_projet/tests/test_model_projet.py
@@ -4,7 +4,7 @@ from datetime import timezone as tz
 import pytest
 from django.db import connection
 
-from gsl_core.models import Departement
+from gsl_core.models import Arrondissement, Departement
 from gsl_core.tests.factories import (
     AdresseFactory,
     ArrondissementFactory,
@@ -59,10 +59,7 @@ def test_create_projet_from_dossier():
     assert projet.address == dossier.projet_adresse
 
     assert projet.demandeur is not None
-    assert (
-        projet.demandeur.arrondissement
-        == dossier.porteur_de_projet_arrondissement.core_arrondissement
-    )
+    assert isinstance(projet.demandeur.arrondissement, Arrondissement)
     other_projet = Projet.get_or_create_from_ds_dossier(dossier)
     assert other_projet == projet
 

--- a/gsl_projet/tests/test_model_projet.py
+++ b/gsl_projet/tests/test_model_projet.py
@@ -58,6 +58,11 @@ def test_create_projet_from_dossier():
     assert projet.address.commune == dossier.projet_adresse.commune
     assert projet.address == dossier.projet_adresse
 
+    assert projet.demandeur is not None
+    assert (
+        projet.demandeur.arrondissement
+        == dossier.porteur_de_projet_arrondissement.core_arrondissement
+    )
     other_projet = Projet.get_or_create_from_ds_dossier(dossier)
     assert other_projet == projet
 


### PR DESCRIPTION
## 🌮 Objectif

Faciliter la lecture du code et éviter de stocker trop d'informations redondantes : les champs `departement` et `address` sont inutilisés sur Projet

## 🔍 Liste des modifications

- _Liste des modifications_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
