### PR TITLE
Utilisation des statuts du projet dans les pages projets et détail du projet plutôt que le statut DS

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -118,6 +118,13 @@ ul.no-list-style li {
     text-overflow: ellipsis;
 }
 
+.max_120_width {
+    max-width: 140px;
+    width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .gsl_projet_table__total {
     width: 100%;
     justify-content: center;
@@ -216,20 +223,12 @@ ul.no-list-style li {
     }
 }
 
-.ds_state__accepte {
+.projet_status__accepted {
     color: var(--text-default-success)
 }
 
-.ds_state__accepte::before {
-    content: "✅" / "";
-}
-
-.ds_state__refuse{
+.projet_status__refused {
     color: var(--text-default-error)
-}
-
-.ds_state__refuse::before {
-    content: "❌" / "";
 }
 
 /* simulation */

--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -231,6 +231,25 @@ ul.no-list-style li {
     color: var(--text-default-error)
 }
 
+/* projet detail */
+.badge-projet-status__accepted {
+    background-color: var(--background-contrast-success);
+    color: var(--text-default-success);
+}
+
+.badge-projet-status__refused {
+    background-color: var(--background-contrast-error);
+    color: var(--text-default-error);
+}
+/* .badge-projet-status__processing {
+    background-color: var(--background-contrast-info);
+    color: var(--text-default-info);
+} */
+.badge-projet-status__unanswered {
+    background-color: var(--background-contrast-warning);
+    color: var(--text-default-warning);
+}
+
 /* simulation */
 
 .blue-icon {

--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -21,3 +21,8 @@ def euro(value, decimals=0):
     if not isinstance(value, (float, int, Decimal)) or isinstance(value, bool):
         return "—"
     return floatformat(value, f"{decimals}g") + " €"
+
+
+@register.filter
+def remove_first_word(value):
+    return value.split(" ", 1)[1]

--- a/gsl_projet/templates/gsl_projet/projet.html
+++ b/gsl_projet/templates/gsl_projet/projet.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static dsfr_tags %}
+{% load static dsfr_tags gsl_filters %}
 
 {% block breadcrumb %}
     {% dsfr_breadcrumb breadcrumb_dict %}
@@ -14,7 +14,7 @@
     </div>
 
     <h1>
-        <span class="fr-badge fr-text--xl gsl-pull-right fr-mt-2v fr-ml-5w">{{ projet.get_status_display }}</span>
+        <span class="fr-badge fr-text--xl gsl-pull-right fr-mt-2v fr-ml-5w badge-projet-status__{{ projet.status }}">{{ projet.get_status_display|remove_first_word }}</span>
         {{ dossier.projet_intitule|lower|capfirst }}
     </h1>
 

--- a/gsl_projet/templates/gsl_projet/projet.html
+++ b/gsl_projet/templates/gsl_projet/projet.html
@@ -14,7 +14,7 @@
     </div>
 
     <h1>
-        <span class="fr-badge fr-text--xl gsl-pull-right fr-mt-2v fr-ml-5w">{{ dossier.get_ds_state_display }}</span>
+        <span class="fr-badge fr-text--xl gsl-pull-right fr-mt-2v fr-ml-5w">{{ projet.get_status_display }}</span>
         {{ dossier.projet_intitule|lower|capfirst }}
     </h1>
 

--- a/gsl_projet/templates/includes/_projets_table.html
+++ b/gsl_projet/templates/includes/_projets_table.html
@@ -38,7 +38,7 @@
                 <th>
                     Catégorie d'opération
                 </th>
-                <th>
+                <th class="max_120_width">
                     Statut
                 </th>
                 <th>
@@ -86,8 +86,8 @@
                             {% endfor %}
                         </ul>
                     </td>
-                    <td class="ds_state__{{ projet.dossier_ds.ds_state }}">
-                        <b>{{ projet.dossier_ds.get_ds_state_display }}</b>
+                    <td class="projet_status__{{ projet.status }}">
+                        <b>{{ projet.get_status_display }}</b>
                     </td>
                     <td class="fr-cell--right">
                         <a class="fr-btn--tertiary-no-outline gsl-no-underline"

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -503,30 +503,23 @@ def test_filter_with_wrong_montant_demande_values(
 def projets_with_status(demandeur) -> list[Projet]:
     projets = []
     for status, count in (
-        ("accepte", 1),
-        ("en_construction", 2),
-        ("en_instruction", 3),
-        ("refuse", 4),
-        ("sans_suite", 5),
+        ("accepted", 1),
+        ("processing", 2),
+        ("refused", 4),
+        ("unanswered", 5),
     ):
         for _ in range(count):
-            projets.append(
-                ProjetFactory(
-                    dossier_ds__ds_state=status,
-                    demandeur=demandeur,
-                )
-            )
+            projets.append(ProjetFactory(status=status, demandeur=demandeur))
     return projets
 
 
 @pytest.mark.parametrize(
     "status,expected_count",
     [
-        ("accepte", 1),
-        ("en_construction", 2),
-        ("en_instruction", 3),
-        ("refuse", 4),
-        ("sans_suite", 5),
+        ("accepted", 1),
+        ("processing", 2),
+        ("refused", 4),
+        ("unanswered", 5),
     ],
 )
 def test_filter_by_status(req, view, projets_with_status, status, expected_count):
@@ -535,7 +528,7 @@ def test_filter_by_status(req, view, projets_with_status, status, expected_count
     qs = view.get_filterset(ProjetFilters).qs
 
     assert qs.count() == expected_count
-    assert qs.first().dossier_ds.ds_state == status
+    assert qs.first().status == status
 
 
 def test_get_status_placeholder(req, view, projets_with_status):
@@ -545,9 +538,9 @@ def test_get_status_placeholder(req, view, projets_with_status):
 
 
 def test_get_status_placeholder_with_status(req, view, projets_with_status):
-    request = req.get("/?status=accepte&status=en_construction")
+    request = req.get("/?status=accepted&status=processing")
     view.request = request
     assert (
         view._get_status_placeholder(ProjetListView.STATE_MAPPINGS)
-        == "Accepté, En construction"
+        == "✅ Accepté, 🔄 En traitement"
     )

--- a/gsl_projet/utils/django_filters_custom_widget.py
+++ b/gsl_projet/utils/django_filters_custom_widget.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.utils.safestring import mark_safe
 
-from gsl_demarches_simplifiees.models import Dossier
+from gsl_projet.models import Projet
 from gsl_simulation.models import SimulationProjet
 
 
@@ -12,11 +12,10 @@ class CustomCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
             SimulationProjet.STATUS_PROVISOIRE: "blue",
             SimulationProjet.STATUS_REFUSED: "red",
             SimulationProjet.STATUS_ACCEPTED: "green",
-            Dossier.STATE_ACCEPTE: "green",
-            Dossier.STATE_EN_CONSTRUCTION: "blue",
-            Dossier.STATE_EN_INSTRUCTION: "blue",
-            Dossier.STATE_REFUSE: "red",
-            Dossier.STATE_SANS_SUITE: "orange",
+            Projet.STATUS_ACCEPTED: "green",
+            Projet.STATUS_PROCESSING: "",
+            Projet.STATUS_REFUSED: "red",
+            Projet.STATUS_UNANSWERED: "",
         }.get(option_value, "")
 
     def render(self, name, value, attrs=None, renderer=None):

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -11,6 +11,7 @@ from gsl_demarches_simplifiees.models import Dossier
 from gsl_projet.models import Projet
 from gsl_projet.services import ProjetService
 from gsl_projet.utils.django_filters_custom_widget import CustomCheckboxSelectMultiple
+from gsl_projet.utils.utils import order_couples_tuple_by_first_value
 
 
 class ProjetFilters(FilterSet):
@@ -111,9 +112,18 @@ class ProjetFilters(FilterSet):
         ),
     )
 
+    ordered_status = (
+        Projet.STATUS_PROCESSING,
+        Projet.STATUS_REFUSED,
+        Projet.STATUS_ACCEPTED,
+        Projet.STATUS_UNANSWERED,
+    )
+
     status = MultipleChoiceFilter(
-        field_name="dossier_ds__ds_state",
-        choices=Dossier.DS_STATE_VALUES,
+        field_name="status",
+        choices=order_couples_tuple_by_first_value(
+            Projet.STATUS_CHOICES, ordered_status
+        ),
         widget=CustomCheckboxSelectMultiple(),
     )
 

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -5,7 +5,6 @@ from django.views.decorators.http import require_GET
 from django.views.generic import ListView
 from django_filters.views import FilterView
 
-from gsl_demarches_simplifiees.models import Dossier
 from gsl_projet.services import ProjetService
 from gsl_projet.utils.filter_utils import FilterUtils
 from gsl_projet.utils.projet_filters import ProjetFilters
@@ -128,7 +127,7 @@ class ProjetListView(FilterView, ListView, FilterUtils):
     paginate_by = 25
     filterset_class = ProjetListViewFilters
     template_name = "gsl_projet/projet_list.html"
-    STATE_MAPPINGS = {key: value for key, value in Dossier.DS_STATE_VALUES}
+    STATE_MAPPINGS = {key: value for key, value in Projet.STATUS_CHOICES}
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
## 🌮 Objectif

Utilisation des statuts de l'outil plutôt que ceux de DS

## 🔍 Liste des modifications

- `ProjetFilters` => utilisation des nouveaux statuts
- `projet.html` => on met le nouveau statut
- `_projet_table.html` => on affiche le nouveau statut
