### PR TITLE
Ajout d'un outillage pour intervenir plus facilement sur nos serveurs

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -72,6 +72,7 @@ INSTALLED_APPS = [
     "import_export",
     "django_htmx",
     "django_filters",
+    "django_extensions",
     # gsl apps:
     "gsl_core",
     "gsl_demarches_simplifiees",
@@ -99,7 +100,6 @@ MIDDLEWARE = [
 
 if DEBUG:
     INSTALLED_APPS.append("query_counter")
-    INSTALLED_APPS.append("django_extensions")
     MIDDLEWARE.append("query_counter.middleware.DjangoQueryCounterMiddleware")
 
 AUTHENTICATION_BACKENDS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "django-celery-beat",
     "django-csp",
     "django-dsfr",
+    "django-extensions",
     "django-filter",
     "django-fsm-2",
     "django-htmx",
@@ -38,7 +39,6 @@ build-backend = "setuptools.build_meta"
 [project.optional-dependencies]
 dev = [
     "diff-cover",
-    "django-extensions",
     "django-query-counter",
     "djlint",
     "factory_boy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,7 @@ django==5.1.4
     #   django-crispy-forms
     #   django-csp
     #   django-dsfr
+    #   django-extensions
     #   django-filter
     #   django-fsm-2
     #   django-htmx
@@ -77,6 +78,8 @@ django-crispy-forms==2.3
 django-csp==3.8
     # via gsl (pyproject.toml)
 django-dsfr==2.0.0
+    # via gsl (pyproject.toml)
+django-extensions==3.2.3
     # via gsl (pyproject.toml)
 django-filter==24.3
     # via gsl (pyproject.toml)


### PR DESCRIPTION
## 🌮 Objectif

Ajout de la librairie [django-extensions](https://github.com/django-extensions/django-extensions/tree/main), afin de pouvoir avoir accès à `shell_plus`.

Possibilités :
- utiliser un shell avec les modèles disponibles tout de suite, sans avoir à les importer avec `shell_plus`
- générer des graphes de visualisations des modèles avec `graph_models`
- vérifier la validité des templates avec `python manage.py validate_templates`
- lister les urls avec `python manage.py show_urls`

## 🔍 Liste des modifications

- Déplacement de la librairie pour passer des dev dependencies aux dependecies
