### PR TITLE
Correctifs sur les filtres de la page projet

### DIFF
--- a/gsl_demarches_simplifiees/tests/factories.py
+++ b/gsl_demarches_simplifiees/tests/factories.py
@@ -14,7 +14,7 @@ class DemarcheFactory(factory.django.DjangoModelFactory):
         model = Demarche
 
     ds_id = factory.Sequence(lambda n: f"demarche-{n}")
-    ds_number = factory.Faker("random_int", min=1000000, max=9999999)
+    ds_number = factory.Sequence(lambda n: 1_000_000 + n)
     ds_title = "Titre de la démarche"
     ds_state = Demarche.STATE_PUBLIEE
 

--- a/gsl_demarches_simplifiees/tests/test_factories.py
+++ b/gsl_demarches_simplifiees/tests/test_factories.py
@@ -4,9 +4,15 @@ from gsl_demarches_simplifiees.models import (
     Demarche,
     Dossier,
     NaturePorteurProjet,
+    PersonneMorale,
 )
 
-from .factories import DemarcheFactory, DossierFactory, NaturePorteurProjetFactory
+from .factories import (
+    DemarcheFactory,
+    DossierFactory,
+    NaturePorteurProjetFactory,
+    PersonneMoraleFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -14,6 +20,7 @@ test_data = (
     (DemarcheFactory, Demarche),
     (DossierFactory, Dossier),
     (NaturePorteurProjetFactory, NaturePorteurProjet),
+    (PersonneMoraleFactory, PersonneMorale),
 )
 
 

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -24,6 +24,7 @@ class ProjetFilters(FilterSet):
             }
         ),
         empty_label="Toutes les dotations",
+        lookup_expr="contains",
     )
 
     porteur = ChoiceFilter(

--- a/gsl_projet/utils/utils.py
+++ b/gsl_projet/utils/utils.py
@@ -1,5 +1,5 @@
 def order_couples_tuple_by_first_value(
-    choices: tuple[tuple[str, str]], ordered_first_values: list[str]
+    choices: tuple[tuple[str, str], ...], ordered_first_values: tuple[str, ...]
 ):
     order_dict = {status: index for index, status in enumerate(ordered_first_values)}
     return sorted(

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -79,6 +79,15 @@ def get_projet(request, projet_id):
 
 
 class ProjetListViewFilters(ProjetFilters):
+    filterset = (
+        "dotation",
+        "porteur",
+        "status",
+        "cout_total",
+        "montant_demande",
+        "montant_retenu",
+    )
+
     @property
     def qs(self):
         qs = super().qs

--- a/gsl_simulation/tasks.py
+++ b/gsl_simulation/tasks.py
@@ -20,7 +20,7 @@ def add_enveloppe_projets_to_simulation(simulation_id):
     simulation_dotation = simulation.enveloppe.type
     # todo later: "simulation par arrondissement"
     selected_projets = Projet.objects.for_perimetre(simulation_perimetre).filter(
-        dossier_ds__demande_dispositif_sollicite=simulation_dotation
+        dossier_ds__demande_dispositif_sollicite__contains=simulation_dotation
     )
     selected_projets = selected_projets.for_current_year()
 

--- a/gsl_simulation/tests/test_tasks.py
+++ b/gsl_simulation/tests/test_tasks.py
@@ -226,3 +226,69 @@ def test_add_enveloppe_projets_to_dsil_simulation(
     assert simulation_projet.montant == 2_500
     assert simulation_projet.taux == 0
     assert simulation_projet.enveloppe.type == "DSIL"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "demande_dispositif_sollicite, count",
+    (
+        ("DETR", 1),
+        ("['DETR']", 1),
+        ("['DETR', 'DSIL']", 1),
+        ("['DETR et DSIL']", 1),
+        ("DETR et DSIL", 1),
+        ("['DETR', 'DSIL', 'DETR et DSIL']", 1),
+        ("['DETR', 'DETR et DSIL']", 1),
+        ("['', 'DETR', '', 'DETR et DSIL']", 1),
+        ("['DSIL', 'DETR et DSIL']", 1),
+        ("DSIL", 0),
+        ("['DSIL']", 0),
+    ),
+)
+def test_add_enveloppe_projets_to_DETR_simulation_containing_DETR_in_demande_dispositif_sollicite(
+    detr_simulation, departement_perimetre, demande_dispositif_sollicite, count
+):
+    demandeur = DemandeurFactory(
+        departement=departement_perimetre.departement,
+    )
+    ProjetFactory(
+        dossier_ds__demande_dispositif_sollicite=demande_dispositif_sollicite,
+        demandeur=demandeur,
+    )
+
+    add_enveloppe_projets_to_simulation(detr_simulation.id)
+
+    assert SimulationProjet.objects.count() == count
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "demande_dispositif_sollicite, count",
+    (
+        ("DETR", 0),
+        ("['DETR']", 0),
+        ("['DETR', 'DSIL']", 1),
+        ("['DETR et DSIL']", 1),
+        ("DETR et DSIL", 1),
+        ("['DETR', 'DSIL', 'DETR et DSIL']", 1),
+        ("['DETR', 'DETR et DSIL']", 1),
+        ("['', 'DETR', '', 'DETR et DSIL']", 1),
+        ("['DSIL', 'DETR et DSIL']", 1),
+        ("DSIL", 1),
+        ("['DSIL']", 1),
+    ),
+)
+def test_add_enveloppe_projets_to_DSIL_simulation_containing_DSIL_in_demande_dispositif_sollicite(
+    dsil_simulation, departement_perimetre, demande_dispositif_sollicite, count
+):
+    demandeur = DemandeurFactory(
+        departement=departement_perimetre.departement,
+    )
+    ProjetFactory(
+        dossier_ds__demande_dispositif_sollicite=demande_dispositif_sollicite,
+        demandeur=demandeur,
+    )
+
+    add_enveloppe_projets_to_simulation(dsil_simulation.id)
+
+    assert SimulationProjet.objects.count() == count


### PR DESCRIPTION
## 🌮 Objectif

- Supprimer le filtre en trop (montant prévisionnel accordé).
- Faire fonctionner le filtre DETR/DSIL même pour les valeurs exotiques provenant de DS.

## ⚠️ Informations supplémentaires

- Modification d'une factory qui avait posé un problème d'unicité