### PR TITLE
Retrait du picto "crayon" dans une simulation

### DIFF
--- a/gsl_simulation/templates/includes/_simulation_detail_row.html
+++ b/gsl_simulation/templates/includes/_simulation_detail_row.html
@@ -47,11 +47,6 @@
     <td class="fr-cell--right gsl-nowrap">
         <a class="fr-btn--tertiary-no-outline gsl-no-underline"
            href="{{ projet.get_absolute_url }}">
-            <span class="fr-sr-only">Modifier le projet {{ projet.dossier_ds.ds_number }}</span>
-            <span class="fr-icon-edit-fill fr-icon--sm" aria-hidden="true"></span>
-        </a>
-        <a class="fr-btn--tertiary-no-outline gsl-no-underline"
-           href="{{ projet.get_absolute_url }}">
             <span class="fr-sr-only">Voir le projet {{ projet.dossier_ds.ds_number }}</span>
             <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
         </a>


### PR DESCRIPTION
## 🌮 Objectif

Retirer le picto "crayon" qui crée de la confusion.