### PR TITLE
Ajout des couleurs dans les champs montant et status

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -179,38 +179,6 @@ ul.no-list-style li {
     padding: 1rem max(calc((100vw - 1200px) / 2), 1.5rem);
 }
 
-.gsl-projet-table__select {
-    text-align: right;
-    padding: 4px;
-    padding-right: 20px;
-    background-position: calc(100% - 4px) 50%;
-    box-shadow: none
-}
-
-.gsl-projet-table__input-wrap {
-    position: relative;
-    display: inline-block;
-}
-.gsl-projet-table__input-wrap > input {
-    text-align: right;
-    padding: 4px;
-    padding-right: 12px;
-    box-shadow: none
-}
-
-.gsl-projet-table__input-symbol {
-    position: absolute;
-    top: 50%;
-    right: 4px;
-    transform: translateY(-50%);
-    pointer-events: none; /* Ne pas interférer avec les clics */
-    color: #333;
-}
-
-.gsl-projet-table__rate > input {
-    padding-right: 16px;
-}
-
 .fr-table__footer {
     justify-content: center;
 }

--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -1,3 +1,39 @@
+/* table */
+.gsl-projet-table__select {
+  text-align: right;
+  padding: 4px;
+  padding-right: 20px;
+  background-position: calc(100% - 4px) 50%;
+  box-shadow: none
+}
+
+.gsl-projet-table__input-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.gsl-projet-table__input-wrap > input {
+  text-align: right;
+  padding: 4px;
+  padding-right: 12px;
+  /* box-shadow: none */
+}
+
+.gsl-projet-table__input-symbol {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  pointer-events: none; /* Ne pas interférer avec les clics */
+  color: #333;
+}
+
+.gsl-projet-table__rate > input {
+  padding-right: 16px;
+}
+
+
+/* colors */
 
 .success-color {
   color: var(--text-default-success);
@@ -14,6 +50,8 @@
 .dismiss-color {
   color: var(--text-default-warning);
 }
+
+/* modal */
 
 .confirmation-modal-footer {
   display: flex;
@@ -66,4 +104,21 @@
 
 #status-select:has(> option[value="provisoire"]:checked){
   color: var(--text-default-info)
+}
+
+/* inputs */
+
+.input-status-color-valid{
+  background-color: var(--background-alt-green-emeraude);
+  box-shadow: inset 0 -2px 0 0 var(--background-action-high-success)
+}
+
+.input-status-color-provisoire{
+  background-color: var(--text-inverted-blue-ecume);
+  box-shadow: inset 0 -2px 0 0 var(--border-action-high-info)
+}
+
+.fr-input:disabled.input-status-color-cancelled {
+  background-color: var(--background-alt-orange-terre-battue);
+  box-shadow: inset 0 -2px 0 0 var(--border-plain-error)
 }

--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -41,11 +41,29 @@
   background-color: var(--background-action-high-error-hover) !important;
 }
 
-.dismiss-button-button{
+.dismiss-button{
   background-color: var(--background-action-high-warning);
   color: var(--background-alt-blue-france)
 }
 
-.dismiss-button-button:hover{
+.dismiss-button:hover{
   background-color: var(--background-action-high-warning-hover) !important;
+}
+
+/* status select */
+
+#status-select {
+  font-weight: bold;
+}
+
+#status-select:has(> option[value="valid"]:checked){
+  color: var(--text-default-success)
+}
+
+#status-select:has(> option[value="cancelled"]:checked){
+  color: var(--text-default-error)
+}
+
+#status-select:has(> option[value="provisoire"]:checked){
+  color: var(--text-default-info)
 }

--- a/gsl_simulation/templates/includes/_montant_form.html
+++ b/gsl_simulation/templates/includes/_montant_form.html
@@ -6,7 +6,7 @@
         <input name="montant"
                type="text"
                inputmode="numeric"
-               class="fr-input input-simulation-projet-{{ simu.pk }}"
+               class="fr-input input-simulation-projet-{{ simu.pk }} input-status-color-{{ simu.status }}"
                hx-patch="{% url 'simulation:patch-simulation-projet-montant' simu.id %}"
                hx-disabled-elt=".input-simulation-projet-{{ simu.pk }}"
                hx-trigger="change, keyup[key=='Enter']"

--- a/gsl_simulation/templates/includes/_status_form.html
+++ b/gsl_simulation/templates/includes/_status_form.html
@@ -5,7 +5,7 @@
       hx-trigger="status-confirmed"
       hx-disabled-elt="find .input-simulation-projet-{{ simu.pk }}">
     {% csrf_token %}
-    <select class="fr-select gsl-projet-table__select input-simulation-projet-{{ simu.pk }}"
+    <select class="fr-select gsl-projet-table__select input-simulation-projet-{{ simu.pk }} input-status-select-{{ simu.status }}"
             id="status-select"
             name="status"
             onchange="handleStatusChange(this, '{{ simu.status }}')">


### PR DESCRIPTION
## 🌮 Objectif

- Ajout de bleu pour les provisoires
- Ajout de vert pour les acceptés
- Ajout de rouge pour les refusés

## 🔍 Liste des modifications

- Bonus, on mets les classes spécifiques de la simulation dans le css adéquate

## 🖼️ Images

![image](https://github.com/user-attachments/assets/87d3b62f-d593-4304-9cf7-b8eacd26061d)