### PR TITLE
Intégration des impacts d'un retour à "Accepté provisoirement" d'un projet dans une simulation

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -179,38 +179,6 @@ ul.no-list-style li {
     padding: 1rem max(calc((100vw - 1200px) / 2), 1.5rem);
 }
 
-.gsl-projet-table__select {
-    text-align: right;
-    padding: 4px;
-    padding-right: 20px;
-    background-position: calc(100% - 4px) 50%;
-    box-shadow: none
-}
-
-.gsl-projet-table__input-wrap {
-    position: relative;
-    display: inline-block;
-}
-.gsl-projet-table__input-wrap > input {
-    text-align: right;
-    padding: 4px;
-    padding-right: 12px;
-    box-shadow: none
-}
-
-.gsl-projet-table__input-symbol {
-    position: absolute;
-    top: 50%;
-    right: 4px;
-    transform: translateY(-50%);
-    pointer-events: none; /* Ne pas interférer avec les clics */
-    color: #333;
-}
-
-.gsl-projet-table__rate > input {
-    padding-right: 16px;
-}
-
 .fr-table__footer {
     justify-content: center;
 }

--- a/gsl_projet/services.py
+++ b/gsl_projet/services.py
@@ -60,12 +60,6 @@ class ProjetService:
             "dossier_ds__demande_montant__sum"
         ]
 
-    @classmethod
-    def get_total_amount_granted(cls, projet_qs: QuerySet):
-        return projet_qs.aggregate(Sum("simulationprojet__montant"))[
-            "simulationprojet__montant__sum"
-        ]
-
     PORTEUR_MAPPINGS = {
         "EPCI": NaturePorteurProjet.EPCI_NATURES,
         "Communes": NaturePorteurProjet.COMMUNE_NATURES,

--- a/gsl_projet/tests/test_services.py
+++ b/gsl_projet/tests/test_services.py
@@ -116,16 +116,6 @@ def test_get_same_total_cost_even_if_there_is_other_projets(
     assert ProjetService.get_total_cost(qs) == 100_000
 
 
-@pytest.mark.django_db
-def test_get_total_amount_granted(simulation):
-    SimulationProjetFactory(simulation=simulation, montant=1000)
-    SimulationProjetFactory(simulation=simulation, montant=2000)
-    SimulationProjetFactory(montant=4000)
-
-    qs = Projet.objects.filter(simulationprojet__simulation=simulation).all()
-    assert ProjetService.get_total_amount_granted(qs) == 3000
-
-
 @pytest.fixture
 def projets_with_dossier_ds__demande_montant_not_in_simulation() -> None:
     for amount in (10_000, 2_000):

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -71,6 +71,17 @@ class SimulationProjetService:
         ):
             return cls._set_back_to_processing(simulation_projet)
 
+        if (
+            new_status == SimulationProjet.STATUS_PROVISOIRE
+            and simulation_projet.status
+            in (
+                SimulationProjet.STATUS_ACCEPTED,
+                SimulationProjet.STATUS_REFUSED,
+                SimulationProjet.STATUS_DISMISSED,
+            )
+        ):
+            cls._set_back_to_processing(simulation_projet)
+
         simulation_projet.status = new_status
         simulation_projet.save()
         return simulation_projet

--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -1,3 +1,39 @@
+/* table */
+.gsl-projet-table__select {
+  text-align: right;
+  padding: 4px;
+  padding-right: 20px;
+  background-position: calc(100% - 4px) 50%;
+  box-shadow: none
+}
+
+.gsl-projet-table__input-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.gsl-projet-table__input-wrap > input {
+  text-align: right;
+  padding: 4px;
+  padding-right: 12px;
+  /* box-shadow: none */
+}
+
+.gsl-projet-table__input-symbol {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  pointer-events: none; /* Ne pas interférer avec les clics */
+  color: #333;
+}
+
+.gsl-projet-table__rate > input {
+  padding-right: 16px;
+}
+
+
+/* colors */
 
 .success-color {
   color: var(--text-default-success);
@@ -14,6 +50,8 @@
 .dismiss-color {
   color: var(--text-default-warning);
 }
+
+/* modal */
 
 .confirmation-modal-footer {
   display: flex;
@@ -41,11 +79,46 @@
   background-color: var(--background-action-high-error-hover) !important;
 }
 
-.dismiss-button-button{
+.dismiss-button{
   background-color: var(--background-action-high-warning);
   color: var(--background-alt-blue-france)
 }
 
-.dismiss-button-button:hover{
+.dismiss-button:hover{
   background-color: var(--background-action-high-warning-hover) !important;
+}
+
+/* status select */
+
+#status-select {
+  font-weight: bold;
+}
+
+#status-select:has(> option[value="valid"]:checked){
+  color: var(--text-default-success)
+}
+
+#status-select:has(> option[value="cancelled"]:checked){
+  color: var(--text-default-error)
+}
+
+#status-select:has(> option[value="provisoire"]:checked){
+  color: var(--text-default-info)
+}
+
+/* inputs */
+
+.input-status-color-valid{
+  background-color: var(--background-alt-green-emeraude);
+  box-shadow: inset 0 -2px 0 0 var(--background-action-high-success)
+}
+
+.input-status-color-provisoire{
+  background-color: var(--text-inverted-blue-ecume);
+  box-shadow: inset 0 -2px 0 0 var(--border-action-high-info)
+}
+
+.fr-input:disabled.input-status-color-cancelled {
+  background-color: var(--background-alt-orange-terre-battue);
+  box-shadow: inset 0 -2px 0 0 var(--border-plain-error)
 }

--- a/gsl_simulation/static/js/simulationProjetStatusConfirmation.js
+++ b/gsl_simulation/static/js/simulationProjetStatusConfirmation.js
@@ -18,7 +18,7 @@ STATUS_TO_MODAL_ID = {
 
 STATUS_TO_FRENCH_WORD = {
     "valid": "validé",
-    "cancelled": "annulé",
+    "cancelled": "refusé",
     "dismissed": "classé sans suite",
 }
 
@@ -29,10 +29,10 @@ function mustOpenConfirmationModal(newValue, originalValue) {
     return false;
 }
 
-function replaceProcessingModalContentText(originalValue, modalContentId) {
-    processingConfirmationModalContent = document.getElementById(modalContentId)
-    const newText = processingConfirmationModalContent.innerHTML.replace("TO_REPLACE", STATUS_TO_FRENCH_WORD[originalValue])
-    processingConfirmationModalContent.innerHTML = newText
+function replaceInitialStatusModalContentText(originalValue, modalContentId) {
+    confirmationModalContent = document.getElementById(modalContentId)
+    const newText = STATUS_TO_FRENCH_WORD[originalValue]
+    confirmationModalContent.querySelector(".initial-status").innerHTML= newText
 }
 
 function handleStatusChange(select, originalValue) {
@@ -51,7 +51,7 @@ function showConfirmationModal(select, originalValue) {
     }
     selectedElement = select;
     if ([PROCESSING, PROVISOIRE].includes(status)) {
-        replaceProcessingModalContentText(originalValue, `${status}-confirmation-modal-content`)
+        replaceInitialStatusModalContentText(originalValue, `${status}-confirmation-modal-content`)
     }
 
     modal = document.getElementById(modalId)

--- a/gsl_simulation/static/js/simulationProjetStatusConfirmation.js
+++ b/gsl_simulation/static/js/simulationProjetStatusConfirmation.js
@@ -4,6 +4,7 @@ const VALID = "valid";
 const CANCELLED = "cancelled";
 const DISMISSED = "dismissed";
 const PROCESSING = "draft";
+const PROVISOIRE = "provisoire";
 
 const STATUSES_WITH_OTHER_SIMULATION_IMPACT = [VALID, CANCELLED, DISMISSED];
 
@@ -12,6 +13,7 @@ STATUS_TO_MODAL_ID = {
     "cancelled": "refuse-confirmation-modal",
     "draft": "processing-confirmation-modal",
     "dismissed": "dismiss-confirmation-modal",
+    "provisoire": "provisoire-confirmation-modal",
 }
 
 STATUS_TO_FRENCH_WORD = {
@@ -23,11 +25,12 @@ STATUS_TO_FRENCH_WORD = {
 function mustOpenConfirmationModal(newValue, originalValue) {
     if (STATUSES_WITH_OTHER_SIMULATION_IMPACT.includes(newValue)) return true;
     if (newValue === PROCESSING && STATUSES_WITH_OTHER_SIMULATION_IMPACT.includes(originalValue)) return true;
+    if (newValue === PROVISOIRE && STATUSES_WITH_OTHER_SIMULATION_IMPACT.includes(originalValue)) return true;
     return false;
 }
 
-function replaceProcessingModalContentText(originalValue) {
-    processingConfirmationModalContent = document.getElementById("processing-confirmation-modal-content")
+function replaceProcessingModalContentText(originalValue, modalContentId) {
+    processingConfirmationModalContent = document.getElementById(modalContentId)
     const newText = processingConfirmationModalContent.innerHTML.replace("TO_REPLACE", STATUS_TO_FRENCH_WORD[originalValue])
     processingConfirmationModalContent.innerHTML = newText
 }
@@ -47,8 +50,8 @@ function showConfirmationModal(select, originalValue) {
         return
     }
     selectedElement = select;
-    if (status === PROCESSING) {
-        replaceProcessingModalContentText(originalValue)
+    if ([PROCESSING, PROVISOIRE].includes(status)) {
+        replaceProcessingModalContentText(originalValue, `${status}-confirmation-modal-content`)
     }
 
     modal = document.getElementById(modalId)

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -90,6 +90,7 @@
     {% include "includes/modals/_refuse_confirmation_modal.html" %}
     {% include "includes/modals/_dismiss_confirmation_modal.html" %}
     {% include "includes/modals/_go_back_to_processing_modal.html" %}
+    {% include "includes/modals/_go_back_to_provisoire_modal.html" %}
 {% endblock modal %}
 
 {% block extra_js %}

--- a/gsl_simulation/templates/includes/_montant_form.html
+++ b/gsl_simulation/templates/includes/_montant_form.html
@@ -6,7 +6,7 @@
         <input name="montant"
                type="text"
                inputmode="numeric"
-               class="fr-input input-simulation-projet-{{ simu.pk }}"
+               class="fr-input input-simulation-projet-{{ simu.pk }} input-status-color-{{ simu.status }}"
                hx-patch="{% url 'simulation:patch-simulation-projet-montant' simu.id %}"
                hx-disabled-elt=".input-simulation-projet-{{ simu.pk }}"
                hx-trigger="change, keyup[key=='Enter']"

--- a/gsl_simulation/templates/includes/_status_form.html
+++ b/gsl_simulation/templates/includes/_status_form.html
@@ -5,7 +5,7 @@
       hx-trigger="status-confirmed"
       hx-disabled-elt="find .input-simulation-projet-{{ simu.pk }}">
     {% csrf_token %}
-    <select class="fr-select gsl-projet-table__select input-simulation-projet-{{ simu.pk }}"
+    <select class="fr-select gsl-projet-table__select input-simulation-projet-{{ simu.pk }} input-status-select-{{ simu.status }}"
             id="status-select"
             name="status"
             onchange="handleStatusChange(this, '{{ simu.status }}')">

--- a/gsl_simulation/templates/includes/modals/_accept_confirmation_modal.html
+++ b/gsl_simulation/templates/includes/modals/_accept_confirmation_modal.html
@@ -13,7 +13,7 @@
                         </button>
                     </div>
                     <div class="fr-modal__content">
-                        <h1 id="modal-title" class="fr-modal__title success-color">
+                        <h1 class="fr-modal__title success-color">
                             <span class="fr-icon-checkbox-fill fr-icon--lg" aria-hidden="true"></span> Accepter le financement du projet
                         </h1>
                         <p>

--- a/gsl_simulation/templates/includes/modals/_dismiss_confirmation_modal.html
+++ b/gsl_simulation/templates/includes/modals/_dismiss_confirmation_modal.html
@@ -13,7 +13,7 @@
                         </button>
                     </div>
                     <div class="fr-modal__content">
-                        <h1 id="modal-title" class="fr-modal__title dismiss-color">
+                        <h1 class="fr-modal__title dismiss-color">
                             <span class="fr-icon-checkbox-fill fr-icon--lg" aria-hidden="true"></span> Classer sans suite la demande de financement
                         </h1>
                         <p>

--- a/gsl_simulation/templates/includes/modals/_go_back_to_processing_modal.html
+++ b/gsl_simulation/templates/includes/modals/_go_back_to_processing_modal.html
@@ -13,11 +13,11 @@
                         </button>
                     </div>
                     <div class="fr-modal__content">
-                        <h1 id="modal-title" class="fr-modal__title processing-color">
+                        <h1 class="fr-modal__title processing-color">
                             <span class="fr-icon-draft-fill fr-icon--lg" aria-hidden="true"></span> Revenir au statut “En traitement”
                         </h1>
-                        <p id="processing-confirmation-modal-content">
-                            Ce projet TO_REPLACE va être remis en traitement dans toutes les simulations dans lesquelles il a été ajouté.
+                        <p id="draft-confirmation-modal-content">
+                            Ce projet <span class="initial-status"></span> va être remis en traitement dans toutes les simulations dans lesquelles il a été ajouté.
                             Il n'apparaîtra plus dans la programmation officielle {{ enveloppe.type }} {{ simulation_year }}.
                         </p>
                         <p>

--- a/gsl_simulation/templates/includes/modals/_go_back_to_provisoire_modal.html
+++ b/gsl_simulation/templates/includes/modals/_go_back_to_provisoire_modal.html
@@ -1,0 +1,40 @@
+<dialog id="provisoire-confirmation-modal" class="fr-modal">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button aria-controls="modal"
+                                title="Fermer"
+                                type="button"
+                                class="fr-btn--close fr-btn"
+                                onClick="closeModal('provisoire-confirmation-modal')">
+                            Fermer
+                        </button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="modal-title" class="fr-modal__title processing-color">
+                            <span class="fr-icon-draft-fill fr-icon--lg" aria-hidden="true"></span> Revenir au statut “Accepté provisoirement”
+                        </h1>
+                        <p id="provisoire-confirmation-modal-content">
+                            Ce projet TO_REPLACE va être remis en traitement dans toutes les autres simulations dans lesquelles il a été ajouté.
+                            Il n'apparaîtra plus dans la programmation officielle {{ enveloppe.type }} {{ simulation_year }}.
+                        </p>
+                        <p>
+                            Êtes-vous sûr(e) d'accepter provisoirement le projet ?
+                        </p>
+                    </div>
+                    <div class="fr-modal__footer confirmation-modal-footer">
+                        <button class="fr-btn fr-btn--secondary"
+                                onclick="closeModal('provisoire-confirmation-modal')">
+                            Annuler
+                        </button>
+                        <button class="fr-btn fr-btn--primary" id="confirmChange">
+                            Oui
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/gsl_simulation/templates/includes/modals/_go_back_to_provisoire_modal.html
+++ b/gsl_simulation/templates/includes/modals/_go_back_to_provisoire_modal.html
@@ -13,11 +13,11 @@
                         </button>
                     </div>
                     <div class="fr-modal__content">
-                        <h1 id="modal-title" class="fr-modal__title processing-color">
+                        <h1 class="fr-modal__title processing-color">
                             <span class="fr-icon-draft-fill fr-icon--lg" aria-hidden="true"></span> Revenir au statut “Accepté provisoirement”
                         </h1>
                         <p id="provisoire-confirmation-modal-content">
-                            Ce projet TO_REPLACE va être remis en traitement dans toutes les autres simulations dans lesquelles il a été ajouté.
+                            Ce projet <span class="initial-status"></span> va être remis en traitement dans toutes les autres simulations dans lesquelles il a été ajouté.
                             Il n'apparaîtra plus dans la programmation officielle {{ enveloppe.type }} {{ simulation_year }}.
                         </p>
                         <p>

--- a/gsl_simulation/templates/includes/modals/_refuse_confirmation_modal.html
+++ b/gsl_simulation/templates/includes/modals/_refuse_confirmation_modal.html
@@ -13,7 +13,7 @@
                         </button>
                     </div>
                     <div class="fr-modal__content">
-                        <h1 id="modal-title" class="fr-modal__title refuse-color">
+                        <h1 class="fr-modal__title refuse-color">
                             <span class="fr-icon-checkbox-fill fr-icon--lg" aria-hidden="true"></span> Refuser le financement du projet
                         </h1>
                         <p>

--- a/gsl_simulation/tests/services/test_simulation_services.py
+++ b/gsl_simulation/tests/services/test_simulation_services.py
@@ -13,9 +13,10 @@ from gsl_programmation.tests.factories import (
     DetrEnveloppeFactory,
     DsilEnveloppeFactory,
 )
-from gsl_simulation.models import Simulation
+from gsl_projet.models import Projet
+from gsl_simulation.models import Simulation, SimulationProjet
 from gsl_simulation.services.simulation_service import SimulationService
-from gsl_simulation.tests.factories import SimulationFactory
+from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
 
 
 @pytest.mark.django_db
@@ -123,3 +124,49 @@ def test_slug_generation():
 
     slug = SimulationService.get_slug("Other test 1")
     assert slug == "other-test-1-1"
+
+
+@pytest.fixture
+def simulation():
+    return SimulationFactory()
+
+
+@pytest.mark.django_db
+def test_get_total_amount_granted(simulation):
+    # must be included
+    accepted_projet = SimulationProjetFactory(
+        simulation=simulation, status=SimulationProjet.STATUS_ACCEPTED, montant=1_200
+    )
+    provisionally_accepted_projet = SimulationProjetFactory(
+        simulation=simulation, status=SimulationProjet.STATUS_PROVISOIRE, montant=2_300
+    )
+
+    # must not be included
+    SimulationProjetFactory(
+        simulation=simulation, status=SimulationProjet.STATUS_REFUSED, montant=3_000
+    )
+    SimulationProjetFactory(
+        simulation=simulation, status=SimulationProjet.STATUS_DISMISSED, montant=4_000
+    )
+    SimulationProjetFactory(
+        simulation=simulation, status=SimulationProjet.STATUS_PROCESSING, montant=5_000
+    )
+    SimulationProjetFactory(
+        projet=accepted_projet.projet,
+        status=SimulationProjet.STATUS_ACCEPTED,
+        montant=6_000,
+    )
+    SimulationProjetFactory(
+        projet=provisionally_accepted_projet.projet,
+        status=SimulationProjet.STATUS_PROVISOIRE,
+        montant=8_000,
+    )
+
+    qs = Projet.objects.filter(simulationprojet__simulation=simulation)
+    assert SimulationService.get_total_amount_granted(qs, simulation) == 3_500
+
+
+@pytest.mark.django_db
+def test_get_total_amount_granted_with_empty_qs(simulation):
+    qs = Projet.objects.all()
+    assert SimulationService.get_total_amount_granted(qs, simulation) == 0

--- a/gsl_simulation/tests/services/test_simulation_services.py
+++ b/gsl_simulation/tests/services/test_simulation_services.py
@@ -142,6 +142,7 @@ def test_get_total_amount_granted(simulation):
     )
 
     # must not be included
+    ## other statuses
     SimulationProjetFactory(
         simulation=simulation, status=SimulationProjet.STATUS_REFUSED, montant=3_000
     )
@@ -151,6 +152,7 @@ def test_get_total_amount_granted(simulation):
     SimulationProjetFactory(
         simulation=simulation, status=SimulationProjet.STATUS_PROCESSING, montant=5_000
     )
+    ## not in simulation
     SimulationProjetFactory(
         projet=accepted_projet.projet,
         status=SimulationProjet.STATUS_ACCEPTED,
@@ -163,7 +165,7 @@ def test_get_total_amount_granted(simulation):
     )
 
     qs = Projet.objects.filter(simulationprojet__simulation=simulation)
-    assert SimulationService.get_total_amount_granted(qs, simulation) == 3_500
+    assert SimulationService.get_total_amount_granted(qs, simulation) == 1_200 + 2_300
 
 
 @pytest.mark.django_db

--- a/gsl_simulation/tests/test_views.py
+++ b/gsl_simulation/tests/test_views.py
@@ -568,13 +568,11 @@ def test_patch_status_simulation_projet_with_refused_value(
         headers={"HX-Request": "true"},
     )
 
-    updated_simulation_projet = SimulationProjet.objects.select_related("projet").get(
-        id=simulation_projet.id
-    )
-    projet = Projet.objects.get(id=updated_simulation_projet.projet.id)
+    simulation_projet.refresh_from_db()
+    projet = Projet.objects.get(id=simulation_projet.projet.id)
 
     assert response.status_code == 200
-    assert updated_simulation_projet.status == SimulationProjet.STATUS_REFUSED
+    assert simulation_projet.status == SimulationProjet.STATUS_REFUSED
     assert projet.status == Projet.STATUS_REFUSED
     assert "0 projet validé" in response.content.decode()
     assert "1 projet refusé" in response.content.decode()

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -9,6 +9,7 @@ from gsl_simulation.models import SimulationProjet
 from gsl_simulation.services.simulation_projet_service import (
     SimulationProjetService,
 )
+from gsl_simulation.services.simulation_service import SimulationService
 from gsl_simulation.utils import replace_comma_by_dot
 from gsl_simulation.views.decorators import (
     exception_handler_decorator,
@@ -43,7 +44,9 @@ def redirect_to_simulation_projet(request, simulation_projet):
             filter_params,
         )
 
-        total_amount_granted = ProjetService.get_total_amount_granted(filtered_projets)
+        total_amount_granted = SimulationService.get_total_amount_granted(
+            filtered_projets, simulation_projet.simulation
+        )
 
         return render(
             request,

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -153,7 +153,9 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
         context["status_summary"] = simulation.get_projet_status_summary()
         context["total_cost"] = ProjetService.get_total_cost(qs)
         context["total_amount_asked"] = ProjetService.get_total_amount_asked(qs)
-        context["total_amount_granted"] = ProjetService.get_total_amount_granted(qs)
+        context["total_amount_granted"] = SimulationService.get_total_amount_granted(
+            qs, simulation
+        )
         context["available_states"] = SimulationProjet.STATUS_CHOICES
         context["filter_params"] = self.request.GET.urlencode()
         context["enveloppe"] = self._get_enveloppe_data(simulation)


### PR DESCRIPTION
## 🌮 Objectif

Les impacts d'un retour à "Accepté provisoirement" d'un projet sont les suivants :
- Tous les projets de simulations liés à ce projet des autres simulations repassent "En traitement"
- Le projet n'est plus comptabilisé dans l'enveloppe associée
- Le projet n'est plus comptabilisé dans les badges associés à une simulation
- Le montant prévisionnel accordé est comptabilisé dans l'en-tête de la colonne de CETTE simulation

## 🔍 Liste des modifications

- L'ouverture de la modale de confirmation de changement de statut est appelé sur lorsque le statut d'origine est "Accepté", "Refusé" ou "Classé sans suite"
- On s'appuie sur la transition `set_back_status_to_processing`

## 🖼️ Images

![image](https://github.com/user-attachments/assets/b8f11c5b-4084-4c05-a56f-0c22c09ca9fb)
