### PR TITLE
Tâche de création de tous les périmètres territoriaux

### DIFF
--- a/gsl_core/management/commands/create_perimetres.py
+++ b/gsl_core/management/commands/create_perimetres.py
@@ -1,0 +1,44 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from gsl_core.models import Arrondissement, Perimetre
+
+
+class Command(BaseCommand):
+    """
+    python manage.py create_perimetres
+    """
+
+    help = "Create all perimeters from existing territoires"
+
+    def handle(self, *args, **kwargs):
+        i = 0
+        for arrondissement in Arrondissement.objects.select_related(
+            "departement", "departement__region"
+        ).all():
+            _, is_created = Perimetre.objects.get_or_create(
+                arrondissement=arrondissement,
+                departement=arrondissement.departement,
+                region=arrondissement.departement.region,
+            )
+            if is_created:
+                i += 1
+
+            _, is_created = Perimetre.objects.get_or_create(
+                arrondissement=None,
+                departement=arrondissement.departement,
+                region=arrondissement.departement.region,
+            )
+            if is_created:
+                i += 1
+
+            _, is_created = Perimetre.objects.get_or_create(
+                arrondissement=None,
+                departement=None,
+                region=arrondissement.departement.region,
+            )
+            if is_created:
+                i += 1
+
+        logging.info(f"Et voilà le travail, {i} périmètres ont été créés")

--- a/gsl_core/tests/test_commands.py
+++ b/gsl_core/tests/test_commands.py
@@ -1,0 +1,30 @@
+import logging
+
+import pytest
+from django.core.management import call_command
+
+from gsl_core.models import Arrondissement, Departement, Perimetre, Region
+from gsl_core.tests.factories import (
+    ArrondissementFactory,
+    PerimetreArrondissementFactory,
+)
+
+
+@pytest.mark.django_db
+def test_create_perimetres(caplog):
+    arrondissements = ArrondissementFactory.create_batch(10)
+    PerimetreArrondissementFactory(arrondissement=arrondissements[0])
+    assert Perimetre.objects.count() == 1
+    assert Arrondissement.objects.count() == 10
+    assert Departement.objects.count() == 10
+    assert Region.objects.count() == 10
+
+    with caplog.at_level(logging.INFO):
+        call_command("create_perimetres")
+
+    perimetres = Perimetre.objects
+    assert perimetres.filter(arrondissement__isnull=True).count() == 20
+    assert perimetres.filter(departement__isnull=True).count() == 10
+    assert perimetres.count() == 30
+
+    assert "Et voilà le travail, 29 périmètres ont été créés" in caplog.text


### PR DESCRIPTION
## 🌮 Objectif

Avoir tous les périmètres pré-remplis pour éviter de devoir les créer au fil de l'eau

## 🔍 Liste des modifications

- Création d'une commande
- Ajout d'un test

## ⚠️ Informations supplémentaires

À lancer en prod et en staging + sur les environnements de dev après import des données INSEE


