### PR TITLE
Séparation des classes CSS spécifiques à une simulation dans un fichier dédié

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -250,58 +250,8 @@ ul.no-list-style li {
     color: var(--text-default-warning);
 }
 
-/* simulation */
-
+/* common */
 .blue-icon {
     color: var(--blue-france-sun-113-625);
-}
-
-.success-color {
-    color: var(--text-default-success);
-}
-
-.refuse-color {
-    color: var(--text-default-error);
-}
-
-.processing-color {
-    color: var(--text-mention-grey);
-}
-
-.set-unanswered-color {
-    color: var(--text-default-warning);
-}
-
-.confirmation-modal-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 1em;
-}
-
-
-.accept-button{
-    background-color: var(--background-action-high-success);
-    color: var(--background-alt-blue-france)
-}
-
-.accept-button:hover{
-    background-color: var(--background-action-high-success-hover) !important;
-}
-
-.refuse-button{
-    background-color: var(--background-action-high-error);
-    color: var(--background-alt-blue-france)
-}
-
-.refuse-button:hover{
-    background-color: var(--background-action-high-error-hover) !important;
-}
-
-.set-unanswered-button{
-    background-color: var(--background-action-high-warning);
-    color: var(--background-alt-blue-france)
-}
-
-.set-unanswered-button:hover{
-    background-color: var(--background-action-high-warning-hover) !important;
-}
+  }
+  

--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -10,8 +10,8 @@
         {% dsfr_css %}
         {% dsfr_favicon %}
 
+        <link rel="stylesheet" href="{% static "css/gsl.css" %}">
         {% block extra_css %}
-            <link rel="stylesheet" href="{% static "css/gsl.css" %}">
         {% endblock extra_css %}
 
         {% block title %}

--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -1,0 +1,51 @@
+
+.success-color {
+  color: var(--text-default-success);
+}
+
+.refuse-color {
+  color: var(--text-default-error);
+}
+
+.processing-color {
+  color: var(--text-mention-grey);
+}
+
+.set-unanswered-color {
+  color: var(--text-default-warning);
+}
+
+.confirmation-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1em;
+}
+
+/* buttons */
+
+.accept-button{
+  background-color: var(--background-action-high-success);
+  color: var(--background-alt-blue-france)
+}
+
+.accept-button:hover{
+  background-color: var(--background-action-high-success-hover) !important;
+}
+
+.refuse-button{
+  background-color: var(--background-action-high-error);
+  color: var(--background-alt-blue-france)
+}
+
+.refuse-button:hover{
+  background-color: var(--background-action-high-error-hover) !important;
+}
+
+.set-unanswered-button{
+  background-color: var(--background-action-high-warning);
+  color: var(--background-alt-blue-france)
+}
+
+.set-unanswered-button:hover{
+  background-color: var(--background-action-high-warning-hover) !important;
+}

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -5,6 +5,10 @@
     {% dsfr_breadcrumb breadcrumb_dict %}
 {% endblock breadcrumb %}
 
+{% block extra_css %}
+    <link rel="stylesheet" href="{% static 'css/simulation_detail.css' %}">
+{% endblock extra_css %}
+
 {% block content %}
     <h1>
         {{ title }}

--- a/gsl_simulation/templates/gsl_simulation/simulation_list.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_list.html
@@ -6,7 +6,6 @@
 {% endblock breadcrumb %}
 
 {% block extra_css %}
-    {{ block.super }}
     <link rel="stylesheet" href="{% static 'css/simulation_list.css' %}">
 {% endblock extra_css %}
 

--- a/gsl_simulation/templates/includes/_enveloppe_summary.html
+++ b/gsl_simulation/templates/includes/_enveloppe_summary.html
@@ -3,6 +3,7 @@
 {% block extra_css %}
     <link rel="stylesheet" href="{% static 'css/enveloppe_summary.css' %}">
 {% endblock extra_css %}
+
 <div class="fr-table--lg enveloppe-summary">
     <table>
         <thead>


### PR DESCRIPTION
## 🌮 Objectif

Ne pas importer du css pour rien (ex: si je ne suis pas connecté)

## 🔍 Liste des modifications

- création d'un fichier `simulation_detail.css`
- retravail du block `extra_css`