### PR TITLE
Ajout des contraintes sur les montants et taux sur les projets de simulation et de programmation

### DIFF
--- a/gsl_programmation/models.py
+++ b/gsl_programmation/models.py
@@ -1,9 +1,8 @@
-from math import isclose
-
 from django.core.exceptions import ValidationError
 from django.db import models
 
 from gsl_core.models import Perimetre
+from gsl_programmation.utils import is_there_less_or_equal_than_0_009_of_difference
 from gsl_projet.models import Projet
 
 
@@ -151,14 +150,14 @@ class ProgrammationProjet(models.Model):
     def _validate_taux(self, errors):
         if self.taux and self.taux > 100:
             errors["taux"] = {
-                "Le taux de la programmation ne peut pas être supérieur à 100"
+                "Le taux de la programmation ne peut pas être supérieur à 100."
             }
 
     def _validate_montant(self, errors):
         if self.projet.assiette is not None:
             if self.projet.assiette > 0:
-                if not isclose(
-                    self.taux, self.montant * 100 / self.projet.assiette, abs_tol=0.009
+                if not is_there_less_or_equal_than_0_009_of_difference(
+                    self.taux, self.montant * 100 / self.projet.assiette
                 ):
                     errors["taux"] = {
                         "Le taux et le montant de la programmation ne sont pas cohérents. "

--- a/gsl_programmation/models.py
+++ b/gsl_programmation/models.py
@@ -141,27 +141,53 @@ class ProgrammationProjet(models.Model):
 
     def clean(self):
         errors = {}
-        if self.projet.assiette is not None and self.projet.assiette > 0:
-            if not isclose(
-                self.taux, self.montant * 100 / self.projet.assiette, abs_tol=0.009
+        self._validate_taux(errors)
+        self._validate_montant(errors)
+        self._validate_enveloppe(errors)
+        self._validate_for_refused_status(errors)
+        if errors:
+            raise ValidationError(errors)
+
+    def _validate_taux(self, errors):
+        if self.taux and self.taux > 100:
+            errors["taux"] = {
+                "Le taux de la programmation ne peut pas être supérieur à 100"
+            }
+
+    def _validate_montant(self, errors):
+        if self.projet.assiette is not None:
+            if self.projet.assiette > 0:
+                if not isclose(
+                    self.taux, self.montant * 100 / self.projet.assiette, abs_tol=0.009
+                ):
+                    errors["taux"] = {
+                        "Le taux et le montant de la programmation ne sont pas cohérents. "
+                        f"Taux attendu : {str(round(self.montant * 100 / self.projet.assiette, 2))}"
+                    }
+            if self.montant and self.montant > self.projet.assiette:
+                errors["montant"] = {
+                    "Le montant de la programmation ne peut pas être supérieur à l'assiette du projet."
+                }
+        else:
+            if (
+                self.montant
+                and self.projet.dossier_ds.finance_cout_total
+                and self.montant > self.projet.dossier_ds.finance_cout_total
             ):
-                errors["taux"] = {
-                    "Le taux et le montant de la programmation ne sont pas cohérents. "
-                    f"Taux attendu : {str(round(self.montant * 100 / self.projet.assiette, 2))}"
+                errors["montant"] = {
+                    "Le montant de la programmation ne peut pas être supérieur au coût total du projet."
                 }
 
+    def _validate_enveloppe(self, errors):
         if self.enveloppe.is_deleguee:
             errors["enveloppe"] = {
                 "Une programmation ne peut pas être faite sur une enveloppe déléguée."
                 "Il faut programmer sur l'enveloppe mère."
             }
 
+    def _validate_for_refused_status(self, errors):
         if self.status == self.STATUS_REFUSED:
             if self.montant != 0:
                 errors["montant"] = {"Un projet refusé doit avoir un montant nul."}
-
             if self.taux != 0:
                 errors["taux"] = {"Un projet refusé doit avoir un taux nul."}
-
-        if errors:
-            raise ValidationError(errors)

--- a/gsl_programmation/tests/test_model_programmation_projet.py
+++ b/gsl_programmation/tests/test_model_programmation_projet.py
@@ -15,7 +15,7 @@ from gsl_projet.tests.factories import ProjetFactory
 
 
 def test_programmation_projet_cant_have_a_montant_higher_than_projet_assiette():
-    projet = ProjetFactory.build(assiette=100)
+    projet = ProjetFactory.build(assiette=100, dossier_ds__finance_cout_total=200)
     with pytest.raises(ValidationError) as exc_info:
         pp = ProgrammationProjetFactory.build(projet=projet, montant=101)
         pp.full_clean()

--- a/gsl_programmation/tests/test_model_programmation_projet.py
+++ b/gsl_programmation/tests/test_model_programmation_projet.py
@@ -13,9 +13,39 @@ from gsl_programmation.tests.factories import (
 from gsl_projet.models import Projet
 from gsl_projet.tests.factories import ProjetFactory
 
-pytestmark = pytest.mark.django_db
+
+def test_programmation_projet_cant_have_a_montant_higher_than_projet_assiette():
+    projet = ProjetFactory.build(assiette=100)
+    with pytest.raises(ValidationError) as exc_info:
+        pp = ProgrammationProjetFactory.build(projet=projet, montant=101)
+        pp.full_clean()
+    assert (
+        "Le montant de la programmation ne peut pas être supérieur à l'assiette du projet."
+        in str(exc_info.value.message_dict.get("montant")[0])
+    )
 
 
+def test_programmation_projet_cant_have_a_montant_higher_than_projet_cout_total():
+    projet = ProjetFactory.build(dossier_ds__finance_cout_total=100)
+    with pytest.raises(ValidationError) as exc_info:
+        pp = ProgrammationProjetFactory.build(projet=projet, montant=101)
+        pp.full_clean()
+    assert (
+        "Le montant de la programmation ne peut pas être supérieur au coût total du projet."
+        in str(exc_info.value.message_dict.get("montant")[0])
+    )
+
+
+def test_programmation_projet_cant_have_a_taux_higher_than_100():
+    with pytest.raises(ValidationError) as exc_info:
+        pp = ProgrammationProjetFactory.build(taux=101)
+        pp.full_clean()
+    assert "Le taux de la programmation ne peut pas être supérieur à 100" in str(
+        exc_info.value.message_dict.get("taux")[0]
+    )
+
+
+@pytest.mark.django_db
 def test_i_cannot_create_two_prog_for_the_same_projet_enveloppe():
     first_prog_projet = ProgrammationProjetFactory(
         status=ProgrammationProjet.STATUS_ACCEPTED
@@ -28,6 +58,7 @@ def test_i_cannot_create_two_prog_for_the_same_projet_enveloppe():
         )
 
 
+@pytest.mark.django_db
 def test_i_can_accept_a_project_on_two_different_enveloppes():
     first_prog_projet = ProgrammationProjetFactory(
         status=ProgrammationProjet.STATUS_ACCEPTED, enveloppe=DetrEnveloppeFactory()
@@ -44,6 +75,7 @@ def projet() -> Projet:
     return ProjetFactory(assiette=Decimal("1234.00"))
 
 
+@pytest.mark.django_db
 def test_taux_consistency_is_valid_with_a_difference_of_more_than_a_tenth(projet):
     for taux in [Decimal("3.39"), Decimal("3.42")]:
         prog_projet = ProgrammationProjetFactory(
@@ -60,6 +92,7 @@ def test_taux_consistency_is_valid_with_a_difference_of_more_than_a_tenth(projet
         assert "Taux attendu : 3.40" in exception_message
 
 
+@pytest.mark.django_db
 def test_taux_consistency_is_valid_with_a_difference_of_less_than_a_tenth(projet):
     for taux in [Decimal("3.40"), Decimal("3.41")]:
         prog_projet = ProgrammationProjetFactory(
@@ -78,6 +111,7 @@ def enveloppe_deleguee(enveloppe) -> Enveloppe:
     return DsilEnveloppeFactory(deleguee_by=enveloppe)
 
 
+@pytest.mark.django_db
 def test_clean_programmation_on_deleguee_enveloppe(projet, enveloppe_deleguee):
     programmation = ProgrammationProjet(
         projet=projet,
@@ -93,6 +127,7 @@ def test_clean_programmation_on_deleguee_enveloppe(projet, enveloppe_deleguee):
     )
 
 
+@pytest.mark.django_db
 def test_clean_valid_programmation(projet, enveloppe):
     programmation = ProgrammationProjet(
         projet=projet,
@@ -103,6 +138,7 @@ def test_clean_valid_programmation(projet, enveloppe):
     programmation.clean()
 
 
+@pytest.mark.django_db
 def test_clean_programmation_with_refused_status(projet, enveloppe):
     programmation = ProgrammationProjet(
         projet=projet,

--- a/gsl_programmation/tests/test_model_programmation_projet.py
+++ b/gsl_programmation/tests/test_model_programmation_projet.py
@@ -21,7 +21,7 @@ def test_programmation_projet_cant_have_a_montant_higher_than_projet_assiette():
         pp.full_clean()
     assert (
         "Le montant de la programmation ne peut pas être supérieur à l'assiette du projet."
-        in str(exc_info.value.message_dict.get("montant")[0])
+        in exc_info.value.message_dict.get("montant")[0]
     )
 
 
@@ -32,7 +32,7 @@ def test_programmation_projet_cant_have_a_montant_higher_than_projet_cout_total(
         pp.full_clean()
     assert (
         "Le montant de la programmation ne peut pas être supérieur au coût total du projet."
-        in str(exc_info.value.message_dict.get("montant")[0])
+        in exc_info.value.message_dict.get("montant")[0]
     )
 
 
@@ -40,8 +40,9 @@ def test_programmation_projet_cant_have_a_taux_higher_than_100():
     with pytest.raises(ValidationError) as exc_info:
         pp = ProgrammationProjetFactory.build(taux=101)
         pp.full_clean()
-    assert "Le taux de la programmation ne peut pas être supérieur à 100" in str(
-        exc_info.value.message_dict.get("taux")[0]
+    assert (
+        "Le taux de la programmation ne peut pas être supérieur à 100."
+        in exc_info.value.message_dict.get("taux")[0]
     )
 
 
@@ -87,7 +88,7 @@ def test_taux_consistency_is_valid_with_a_difference_of_more_than_a_tenth(projet
         exception_message = exc_info.value.message_dict["taux"][0]
         assert (
             "Le taux et le montant de la programmation ne sont pas cohérents."
-            in str(exc_info.value)
+            in exception_message
         )
         assert "Taux attendu : 3.40" in exception_message
 
@@ -123,7 +124,7 @@ def test_clean_programmation_on_deleguee_enveloppe(projet, enveloppe_deleguee):
         programmation.clean()
     assert (
         "Une programmation ne peut pas être faite sur une enveloppe déléguée."
-        in str(exc_info.value.message_dict["enveloppe"])
+        in exc_info.value.message_dict["enveloppe"][0]
     )
 
 

--- a/gsl_programmation/tests/test_utils.py
+++ b/gsl_programmation/tests/test_utils.py
@@ -1,0 +1,32 @@
+from gsl_programmation.utils import is_there_less_or_equal_than_0_009_of_difference
+
+
+def test_is_there_less_or_equal_than_0_009_of_difference_true():
+    assert is_there_less_or_equal_than_0_009_of_difference(1.001, 1.002) is True
+    assert is_there_less_or_equal_than_0_009_of_difference(1.0, 1.008) is True
+    assert is_there_less_or_equal_than_0_009_of_difference(-1.0, -1.008) is True
+
+
+def test_is_there_less_or_equal_than_0_009_of_difference_false():
+    assert is_there_less_or_equal_than_0_009_of_difference(1.0, 1.01) is False
+    assert is_there_less_or_equal_than_0_009_of_difference(1.0, 1.02) is False
+    assert is_there_less_or_equal_than_0_009_of_difference(-1.0, -1.02) is False
+
+
+def test_is_there_less_or_equal_than_0_009_of_difference_edge_cases():
+    assert is_there_less_or_equal_than_0_009_of_difference(1.0, 1.009) is True  # 0,009
+    assert (
+        is_there_less_or_equal_than_0_009_of_difference(1.0, 1.0091) is False
+    )  # 0,0091
+
+    assert is_there_less_or_equal_than_0_009_of_difference(1.0, 0.991) is True  # 0,009
+    assert (
+        is_there_less_or_equal_than_0_009_of_difference(1.0, 0.9909) is False
+    )  # 0,0091
+
+    assert (
+        is_there_less_or_equal_than_0_009_of_difference(-1.0, -1.009) is True
+    )  # 0,009
+    assert (
+        is_there_less_or_equal_than_0_009_of_difference(-1.0, -1.0091) is False
+    )  # 0,0091

--- a/gsl_programmation/utils.py
+++ b/gsl_programmation/utils.py
@@ -1,0 +1,2 @@
+def is_there_less_or_equal_than_0_009_of_difference(a: float, b: float) -> bool:
+    return round(abs(round(a, 4) - round(b, 4)), 4) <= 0.009

--- a/gsl_simulation/models.py
+++ b/gsl_simulation/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.db.models import Count
+from django.forms import ValidationError
 
 from gsl_core.models import Collegue
 from gsl_programmation.models import Enveloppe
@@ -92,3 +93,32 @@ class SimulationProjet(models.Model):
     @property
     def enveloppe(self):
         return self.simulation.enveloppe
+
+    def clean(self):
+        errors = {}
+        self._validate_taux(errors)
+        self._validate_montant(errors)
+        if errors:
+            raise ValidationError(errors)
+
+    def _validate_taux(self, errors):
+        if self.taux and self.taux > 100:
+            errors["taux"] = {
+                "Le taux de la programmation ne peut pas être supérieur à 100"
+            }
+
+    def _validate_montant(self, errors):
+        if self.projet.assiette is not None:
+            if self.montant and self.montant > self.projet.assiette:
+                errors["montant"] = {
+                    "Le montant de la programmation ne peut pas être supérieur à l'assiette du projet."
+                }
+        else:
+            if (
+                self.montant
+                and self.projet.dossier_ds.finance_cout_total
+                and self.montant > self.projet.dossier_ds.finance_cout_total
+            ):
+                errors["montant"] = {
+                    "Le montant de la programmation ne peut pas être supérieur au coût total du projet."
+                }

--- a/gsl_simulation/models.py
+++ b/gsl_simulation/models.py
@@ -104,14 +104,14 @@ class SimulationProjet(models.Model):
     def _validate_taux(self, errors):
         if self.taux and self.taux > 100:
             errors["taux"] = {
-                "Le taux de la programmation ne peut pas être supérieur à 100"
+                "Le taux de la simulation ne peut pas être supérieur à 100."
             }
 
     def _validate_montant(self, errors):
         if self.projet.assiette is not None:
             if self.montant and self.montant > self.projet.assiette:
                 errors["montant"] = {
-                    "Le montant de la programmation ne peut pas être supérieur à l'assiette du projet."
+                    "Le montant de la simulation ne peut pas être supérieur à l'assiette du projet."
                 }
         else:
             if (
@@ -120,5 +120,5 @@ class SimulationProjet(models.Model):
                 and self.montant > self.projet.dossier_ds.finance_cout_total
             ):
                 errors["montant"] = {
-                    "Le montant de la programmation ne peut pas être supérieur au coût total du projet."
+                    "Le montant de la simulation ne peut pas être supérieur au coût total du projet."
                 }

--- a/gsl_simulation/tests/test_models.py
+++ b/gsl_simulation/tests/test_models.py
@@ -1,5 +1,7 @@
 import pytest
+from django.forms import ValidationError
 
+from gsl_projet.tests.factories import ProjetFactory
 from gsl_simulation.models import Simulation, SimulationProjet
 from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
 
@@ -44,3 +46,34 @@ def test_get_projet_status_summary(simulation, simulation_projects):
     }
 
     assert summary == expected_summary
+
+
+def test_simulation_projet_cant_have_a_montant_higher_than_projet_assiette():
+    projet = ProjetFactory.build(assiette=100, dossier_ds__finance_cout_total=200)
+    with pytest.raises(ValidationError) as exc_info:
+        pp = SimulationProjetFactory.build(projet=projet, montant=101)
+        pp.full_clean()
+    assert (
+        "Le montant de la simulation ne peut pas être supérieur à l'assiette du projet."
+        in str(exc_info.value.message_dict.get("montant")[0])
+    )
+
+
+def test_simulation_projet_cant_have_a_montant_higher_than_projet_cout_total():
+    projet = ProjetFactory.build(dossier_ds__finance_cout_total=100)
+    with pytest.raises(ValidationError) as exc_info:
+        pp = SimulationProjetFactory.build(projet=projet, montant=101)
+        pp.full_clean()
+    assert (
+        "Le montant de la simulation ne peut pas être supérieur au coût total du projet."
+        in str(exc_info.value.message_dict.get("montant")[0])
+    )
+
+
+def test_simulation_projet_cant_have_a_taux_higher_than_100():
+    with pytest.raises(ValidationError) as exc_info:
+        pp = SimulationProjetFactory.build(taux=101)
+        pp.full_clean()
+    assert "Le taux de la simulation ne peut pas être supérieur à 100" in str(
+        exc_info.value.message_dict.get("taux")[0]
+    )

--- a/gsl_simulation/tests/test_utils.py
+++ b/gsl_simulation/tests/test_utils.py
@@ -1,8 +1,6 @@
 import pytest
 
-from gsl_simulation.utils import (
-    replace_comma_by_dot,
-)
+from gsl_simulation.utils import replace_comma_by_dot
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🌮 Objectif

Ajout de ces contraintes sur les projets de simulation et sur les projets de programmation :
- ne plus pouvoir définir un montant supérieur au cout total du projet ou de l'assiette
- ne plus pouvoir définir un taux supérieur à 100%
