### PR TITLE
Ajout d'infos dans l'admin pour les correspondances techniques DS

### DIFF
--- a/gsl_demarches_simplifiees/admin.py
+++ b/gsl_demarches_simplifiees/admin.py
@@ -182,9 +182,17 @@ class FieldMappingForComputerAdmin(
         for field in FieldMappingForComputer._meta.get_fields()
         if field.name != "django_field"
     ]
-    list_display = ("ds_field_id", "ds_field_label", "django_field", "demarche")
+    list_display = (
+        "ds_field_id",
+        "ds_field_label",
+        "ds_field_type",
+        "django_field",
+        "demarche",
+    )
     list_filter = ("demarche__ds_number", "ds_field_type")
     resource_classes = (FieldMappingForComputerResource,)
+    search_fields = ("ds_field_label", "django_field", "ds_field_id")
+    search_help_text = "Chercher par ID ou intitulé DS, ou par champ Django"
 
 
 @admin.register(Profile)


### PR DESCRIPTION
## 🌮 Objectif

J'ai voulu jeter un coup d'œil aux métadonnées DS (les correspondances champs DS/champs Django), j'ai ajouté dans l'interface les quelques infos qui m'intéressaient.

- Possibilité de chercher/filtrer par ID et libellé
- Ajout du type de champ DS

## 🖼️ Images

![Capture d’écran 2025-02-18 à 10 32 27](https://github.com/user-attachments/assets/bdbc2305-08c6-4ab3-8ea2-a882e728dda6)

