### PR TITLE
Ajout des restrictions de visibilité sur les projets et les simulations

### DIFF
--- a/gsl_core/tests/factories.py
+++ b/gsl_core/tests/factories.py
@@ -110,3 +110,10 @@ class ClientWithLoggedUserFactory(Client):
     def __init__(self, user, **kwargs):
         super().__init__(**kwargs)
         self.force_login(user)
+
+
+class ClientWithLoggedStaffUserFactory(Client):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        user = CollegueFactory(is_staff=True)
+        self.force_login(user)

--- a/gsl_core/tests/test_factories.py
+++ b/gsl_core/tests/test_factories.py
@@ -13,6 +13,7 @@ from ..models import (
 from .factories import (
     AdresseFactory,
     ArrondissementFactory,
+    ClientWithLoggedStaffUserFactory,
     ClientWithLoggedUserFactory,
     CollegueFactory,
     CommuneFactory,
@@ -45,4 +46,10 @@ def test_client_factory():
     user = CollegueFactory()
     for _ in range(2):
         obj = ClientWithLoggedUserFactory(user)
+        assert isinstance(obj, Client)
+
+
+def test_staff_client_factory():
+    for _ in range(2):
+        obj = ClientWithLoggedStaffUserFactory()
         assert isinstance(obj, Client)

--- a/gsl_projet/tests/test_urls.py
+++ b/gsl_projet/tests/test_urls.py
@@ -1,0 +1,82 @@
+import pytest
+from django.urls import reverse
+
+from gsl_core.tests.factories import (
+    ClientWithLoggedStaffUserFactory,
+    ClientWithLoggedUserFactory,
+    CollegueFactory,
+    PerimetreDepartementalFactory,
+)
+from gsl_projet.tests.factories import ProjetFactory
+
+
+@pytest.fixture
+def perimetre_departement_55():
+    return PerimetreDepartementalFactory()
+
+
+@pytest.fixture
+def perimetre_departement_88():
+    return PerimetreDepartementalFactory()
+
+
+@pytest.fixture
+def client_with_55_user_logged(perimetre_departement_55):
+    user = CollegueFactory(perimetre=perimetre_departement_55)
+    return ClientWithLoggedUserFactory(user)
+
+
+@pytest.mark.django_db
+def test_list(client_with_55_user_logged):
+    url = reverse("projet:list")
+    response = client_with_55_user_logged.get(url, follow=True)
+    assert response.status_code == 200
+
+
+@pytest.fixture
+def projets_from_55(perimetre_departement_55):
+    return ProjetFactory.create_batch(3, perimetre=perimetre_departement_55)
+
+
+@pytest.fixture
+def projets_from_88(perimetre_departement_88):
+    return ProjetFactory.create_batch(5, perimetre=perimetre_departement_88)
+
+
+@pytest.mark.django_db
+def test_list_with_only_visible_projets_for_user(
+    client_with_55_user_logged, projets_from_55, projets_from_88
+):
+    url = reverse("projet:list")
+    response = client_with_55_user_logged.get(url, follow=True)
+    assert response.status_code == 200
+    assert response.context["object_list"].count() == 3
+
+
+@pytest.mark.django_db
+def test_projet_detail_visible_by_user_with_correct_perimetre(
+    client_with_55_user_logged, projets_from_55
+):
+    projet = projets_from_55[0]
+    url = reverse("projet:get-projet", args=[projet.id])
+    response = client_with_55_user_logged.get(url, follow=True)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_projet_detail_not_visible_by_user_with_incorrect_perimetre(
+    client_with_55_user_logged, projets_from_88
+):
+    projet = projets_from_88[0]
+    url = reverse("projet:get-projet", args=[projet.id])
+    response = client_with_55_user_logged.get(url, follow=True)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_projet_detail_visible_by_staff(projets_from_88):
+    client_with_staff_user = ClientWithLoggedStaffUserFactory()
+    projet = projets_from_88[0]
+    url = reverse("projet:get-projet", args=[projet.id])
+    response = client_with_staff_user.get(url, follow=True)
+    assert response.status_code == 200

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 
-from gsl_core.models import Perimetre
 from gsl_projet.models import Projet
 from gsl_projet.services import ProjetService
 from gsl_simulation.models import Simulation, SimulationProjet
@@ -115,19 +114,3 @@ class SimulationProjetService:
             pk=simulation_projet.pk
         )
         return updated_simulation_projet
-
-    @classmethod
-    def is_simulation_projet_in_perimetre(
-        cls, simulation_projet: SimulationProjet, perimetre: Perimetre
-    ):
-        simulation_projet_perimetre = simulation_projet.projet.perimetre
-        if perimetre.arrondissement is not None:
-            return (
-                perimetre.arrondissement_id
-                == simulation_projet_perimetre.arrondissement_id
-            )
-        if perimetre.departement is not None:
-            return (
-                perimetre.departement_id == simulation_projet_perimetre.departement_id
-            )
-        return perimetre.region_id == simulation_projet_perimetre.departement.region_id

--- a/gsl_simulation/tests/services/test_simulation_projet_services.py
+++ b/gsl_simulation/tests/services/test_simulation_projet_services.py
@@ -2,11 +2,6 @@ from unittest import mock
 
 import pytest
 
-from gsl_core.tests.factories import (
-    PerimetreArrondissementFactory,
-    PerimetreDepartementalFactory,
-    PerimetreRegionalFactory,
-)
 from gsl_programmation.models import ProgrammationProjet
 from gsl_programmation.tests.factories import (
     DetrEnveloppeFactory,
@@ -278,7 +273,7 @@ def test_update_montant(projet):
 
 
 @pytest.mark.django_db
-def test_update_montant_of_accepted_montat(projet):
+def test_update_montant_of_accepted_montant(projet):
     simulation_projet = SimulationProjetFactory(
         projet=projet, status=SimulationProjet.STATUS_ACCEPTED, montant=1_000
     )
@@ -309,99 +304,3 @@ def test_update_montant_of_accepted_montat(projet):
     programmation_projet.refresh_from_db()
     assert programmation_projet.montant == 500.0
     assert programmation_projet.taux == 50.0
-
-
-@pytest.mark.django_db
-def test_is_simulation_projet_in_perimetre_regional():
-    perimetre_arrondissement = PerimetreArrondissementFactory()
-    perimetre_regional = PerimetreRegionalFactory(
-        region=perimetre_arrondissement.region
-    )
-    projet = ProjetFactory(perimetre=perimetre_arrondissement)
-    simulation_projet = SimulationProjetFactory(projet=projet)
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            simulation_projet, perimetre_regional
-        )
-        is True
-    )
-
-    other_arrondissement_perimetre = PerimetreArrondissementFactory()
-    other_projet = ProjetFactory(perimetre=other_arrondissement_perimetre)
-    other_simulation_projet = SimulationProjetFactory(projet=other_projet)
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            other_simulation_projet, perimetre_regional
-        )
-        is False
-    )
-
-
-@pytest.mark.django_db
-def test_is_simulation_projet_in_perimetre_departemental():
-    perimetre_arrondissement = PerimetreArrondissementFactory()
-    perimetre_departemental = PerimetreDepartementalFactory(
-        departement=perimetre_arrondissement.departement
-    )
-    projet = ProjetFactory(perimetre=perimetre_arrondissement)
-    simulation_projet = SimulationProjetFactory(projet=projet)
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            simulation_projet, perimetre_departemental
-        )
-        is True
-    )
-
-    other_arrondissement = PerimetreArrondissementFactory()
-    other_projet = ProjetFactory(perimetre=other_arrondissement)
-    other_simulation_projet = SimulationProjetFactory(projet=other_projet)
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            other_simulation_projet, perimetre_departemental
-        )
-        is False
-    )
-
-
-@pytest.mark.django_db
-def test_is_simulation_projet_in_perimetre_arrondissement():
-    perimetre_arrondissement = PerimetreArrondissementFactory()
-    projet = ProjetFactory(perimetre=perimetre_arrondissement)
-    simulation_projet = SimulationProjetFactory(projet=projet)
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            simulation_projet, perimetre_arrondissement
-        )
-        is True
-    )
-
-    other_arrondissement_perimetre = PerimetreArrondissementFactory()
-    other_projet = ProjetFactory(perimetre=other_arrondissement_perimetre)
-    other_simulation_projet = SimulationProjetFactory(projet=other_projet)
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            other_simulation_projet, perimetre_arrondissement
-        )
-        is False
-    )
-
-
-@pytest.mark.parametrize(
-    "projet_status, simulation_projet_status_expected",
-    (
-        (Projet.STATUS_ACCEPTED, SimulationProjet.STATUS_ACCEPTED),
-        (Projet.STATUS_REFUSED, SimulationProjet.STATUS_REFUSED),
-        (Projet.STATUS_PROCESSING, SimulationProjet.STATUS_PROCESSING),
-        (Projet.STATUS_UNANSWERED, SimulationProjet.STATUS_REFUSED),
-    ),
-)
-def test_get_simulation_projet_status(projet_status, simulation_projet_status_expected):
-    projet = ProjetFactory.build(status=projet_status)
-    status = SimulationProjetService.get_simulation_projet_status(projet)
-    assert status == simulation_projet_status_expected

--- a/gsl_simulation/tests/services/test_simulation_services.py
+++ b/gsl_simulation/tests/services/test_simulation_services.py
@@ -17,9 +17,8 @@ from gsl_simulation.models import Simulation
 from gsl_simulation.services.simulation_service import SimulationService
 from gsl_simulation.tests.factories import SimulationFactory
 
-pytestmark = pytest.mark.django_db
 
-
+@pytest.mark.django_db
 def test_user_with_department_and_ask_for_dsil_simulation():
     perimetre_departemental = PerimetreDepartementalFactory()
     perimetre_regional = PerimetreRegionalFactory(region=perimetre_departemental.region)
@@ -41,6 +40,7 @@ def test_user_with_department_and_ask_for_dsil_simulation():
     assert simulation.slug == "test"
 
 
+@pytest.mark.django_db
 def test_empty_enveloppe_is_created_if_needed():
     perimetre_departemental = PerimetreDepartementalFactory()
     user = CollegueFactory(perimetre=perimetre_departemental)
@@ -52,6 +52,7 @@ def test_empty_enveloppe_is_created_if_needed():
     assert simulation.enveloppe.type == Enveloppe.TYPE_DETR
 
 
+@pytest.mark.django_db
 def test_user_with_department_and_ask_for_detr_simulation():
     perimetre_departemental = PerimetreDepartementalFactory()
     user = CollegueFactory(perimetre=perimetre_departemental)
@@ -67,6 +68,7 @@ def test_user_with_department_and_ask_for_detr_simulation():
     assert simulation.slug == "test-aussi-le-slug"
 
 
+@pytest.mark.django_db
 def test_user_without_department_and_ask_for_detr_simulation():
     perimetre_regional = PerimetreRegionalFactory()
     user = CollegueFactory(perimetre=perimetre_regional)
@@ -76,6 +78,7 @@ def test_user_without_department_and_ask_for_detr_simulation():
         SimulationService.create_simulation(user, "test", "DETR")
 
 
+@pytest.mark.django_db
 def test_user_with_region_and_ask_for_dsil_simulation():
     perimetre_regional = PerimetreRegionalFactory()
     user = CollegueFactory(perimetre=perimetre_regional)
@@ -87,6 +90,7 @@ def test_user_with_region_and_ask_for_dsil_simulation():
     assert simulation.slug == "test-avec-ce-titre"
 
 
+@pytest.mark.django_db
 def test_user_with_arrondissement_and_ask_for_dsil_simulation():
     perimetre_arrondissement = PerimetreArrondissementFactory()
     user = CollegueFactory(perimetre=perimetre_arrondissement)
@@ -101,6 +105,7 @@ def test_user_with_arrondissement_and_ask_for_dsil_simulation():
     assert simulation.slug == "test-avec-ces-caracteres"
 
 
+@pytest.mark.django_db
 def test_slug_generation():
     SimulationFactory(slug="test")
     SimulationFactory(slug="test-2")

--- a/gsl_simulation/tests/test_urls.py
+++ b/gsl_simulation/tests/test_urls.py
@@ -9,8 +9,9 @@ from gsl_core.tests.factories import (
     CollegueFactory,
     DepartementFactory,
     PerimetreDepartementalFactory,
+    PerimetreRegionalFactory,
 )
-from gsl_programmation.tests.factories import DetrEnveloppeFactory
+from gsl_programmation.tests.factories import DetrEnveloppeFactory, DsilEnveloppeFactory
 from gsl_projet.tests.factories import ProjetFactory
 from gsl_simulation.models import SimulationProjet
 from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
@@ -321,6 +322,87 @@ def test_cant_patch_projet_only_if_projet_is_not_included_in_user_perimetre(
     )
     response = client_with_iconnais_user_logged.patch(url, data="status=valid")
     assert response.status_code == 404
+
+
+@pytest.fixture
+def perimetre_bourgogne(cote_d_or):
+    return PerimetreRegionalFactory(region=cote_d_or.region)
+
+
+@pytest.fixture
+def client_with_bourguignon_user_logged(perimetre_bourgogne):
+    bourguignon_collegue = CollegueFactory(perimetre=perimetre_bourgogne)
+    return ClientWithLoggedUserFactory(bourguignon_collegue)
+
+
+@pytest.mark.django_db
+def test_regional_user_cant_patch_projet_if_simulation_projet_is_associated_to_detr_enveloppe(
+    client_with_bourguignon_user_logged, cote_dorien_simulation_projet
+):
+    url = reverse(
+        "simulation:patch-simulation-projet-taux",
+        kwargs={"pk": cote_dorien_simulation_projet.pk},
+    )
+    response = client_with_bourguignon_user_logged.patch(url, data="taux=0.5")
+    assert response.status_code == 404
+
+    url = reverse(
+        "simulation:patch-simulation-projet-montant",
+        kwargs={"pk": cote_dorien_simulation_projet.pk},
+    )
+    response = client_with_bourguignon_user_logged.patch(url, data="montant=400")
+    assert response.status_code == 404
+
+    url = reverse(
+        "simulation:patch-simulation-projet-status",
+        kwargs={"pk": cote_dorien_simulation_projet.pk},
+    )
+    response = client_with_bourguignon_user_logged.patch(url, data="status=valid")
+    assert response.status_code == 404
+
+
+@pytest.fixture
+def cote_dorien_dsil_simulation_projet(cote_d_or_perimetre):
+    projet = ProjetFactory(perimetre=cote_d_or_perimetre)
+    simulation = SimulationFactory(
+        enveloppe=DsilEnveloppeFactory(perimetre=cote_d_or_perimetre)
+    )
+    return SimulationProjetFactory(
+        projet=projet,
+        simulation=simulation,
+    )
+
+
+@pytest.mark.django_db
+def test_regional_user_can_patch_projet_if_simulation_projet_is_associated_to_dsil_enveloppe_and_in_its_perimetre(
+    client_with_bourguignon_user_logged, cote_dorien_dsil_simulation_projet
+):
+    url = reverse(
+        "simulation:patch-simulation-projet-taux",
+        kwargs={"pk": cote_dorien_dsil_simulation_projet.pk},
+    )
+    response = client_with_bourguignon_user_logged.patch(
+        url, data="taux=0.5", follow=True
+    )
+    assert response.status_code == 200
+
+    url = reverse(
+        "simulation:patch-simulation-projet-montant",
+        kwargs={"pk": cote_dorien_dsil_simulation_projet.pk},
+    )
+    response = client_with_bourguignon_user_logged.patch(
+        url, data="montant=400", follow=True
+    )
+    assert response.status_code == 200
+
+    url = reverse(
+        "simulation:patch-simulation-projet-status",
+        kwargs={"pk": cote_dorien_dsil_simulation_projet.pk},
+    )
+    response = client_with_bourguignon_user_logged.patch(
+        url, data="status=valid", follow=True
+    )
+    assert response.status_code == 200
 
 
 @pytest.fixture

--- a/gsl_simulation/tests/test_urls.py
+++ b/gsl_simulation/tests/test_urls.py
@@ -10,6 +10,7 @@ from gsl_core.tests.factories import (
     DepartementFactory,
     PerimetreDepartementalFactory,
 )
+from gsl_programmation.tests.factories import DetrEnveloppeFactory
 from gsl_projet.tests.factories import ProjetFactory
 from gsl_simulation.models import SimulationProjet
 from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
@@ -28,12 +29,36 @@ def test_simulation_list_url(client_with_user_logged):
     assert response.status_code == 200
 
 
+@pytest.fixture
+def enveloppe_departemental():
+    return DetrEnveloppeFactory()
+
+
+@pytest.fixture
+def client_with_same_departement_perimetre(enveloppe_departemental):
+    collegue = CollegueFactory(perimetre=enveloppe_departemental.perimetre)
+    return ClientWithLoggedUserFactory(collegue)
+
+
 @pytest.mark.django_db
-def test_simulation_detail_url(client_with_user_logged):
-    SimulationFactory(slug="test-slug")
+def test_simulation_detail_url_with_not_authorized_user(
+    client_with_user_logged, enveloppe_departemental
+):
+    SimulationFactory(slug="test-slug", enveloppe=enveloppe_departemental)
 
     url = reverse("simulation:simulation-detail", kwargs={"slug": "test-slug"})
     response = client_with_user_logged.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_simulation_detail_url_for_user_with_correct_perimetre(
+    client_with_same_departement_perimetre, enveloppe_departemental
+):
+    SimulationFactory(slug="test-slug", enveloppe=enveloppe_departemental)
+
+    url = reverse("simulation:simulation-detail", kwargs={"slug": "test-slug"})
+    response = client_with_same_departement_perimetre.get(url)
     assert response.status_code == 200
 
 
@@ -56,8 +81,15 @@ def client_with_cote_d_or_user_logged(cote_d_or_perimetre):
 @pytest.fixture
 def cote_dorien_simulation_projet(cote_d_or_perimetre):
     projet = ProjetFactory(perimetre=cote_d_or_perimetre)
+    simulation = SimulationFactory(
+        enveloppe=DetrEnveloppeFactory(perimetre=cote_d_or_perimetre)
+    )
     return SimulationProjetFactory(
-        projet=projet, status=SimulationProjet.STATUS_PROVISOIRE, taux=0, montant=0
+        projet=projet,
+        simulation=simulation,
+        status=SimulationProjet.STATUS_PROVISOIRE,
+        taux=0,
+        montant=0,
     )
 
 

--- a/gsl_simulation/tests/test_views.py
+++ b/gsl_simulation/tests/test_views.py
@@ -59,11 +59,15 @@ def simulations(perimetre_departemental):
 
 
 @pytest.fixture
-def simulation(perimetre_departemental):
-    enveloppe = DetrEnveloppeFactory(
+def detr_enveloppe(perimetre_departemental):
+    return DetrEnveloppeFactory(
         perimetre=perimetre_departemental, annee=2024, montant=1_000_000
     )
-    return SimulationFactory(enveloppe=enveloppe)
+
+
+@pytest.fixture
+def simulation(detr_enveloppe):
+    return SimulationFactory(enveloppe=detr_enveloppe)
 
 
 @pytest.fixture
@@ -496,7 +500,7 @@ def client_with_user_logged(collegue):
 
 
 @pytest.fixture
-def simulation_projet(collegue) -> SimulationProjet:
+def simulation_projet(collegue, detr_enveloppe) -> SimulationProjet:
     return SimulationProjetFactory(
         projet=ProjetFactory(
             status=Projet.STATUS_PROCESSING,
@@ -504,6 +508,7 @@ def simulation_projet(collegue) -> SimulationProjet:
         ),
         status=SimulationProjet.STATUS_PROCESSING,
         montant=1000,
+        simulation__enveloppe=detr_enveloppe,
     )
 
 
@@ -557,7 +562,7 @@ def test_patch_status_simulation_projet_invalid_status(
 
 
 @pytest.fixture
-def accepted_simulation_projet(collegue) -> SimulationProjet:
+def accepted_simulation_projet(collegue, detr_enveloppe) -> SimulationProjet:
     return SimulationProjetFactory(
         projet=ProjetFactory(
             status=Projet.STATUS_PROCESSING,
@@ -567,6 +572,7 @@ def accepted_simulation_projet(collegue) -> SimulationProjet:
         status=SimulationProjet.STATUS_ACCEPTED,
         montant=1000,
         taux=0.5,
+        simulation__enveloppe=detr_enveloppe,
     )
 
 

--- a/gsl_simulation/tests/test_views.py
+++ b/gsl_simulation/tests/test_views.py
@@ -26,7 +26,7 @@ from gsl_projet.tests.factories import DemandeurFactory, ProjetFactory
 from gsl_simulation.models import SimulationProjet
 from gsl_simulation.tasks import add_enveloppe_projets_to_simulation
 from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
-from gsl_simulation.views import (
+from gsl_simulation.views.simulation_views import (
     SimulationDetailView,
     SimulationListView,
 )

--- a/gsl_simulation/tests/views/test_enveloppe_data.py
+++ b/gsl_simulation/tests/views/test_enveloppe_data.py
@@ -13,7 +13,7 @@ from gsl_programmation.tests.factories import (
 from gsl_projet.models import Projet
 from gsl_projet.tests.factories import SubmittedProjetFactory
 from gsl_simulation.tests.factories import SimulationFactory
-from gsl_simulation.views import SimulationDetailView
+from gsl_simulation.views.simulation_views import SimulationDetailView
 
 
 @pytest.fixture

--- a/gsl_simulation/urls.py
+++ b/gsl_simulation/urls.py
@@ -1,36 +1,44 @@
 from django.urls import path
 
-from . import views
+from gsl_simulation.views import simulation_views
+from gsl_simulation.views.decorators import simulation_must_be_visible_by_user
+from gsl_simulation.views.simulation_projet_views import (
+    patch_montant_simulation_projet,
+    patch_status_simulation_projet,
+    patch_taux_simulation_projet,
+)
 
 urlpatterns = [
     path(
         "simulations/",
-        views.SimulationListView.as_view(),
+        simulation_views.SimulationListView.as_view(),
         name="simulation-list",
     ),
     path(
         "simulation/<slug:slug>/",
-        views.simulation_must_be_visible_by_user(views.SimulationDetailView.as_view()),
+        simulation_must_be_visible_by_user(
+            simulation_views.SimulationDetailView.as_view()
+        ),
         name="simulation-detail",
     ),
     path(
         "modifier-le-taux-d-un-projet-de-simulation/<int:pk>/",
-        views.patch_taux_simulation_projet,
+        patch_taux_simulation_projet,
         name="patch-simulation-projet-taux",
     ),
     path(
         "modifier-le-montant-un-projet-de-simulation/<int:pk>/",
-        views.patch_montant_simulation_projet,
+        patch_montant_simulation_projet,
         name="patch-simulation-projet-montant",
     ),
     path(
         "modifier-le-statut-d-un-projet-de-simulation/<int:pk>/",
-        views.patch_status_simulation_projet,
+        patch_status_simulation_projet,
         name="patch-simulation-projet-status",
     ),
     path(
         "creation-simulation",
-        views.simulation_form,
+        simulation_views.simulation_form,
         name="simulation-form",
     ),
 ]

--- a/gsl_simulation/urls.py
+++ b/gsl_simulation/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     ),
     path(
         "simulation/<slug:slug>/",
-        views.SimulationDetailView.as_view(),
+        views.simulation_must_be_visible_by_user(views.SimulationDetailView.as_view()),
         name="simulation-detail",
     ),
     path(

--- a/gsl_simulation/views/decorators.py
+++ b/gsl_simulation/views/decorators.py
@@ -53,10 +53,10 @@ def exception_handler_decorator(func):
         try:
             return func(*args, **kwargs)
         except Exception as e:
-            logging.error("An error occurred: %s", str(e))
+            logging.error("An error occurred: %s", str(e), exc_info=True)
             return JsonResponse(
                 {
-                    "error": f"An internal error has occurred : {str(e)}",
+                    "error": "An internal error has occurred.",
                 },
                 status=400,
             )

--- a/gsl_simulation/views/decorators.py
+++ b/gsl_simulation/views/decorators.py
@@ -1,0 +1,65 @@
+import logging
+
+from django.http import Http404, JsonResponse
+from django.shortcuts import get_object_or_404
+
+from gsl_programmation.services.enveloppe_service import EnveloppeService
+from gsl_simulation.models import Simulation, SimulationProjet
+from gsl_simulation.services.simulation_projet_service import (
+    SimulationProjetService,
+)
+
+
+def simulation_must_be_visible_by_user(func):
+    def wrapper(*args, **kwargs):
+        user = args[0].user
+        if user.is_staff:
+            return func(*args, **kwargs)
+
+        simulation = get_object_or_404(Simulation, slug=kwargs["slug"])
+        enveloppes_visible_by_user = EnveloppeService.get_enveloppes_visible_for_a_user(
+            user
+        )
+        if simulation.enveloppe not in enveloppes_visible_by_user:
+            raise Http404(
+                "No %s matches the given query." % Simulation._meta.object_name
+            )
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def projet_must_be_in_user_perimetre(func):
+    def wrapper(*args, **kwargs):
+        user = args[0].user
+        if user.is_staff:
+            return func(*args, **kwargs)
+
+        simulation_projet = get_object_or_404(SimulationProjet, id=kwargs["pk"])
+        if not SimulationProjetService.is_simulation_projet_in_perimetre(
+            simulation_projet, user.perimetre
+        ):
+            raise Http404(
+                "No %s matches the given query." % SimulationProjet._meta.object_name
+            )
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def exception_handler_decorator(func):
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            logging.error("An error occurred: %s", str(e))
+            return JsonResponse(
+                {
+                    "error": f"An internal error has occurred : {str(e)}",
+                },
+                status=400,
+            )
+
+    return wrapper

--- a/gsl_simulation/views/decorators.py
+++ b/gsl_simulation/views/decorators.py
@@ -5,9 +5,6 @@ from django.shortcuts import get_object_or_404
 
 from gsl_programmation.services.enveloppe_service import EnveloppeService
 from gsl_simulation.models import Simulation, SimulationProjet
-from gsl_simulation.services.simulation_projet_service import (
-    SimulationProjetService,
-)
 
 
 def simulation_must_be_visible_by_user(func):
@@ -37,9 +34,11 @@ def projet_must_be_in_user_perimetre(func):
             return func(*args, **kwargs)
 
         simulation_projet = get_object_or_404(SimulationProjet, id=kwargs["pk"])
-        if not SimulationProjetService.is_simulation_projet_in_perimetre(
-            simulation_projet, user.perimetre
-        ):
+        enveloppe = simulation_projet.simulation.enveloppe
+        enveloppes_visible_by_user = EnveloppeService.get_enveloppes_visible_for_a_user(
+            user
+        )
+        if enveloppe not in enveloppes_visible_by_user:
             raise Http404(
                 "No %s matches the given query." % SimulationProjet._meta.object_name
             )

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -1,0 +1,109 @@
+from django.http import HttpRequest
+from django.http.request import QueryDict
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import resolve, reverse
+from django.views.decorators.http import require_http_methods
+
+from gsl_projet.services import ProjetService
+from gsl_simulation.models import SimulationProjet
+from gsl_simulation.services.simulation_projet_service import (
+    SimulationProjetService,
+)
+from gsl_simulation.utils import replace_comma_by_dot
+from gsl_simulation.views.decorators import (
+    exception_handler_decorator,
+    projet_must_be_in_user_perimetre,
+)
+from gsl_simulation.views.simulation_views import SimulationDetailView
+
+
+def _get_projets_queryset_with_filters(simulation, filter_params):
+    url = reverse(
+        "simulation:simulation-detail",
+        kwargs={"slug": simulation.slug},
+    )
+    new_request = HttpRequest()
+    new_request.GET = QueryDict(filter_params)
+    new_request.resolver_match = resolve(url)
+
+    view = SimulationDetailView()
+    view.object = simulation
+    view.request = new_request
+    view.kwargs = {"slug": simulation.slug}
+
+    projets = view.get_projet_queryset()
+    return projets
+
+
+def redirect_to_simulation_projet(request, simulation_projet):
+    if request.htmx:
+        filter_params = QueryDict(request.body).get("filter_params")
+        filtered_projets = _get_projets_queryset_with_filters(
+            simulation_projet.simulation,
+            filter_params,
+        )
+
+        total_amount_granted = ProjetService.get_total_amount_granted(filtered_projets)
+
+        return render(
+            request,
+            "htmx/projet_update.html",
+            {
+                "simu": simulation_projet,
+                "projet": simulation_projet.projet,
+                "available_states": SimulationProjet.STATUS_CHOICES,
+                "status_summary": simulation_projet.simulation.get_projet_status_summary(),
+                "total_amount_granted": total_amount_granted,
+                "filter_params": filter_params,
+            },
+        )
+
+    url = reverse(
+        "simulation:simulation-detail",
+        kwargs={"slug": simulation_projet.simulation.slug},
+    )
+    if request.POST.get("filter_params"):
+        url += "?" + request.POST.get("filter_params")
+
+    return redirect(url)
+
+
+@projet_must_be_in_user_perimetre
+@exception_handler_decorator
+@require_http_methods(["POST", "PATCH"])
+def patch_taux_simulation_projet(request, pk):
+    simulation_projet = get_object_or_404(SimulationProjet, id=pk)
+    data = QueryDict(request.body)
+
+    new_taux = replace_comma_by_dot(data.get("taux"))
+    SimulationProjetService.update_taux(simulation_projet, new_taux)
+    return redirect_to_simulation_projet(request, simulation_projet)
+
+
+@projet_must_be_in_user_perimetre
+@exception_handler_decorator
+@require_http_methods(["POST", "PATCH"])
+def patch_montant_simulation_projet(request, pk):
+    simulation_projet = get_object_or_404(SimulationProjet, id=pk)
+    data = QueryDict(request.body)
+
+    new_montant = replace_comma_by_dot(data.get("montant"))
+    SimulationProjetService.update_montant(simulation_projet, new_montant)
+    return redirect_to_simulation_projet(request, simulation_projet)
+
+
+@projet_must_be_in_user_perimetre
+@exception_handler_decorator
+@require_http_methods(["POST", "PATCH"])
+def patch_status_simulation_projet(request, pk):
+    simulation_projet = get_object_or_404(SimulationProjet, id=pk)
+    data = QueryDict(request.body)
+    status = data.get("status")
+
+    if status not in dict(SimulationProjet.STATUS_CHOICES).keys():
+        raise ValueError("Invalid status")
+
+    updated_simulation_projet = SimulationProjetService.update_status(
+        simulation_projet, status
+    )
+    return redirect_to_simulation_projet(request, updated_simulation_projet)


### PR DESCRIPTION
## 🌮 Objectif

Ajout des restrictions de visibilité :
- un utilisateur non-staff ne peut voir que les projets de son périmètre
- un utilisateur non-staff ne peut voir que les simulations de son périmètre
- un utilisateur staff pourra tout voir

## 🔍 Liste des modifications

- Split du fichier views.py du module gsl_simulation en trois fichiers
  -  `decorators`
  -  `simulation_projet_views`
  -  `simulation_projet`
