### PR TITLE
Utiliser Celery pour l'import des communes

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -70,6 +70,7 @@ INSTALLED_APPS = [
     "widget_tweaks",
     "dsfr",
     "import_export",
+    "import_export_extensions",
     "django_htmx",
     "django_filters",
     "django_extensions",

--- a/gsl_core/admin.py
+++ b/gsl_core/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import Group
 from import_export.admin import ImportMixin
+from import_export_extensions.admin import CeleryImportExportMixin
 
 from gsl_core.models import (
     Adresse,
@@ -105,7 +106,7 @@ class ArrondissementAdmin(AllPermsForStaffUser, ImportMixin, admin.ModelAdmin):
 
 
 @admin.register(Commune)
-class CommuneAdmin(AllPermsForStaffUser, ImportMixin, admin.ModelAdmin):
+class CommuneAdmin(AllPermsForStaffUser, CeleryImportExportMixin, admin.ModelAdmin):
     resource_classes = (CommuneResource,)
     list_display = ("name", "insee_code", "departement", "arrondissement")
     list_filter = ("departement__region", "departement", "arrondissement")

--- a/gsl_core/resources.py
+++ b/gsl_core/resources.py
@@ -1,6 +1,7 @@
 from import_export import resources
 from import_export.fields import Field
 from import_export.widgets import ForeignKeyWidget
+from import_export_extensions.resources import CeleryModelResource
 
 from .models import Arrondissement, Commune, Departement, Region
 
@@ -47,7 +48,7 @@ class ArrondissementResource(resources.ModelResource):
         import_id_fields = ("insee_code",)
 
 
-class CommuneResource(resources.ModelResource):
+class CommuneResource(CeleryModelResource):
     insee_code = Field(attribute="insee_code", column_name="COM")
     name = Field(attribute="name", column_name="NCCENR")
     departement = Field(
@@ -72,5 +73,4 @@ class CommuneResource(resources.ModelResource):
     class Meta:
         model = Commune
         import_id_fields = ("insee_code",)
-        use_bulk = True
         skip_unchanged = True

--- a/gsl_core/resources.py
+++ b/gsl_core/resources.py
@@ -73,4 +73,3 @@ class CommuneResource(CeleryModelResource):
     class Meta:
         model = Commune
         import_id_fields = ("insee_code",)
-        skip_unchanged = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "django-fsm-2",
     "django-htmx",
     "django-import-export",
+    "django-import-export-extensions",
     "django-json-widget",
     "django-referrer-policy",
     "django",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,14 +12,19 @@ asgiref==3.8.1
     #   django-htmx
 asttokens==3.0.0
     # via stack-data
+attrs==25.1.0
+    # via
+    #   jsonschema
+    #   referencing
 billiard==4.2.1
     # via celery
 build==1.2.2.post1
     # via pip-tools
-celery==5.4.0
+celery[redis]==5.4.0
     # via
     #   django-celery-beat
     #   django-celery-results
+    #   django-import-export-extensions
     #   gsl (pyproject.toml)
 certifi==2024.8.30
     # via
@@ -83,8 +88,12 @@ django==5.1.4
     #   django-fsm-2
     #   django-htmx
     #   django-import-export
+    #   django-import-export-extensions
+    #   django-picklefield
     #   django-referrer-policy
     #   django-timezone-field
+    #   djangorestframework
+    #   drf-spectacular
     #   gsl (pyproject.toml)
     #   mozilla-django-oidc
 django-celery-beat==2.7.0
@@ -98,17 +107,27 @@ django-csp==3.8
 django-dsfr==2.0.0
     # via gsl (pyproject.toml)
 django-extensions==3.2.3
-    # via gsl (pyproject.toml)
+    # via
+    #   django-import-export-extensions
+    #   gsl (pyproject.toml)
 django-filter==24.3
-    # via gsl (pyproject.toml)
+    # via
+    #   django-import-export-extensions
+    #   gsl (pyproject.toml)
 django-fsm-2==4.0.0
     # via gsl (pyproject.toml)
 django-htmx==1.21.0
     # via gsl (pyproject.toml)
-django-import-export==4.3.3
+django-import-export[xls,xlsx]==4.3.3
+    # via
+    #   django-import-export-extensions
+    #   gsl (pyproject.toml)
+django-import-export-extensions==1.4.1
     # via gsl (pyproject.toml)
 django-json-widget==2.0.1
     # via gsl (pyproject.toml)
+django-picklefield==3.2
+    # via django-import-export-extensions
 django-query-counter==0.4.0
     # via gsl (pyproject.toml)
 django-referrer-policy==1.0
@@ -117,12 +136,20 @@ django-timezone-field==7.0
     # via django-celery-beat
 django-widget-tweaks==1.5.0
     # via django-dsfr
+djangorestframework==3.15.2
+    # via
+    #   django-import-export-extensions
+    #   drf-spectacular
 djlint==1.36.3
     # via gsl (pyproject.toml)
+drf-spectacular==0.28.0
+    # via django-import-export-extensions
 editorconfig==0.17.0
     # via
     #   cssbeautifier
     #   jsbeautifier
+et-xmlfile==2.0.0
+    # via openpyxl
 execnet==2.1.1
     # via pytest-xdist
 executing==2.2.0
@@ -139,6 +166,8 @@ identify==2.6.1
     # via pre-commit
 idna==3.10
     # via requests
+inflection==0.5.1
+    # via drf-spectacular
 iniconfig==2.0.0
     # via pytest
 ipython==8.31.0
@@ -155,6 +184,10 @@ jsbeautifier==1.15.1
     #   djlint
 json5==0.10.0
     # via djlint
+jsonschema==4.23.0
+    # via drf-spectacular
+jsonschema-specifications==2024.10.1
+    # via jsonschema
 kombu==5.4.2
     # via celery
 markupsafe==2.1.5
@@ -165,6 +198,8 @@ mozilla-django-oidc==4.0.1
     # via gsl (pyproject.toml)
 nodeenv==1.9.1
     # via pre-commit
+openpyxl==3.1.5
+    # via tablib
 packaging==24.1
     # via
     #   build
@@ -237,15 +272,27 @@ python-dotenv==1.0.1
 pyyaml==6.0.2
     # via
     #   djlint
+    #   drf-spectacular
     #   pre-commit
 redis==5.1.0
-    # via gsl (pyproject.toml)
+    # via
+    #   celery
+    #   gsl (pyproject.toml)
+referencing==0.36.2
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 regex==2024.11.6
     # via djlint
 requests==2.32.3
     # via
     #   django-dsfr
+    #   django-import-export-extensions
     #   mozilla-django-oidc
+rpds-py==0.23.1
+    # via
+    #   jsonschema
+    #   referencing
 ruff==0.6.8
     # via
     #   gsl (pyproject.toml)
@@ -261,7 +308,7 @@ sqlparse==0.5.1
     # via django
 stack-data==0.6.3
     # via ipython
-tablib==3.7.0
+tablib[xls,xlsx]==3.7.0
     # via django-import-export
 tabulate==0.9.0
     # via django-query-counter
@@ -276,11 +323,14 @@ typing-extensions==4.12.2
     #   dj-database-url
     #   faker
     #   psycopg
+    #   referencing
 tzdata==2024.2
     # via
     #   celery
     #   django-celery-beat
     #   kombu
+uritemplate==4.1.1
+    # via drf-spectacular
 urllib3==2.2.3
     # via
     #   requests
@@ -298,6 +348,10 @@ wheel==0.45.1
     # via pip-tools
 whitenoise==6.8.2
     # via gsl (pyproject.toml)
+xlrd==2.0.1
+    # via tablib
+xlwt==1.3.0
+    # via tablib
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,12 +12,17 @@ asgiref==3.8.1
     #   django-htmx
 asttokens==3.0.0
     # via stack-data
+attrs==25.1.0
+    # via
+    #   jsonschema
+    #   referencing
 billiard==4.2.1
     # via celery
-celery==5.4.0
+celery[redis]==5.4.0
     # via
     #   django-celery-beat
     #   django-celery-results
+    #   django-import-export-extensions
     #   gsl (pyproject.toml)
 certifi==2024.8.30
     # via
@@ -65,8 +70,12 @@ django==5.1.4
     #   django-fsm-2
     #   django-htmx
     #   django-import-export
+    #   django-import-export-extensions
+    #   django-picklefield
     #   django-referrer-policy
     #   django-timezone-field
+    #   djangorestframework
+    #   drf-spectacular
     #   gsl (pyproject.toml)
     #   mozilla-django-oidc
 django-celery-beat==2.7.0
@@ -80,41 +89,67 @@ django-csp==3.8
 django-dsfr==2.0.0
     # via gsl (pyproject.toml)
 django-extensions==3.2.3
-    # via gsl (pyproject.toml)
+    # via
+    #   django-import-export-extensions
+    #   gsl (pyproject.toml)
 django-filter==24.3
-    # via gsl (pyproject.toml)
+    # via
+    #   django-import-export-extensions
+    #   gsl (pyproject.toml)
 django-fsm-2==4.0.0
     # via gsl (pyproject.toml)
 django-htmx==1.21.0
     # via gsl (pyproject.toml)
-django-import-export==4.3.3
+django-import-export[xls,xlsx]==4.3.3
+    # via
+    #   django-import-export-extensions
+    #   gsl (pyproject.toml)
+django-import-export-extensions==1.4.1
     # via gsl (pyproject.toml)
 django-json-widget==2.0.1
     # via gsl (pyproject.toml)
+django-picklefield==3.2
+    # via django-import-export-extensions
 django-referrer-policy==1.0
     # via gsl (pyproject.toml)
 django-timezone-field==7.0
     # via django-celery-beat
 django-widget-tweaks==1.5.0
     # via django-dsfr
+djangorestframework==3.15.2
+    # via
+    #   django-import-export-extensions
+    #   drf-spectacular
+drf-spectacular==0.28.0
+    # via django-import-export-extensions
+et-xmlfile==2.0.0
+    # via openpyxl
 executing==2.2.0
     # via stack-data
 gunicorn==23.0.0
     # via gsl (pyproject.toml)
 idna==3.10
     # via requests
+inflection==0.5.1
+    # via drf-spectacular
 ipython==8.31.0
     # via gsl (pyproject.toml)
 jedi==0.19.2
     # via ipython
 josepy==1.14.0
     # via mozilla-django-oidc
+jsonschema==4.23.0
+    # via drf-spectacular
+jsonschema-specifications==2024.10.1
+    # via jsonschema
 kombu==5.4.2
     # via celery
 matplotlib-inline==0.1.7
     # via ipython
 mozilla-django-oidc==4.0.1
     # via gsl (pyproject.toml)
+openpyxl==3.1.5
+    # via tablib
 packaging==24.1
     # via gunicorn
 parso==0.8.4
@@ -147,12 +182,25 @@ python-dateutil==2.9.0.post0
     #   python-crontab
 python-dotenv==1.0.1
     # via gsl (pyproject.toml)
+pyyaml==6.0.2
+    # via drf-spectacular
 redis==5.1.0
-    # via gsl (pyproject.toml)
+    # via
+    #   celery
+    #   gsl (pyproject.toml)
+referencing==0.36.2
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.32.3
     # via
     #   django-dsfr
+    #   django-import-export-extensions
     #   mozilla-django-oidc
+rpds-py==0.23.1
+    # via
+    #   jsonschema
+    #   referencing
 sentry-sdk==2.15.0
     # via gsl (pyproject.toml)
 six==1.16.0
@@ -161,7 +209,7 @@ sqlparse==0.5.1
     # via django
 stack-data==0.6.3
     # via ipython
-tablib==3.7.0
+tablib[xls,xlsx]==3.7.0
     # via django-import-export
 traitlets==5.14.3
     # via
@@ -171,11 +219,14 @@ typing-extensions==4.12.2
     # via
     #   dj-database-url
     #   psycopg
+    #   referencing
 tzdata==2024.2
     # via
     #   celery
     #   django-celery-beat
     #   kombu
+uritemplate==4.1.1
+    # via drf-spectacular
 urllib3==2.2.3
     # via
     #   requests
@@ -189,3 +240,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 whitenoise==6.8.2
     # via gsl (pyproject.toml)
+xlrd==2.0.1
+    # via tablib
+xlwt==1.3.0
+    # via tablib


### PR DESCRIPTION
## 🌮 Objectif

On ne peut pas importer les communes depuis l'interface d'administration de Scalingo (préprod prod) car le fichier est trop gros et on part systématiquement en timeout.

## 🔍 Liste des modifications

- Utilisation de import_export_extensions


## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
