### PR TITLE
Correctif sur les taux => empêcher des erreurs en normant et vérifiant les valeurs

### DIFF
--- a/gsl_projet/services.py
+++ b/gsl_projet/services.py
@@ -108,3 +108,8 @@ class ProjetService:
             return Decimal(0)
         except ZeroDivisionError:
             return Decimal(0)
+
+    @classmethod
+    def validate_taux(cls, taux: float | Decimal) -> None:
+        if type(taux) not in [float, Decimal, int] or taux < 0 or taux > 100:
+            raise ValueError(f"Taux {taux} must be between 0 and 100")

--- a/gsl_projet/services.py
+++ b/gsl_projet/services.py
@@ -98,11 +98,13 @@ class ProjetService:
     def compute_taux_from_montant(
         cls, projet: Projet, new_montant: float | Decimal
     ) -> Decimal:
-        new_taux = (
-            round(
-                (Decimal(new_montant) / Decimal(projet.assiette_or_cout_total)) * 100, 2
+        try:
+            new_taux = round(
+                (Decimal(new_montant) / Decimal(projet.assiette_or_cout_total)) * 100,
+                2,
             )
-            if projet.assiette_or_cout_total
-            else Decimal(0)
-        )
-        return new_taux
+            return max(min(new_taux, Decimal(100)), Decimal(0))
+        except TypeError:
+            return Decimal(0)
+        except ZeroDivisionError:
+            return Decimal(0)

--- a/gsl_projet/tests/test_services.py
+++ b/gsl_projet/tests/test_services.py
@@ -259,7 +259,7 @@ def test_compute_taux_from_montant_with_projet_without_finance_cout_total():
     ),
 )
 @pytest.mark.django_db
-def test_compute_taux_from_montant_with_projet_without_assiette(
+def test_compute_taux_from_montant_with_various_assiettes(
     assiette, montant, expected_taux
 ):
     projet = ProjetFactory(assiette=assiette)

--- a/gsl_projet/tests/test_services.py
+++ b/gsl_projet/tests/test_services.py
@@ -1,4 +1,5 @@
 from datetime import UTC
+from decimal import Decimal
 
 import pytest
 from django.utils import timezone
@@ -242,6 +243,28 @@ def test_compute_taux_from_montant_with_projet_without_finance_cout_total():
     projet = ProjetFactory()
     taux = ProjetService.compute_taux_from_montant(projet, 10_000)
     assert taux == 0
+
+
+@pytest.mark.parametrize(
+    "montant, assiette, expected_taux",
+    (
+        (10_000, 30_000, 33.33),
+        (10_000, 0, 0),
+        (10_000, 10_000, 100),
+        (100_000, 10_000, 100),
+        (10_000, -3_000, 0),
+        (0, 0, 0),
+        (1_000, None, 0),
+        (None, 4_000, 0),
+    ),
+)
+@pytest.mark.django_db
+def test_compute_taux_from_montant_with_projet_without_assiette(
+    assiette, montant, expected_taux
+):
+    projet = ProjetFactory(assiette=assiette)
+    taux = ProjetService.compute_taux_from_montant(projet, montant)
+    assert taux == round(Decimal(expected_taux), 2)
 
 
 def test_get_projet_status():

--- a/gsl_projet/tests/test_services.py
+++ b/gsl_projet/tests/test_services.py
@@ -282,3 +282,23 @@ def test_get_projet_status():
 
     dossier_unknown = Dossier(ds_state="unknown_state")
     assert ProjetService.get_projet_status(dossier_unknown) is None
+
+
+@pytest.mark.parametrize(
+    "taux, should_raise_exception",
+    [
+        (50, False),
+        (0, False),
+        (100, False),
+        (-1, True),
+        (101, True),
+        (None, True),
+        ("invalid", True),
+    ],
+)
+def test_validate_taux(taux, should_raise_exception):
+    if should_raise_exception:
+        with pytest.raises(ValueError, match=f"Taux {taux} must be between 0 and 100"):
+            ProjetService.validate_taux(taux)
+    else:
+        ProjetService.validate_taux(taux)

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -76,6 +76,7 @@ def patch_taux_simulation_projet(request, pk):
     data = QueryDict(request.body)
 
     new_taux = replace_comma_by_dot(data.get("taux"))
+    ProjetService.validate_taux(new_taux)
     SimulationProjetService.update_taux(simulation_projet, new_taux)
     return redirect_to_simulation_projet(request, simulation_projet)
 


### PR DESCRIPTION
## 🌮 Objectif

Gérer les erreurs potentielles pour ne pas faire crasher l'app

[Erreur Sentry liée](https://sentry.incubateur.net/organizations/betagouv/issues/153239/?environment=staging&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0)

## 🔍 Liste des modifications

- on ajoute un plafond et un plancher à un taux au moment de le compute depuis un montant
- on valide avant d'update un taux depuis la page simulation