### PR TITLE
Mise à jour des dépendances

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: "v0.5.1"
+  rev: "v0.9.9"
   hooks:
     - id: ruff-format
     - id: ruff

--- a/gsl_demarches_simplifiees/management/commands/gql_get_demarche_dossiers.py
+++ b/gsl_demarches_simplifiees/management/commands/gql_get_demarche_dossiers.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
             print(f"----- #{index} -----")
             print(dossier)
 
-        message = f"Total: {index+1} dossier(s)"
+        message = f"Total: {index + 1} dossier(s)"
         print("=" * len(message))
         print(message)
         print("=" * len(message))

--- a/gsl_demarches_simplifiees/tests/test_save_ds_demarche.py
+++ b/gsl_demarches_simplifiees/tests/test_save_ds_demarche.py
@@ -87,9 +87,9 @@ def test_new_human_mapping_is_created_if_ds_label_is_unknown(
 
     save_field_mappings(demarche_data_without_dossier, demarche)
 
-    assert (
-        FieldMappingForHuman.objects.count() == 2
-    ), "Two human mappings should be created."
+    assert FieldMappingForHuman.objects.count() == 2, (
+        "Two human mappings should be created."
+    )
     assert FieldMappingForHuman.objects.filter(label="Commentaire libre").exists()
     assert FieldMappingForHuman.objects.filter(
         label="Un champ qui ne porte pas ce nom-là dans Django"
@@ -131,12 +131,12 @@ def test_new_human_mapping_is_created_if_ds_label_is_unknown(
         ).count()
         == 1
     )
-    assert (
-        FieldMappingForComputer.objects.count() == 13
-    ), "13 computer mappings should have been created."
-    assert (
-        FieldMappingForComputer.objects.exclude(django_field="").count() == 11
-    ), "Only 11 mappings should be associated with an existing field."
+    assert FieldMappingForComputer.objects.count() == 13, (
+        "13 computer mappings should have been created."
+    )
+    assert FieldMappingForComputer.objects.exclude(django_field="").count() == 11, (
+        "Only 11 mappings should be associated with an existing field."
+    )
 
 
 def test_existing_human_mapping_is_used_if_possible(

--- a/gsl_projet/tests/test_projet_manager.py
+++ b/gsl_projet/tests/test_projet_manager.py
@@ -121,9 +121,9 @@ def test_for_staff_user_with_perimetre(departement, projets):
 
     staff_user_projects = list(Projet.objects.for_user(staff_user_with_perimetre).all())
 
-    assert (
-        len(staff_user_projects) == 2
-    ), "We should only get projects within user’s perimeter, even staff"
+    assert len(staff_user_projects) == 2, (
+        "We should only get projects within user’s perimeter, even staff"
+    )
     assert projets[0] in staff_user_projects
     assert projets[1] in staff_user_projects
 
@@ -138,9 +138,9 @@ def test_for_super_user_with_perimetre(departement, projets):
         Projet.objects.for_user(superuser_user_with_perimetre).all()
     )
 
-    assert (
-        len(superuser_projects) == 2
-    ), "We should only get projects within user’s perimeter, even superuser"
+    assert len(superuser_projects) == 2, (
+        "We should only get projects within user’s perimeter, even superuser"
+    )
     assert projets[0] in superuser_projects
     assert projets[1] in superuser_projects
 
@@ -151,9 +151,9 @@ def test_for_normal_user_with_perimetre(departement, projets):
 
     user_projects = list(Projet.objects.for_user(user_with_perimetre).all())
 
-    assert (
-        len(user_projects) == 2
-    ), "We should only get projects within user’s perimeter"
+    assert len(user_projects) == 2, (
+        "We should only get projects within user’s perimeter"
+    )
     assert projets[0] in user_projects
     assert projets[1] in user_projects
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=dev --output-file=requirements-dev.txt pyproject.toml
 #
-amqp==5.2.0
+amqp==5.3.1
     # via kombu
 asgiref==3.8.1
     # via
@@ -21,7 +21,7 @@ celery==5.4.0
     #   django-celery-beat
     #   django-celery-results
     #   gsl (pyproject.toml)
-certifi==2024.8.30
+certifi==2025.1.31
     # via
     #   requests
     #   sentry-sdk
@@ -31,9 +31,9 @@ cfgv==3.4.0
     # via pre-commit
 chardet==5.2.0
     # via diff-cover
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   celery
     #   click-didyoumean
@@ -49,28 +49,27 @@ click-repl==0.3.0
     # via celery
 colorama==0.4.6
     # via djlint
-coverage[toml]==7.6.1
+coverage[toml]==7.6.12
     # via pytest-cov
 cron-descriptor==1.4.5
     # via django-celery-beat
-cryptography==43.0.3
+cryptography==44.0.2
     # via
     #   josepy
     #   mozilla-django-oidc
-    #   pyopenssl
-cssbeautifier==1.15.1
+cssbeautifier==1.15.4
     # via djlint
-decorator==5.1.1
+decorator==5.2.1
     # via ipython
-diff-cover==9.2.0
+diff-cover==9.2.3
     # via gsl (pyproject.toml)
 diff-match-patch==20241021
     # via django-import-export
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
-dj-database-url==2.2.0
+dj-database-url==2.3.0
     # via gsl (pyproject.toml)
-django==5.1.4
+django==5.1.7
     # via
     #   dj-database-url
     #   django-celery-beat
@@ -95,17 +94,17 @@ django-crispy-forms==2.3
     # via django-dsfr
 django-csp==3.8
     # via gsl (pyproject.toml)
-django-dsfr==2.0.0
+django-dsfr==2.2.0
     # via gsl (pyproject.toml)
 django-extensions==3.2.3
     # via gsl (pyproject.toml)
-django-filter==24.3
+django-filter==25.1
     # via gsl (pyproject.toml)
 django-fsm-2==4.0.0
     # via gsl (pyproject.toml)
-django-htmx==1.21.0
+django-htmx==1.22.0
     # via gsl (pyproject.toml)
-django-import-export==4.3.3
+django-import-export==4.3.7
     # via gsl (pyproject.toml)
 django-json-widget==2.0.1
     # via gsl (pyproject.toml)
@@ -113,11 +112,11 @@ django-query-counter==0.4.0
     # via gsl (pyproject.toml)
 django-referrer-policy==1.0
     # via gsl (pyproject.toml)
-django-timezone-field==7.0
+django-timezone-field==7.1
     # via django-celery-beat
 django-widget-tweaks==1.5.0
     # via django-dsfr
-djlint==1.36.3
+djlint==1.36.4
     # via gsl (pyproject.toml)
 editorconfig==0.17.0
     # via
@@ -127,29 +126,31 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.2.0
     # via stack-data
-factory-boy==3.3.1
+factory-boy==3.3.3
     # via gsl (pyproject.toml)
-faker==30.8.2
+faker==36.2.2
     # via factory-boy
-filelock==3.16.1
+filelock==3.17.0
     # via virtualenv
 gunicorn==23.0.0
     # via gsl (pyproject.toml)
-identify==2.6.1
+identify==2.6.8
     # via pre-commit
 idna==3.10
     # via requests
 iniconfig==2.0.0
     # via pytest
-ipython==8.31.0
+ipython==9.0.1
     # via gsl (pyproject.toml)
+ipython-pygments-lexers==1.1.1
+    # via ipython
 jedi==0.19.2
     # via ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via diff-cover
-josepy==1.14.0
+josepy==2.0.0
     # via mozilla-django-oidc
-jsbeautifier==1.15.1
+jsbeautifier==1.15.4
     # via
     #   cssbeautifier
     #   djlint
@@ -157,7 +158,7 @@ json5==0.10.0
     # via djlint
 kombu==5.4.2
     # via celery
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
 matplotlib-inline==0.1.7
     # via ipython
@@ -165,7 +166,7 @@ mozilla-django-oidc==4.0.1
     # via gsl (pyproject.toml)
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   build
     #   gunicorn
@@ -184,15 +185,15 @@ pluggy==1.5.0
     # via
     #   diff-cover
     #   pytest
-pre-commit==3.8.0
+pre-commit==4.1.0
     # via gsl (pyproject.toml)
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   click-repl
     #   ipython
-psycopg[binary]==3.2.4
+psycopg[binary]==3.2.5
     # via gsl (pyproject.toml)
-psycopg-binary==3.2.4
+psycopg-binary==3.2.5
     # via psycopg
 ptyprocess==0.7.0
     # via pexpect
@@ -204,22 +205,21 @@ pygments==2.19.1
     # via
     #   diff-cover
     #   ipython
-pyopenssl==24.2.1
-    # via josepy
+    #   ipython-pygments-lexers
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==8.3.3
+pytest==8.3.5
     # via
     #   gsl (pyproject.toml)
     #   pytest-cov
     #   pytest-django
     #   pytest-ruff
     #   pytest-xdist
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via gsl (pyproject.toml)
-pytest-django==4.9.0
+pytest-django==4.10.0
     # via gsl (pyproject.toml)
 pytest-ruff==0.4.1
     # via gsl (pyproject.toml)
@@ -230,7 +230,6 @@ python-crontab==3.2.0
 python-dateutil==2.9.0.post0
     # via
     #   celery
-    #   faker
     #   python-crontab
 python-dotenv==1.0.1
     # via gsl (pyproject.toml)
@@ -238,7 +237,7 @@ pyyaml==6.0.2
     # via
     #   djlint
     #   pre-commit
-redis==5.1.0
+redis==5.2.1
     # via gsl (pyproject.toml)
 regex==2024.11.6
     # via djlint
@@ -246,22 +245,22 @@ requests==2.32.3
     # via
     #   django-dsfr
     #   mozilla-django-oidc
-ruff==0.6.8
+ruff==0.9.9
     # via
     #   gsl (pyproject.toml)
     #   pytest-ruff
-sentry-sdk==2.15.0
+sentry-sdk==2.22.0
     # via gsl (pyproject.toml)
-six==1.16.0
+six==1.17.0
     # via
     #   cssbeautifier
     #   jsbeautifier
     #   python-dateutil
-sqlparse==0.5.1
+sqlparse==0.5.3
     # via django
 stack-data==0.6.3
     # via ipython
-tablib==3.7.0
+tablib==3.8.0
     # via django-import-export
 tabulate==0.9.0
     # via django-query-counter
@@ -274,14 +273,14 @@ traitlets==5.14.3
 typing-extensions==4.12.2
     # via
     #   dj-database-url
-    #   faker
     #   psycopg
-tzdata==2024.2
+tzdata==2025.1
     # via
     #   celery
     #   django-celery-beat
+    #   faker
     #   kombu
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   requests
     #   sentry-sdk
@@ -290,13 +289,13 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.26.6
+virtualenv==20.29.2
     # via pre-commit
 wcwidth==0.2.13
     # via prompt-toolkit
 wheel==0.45.1
     # via pip-tools
-whitenoise==6.8.2
+whitenoise==6.9.0
     # via gsl (pyproject.toml)
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt pyproject.toml
 #
-amqp==5.2.0
+amqp==5.3.1
     # via kombu
 asgiref==3.8.1
     # via
@@ -19,15 +19,15 @@ celery==5.4.0
     #   django-celery-beat
     #   django-celery-results
     #   gsl (pyproject.toml)
-certifi==2024.8.30
+certifi==2025.1.31
     # via
     #   requests
     #   sentry-sdk
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   celery
     #   click-didyoumean
@@ -41,18 +41,17 @@ click-repl==0.3.0
     # via celery
 cron-descriptor==1.4.5
     # via django-celery-beat
-cryptography==43.0.3
+cryptography==44.0.2
     # via
     #   josepy
     #   mozilla-django-oidc
-    #   pyopenssl
-decorator==5.1.1
+decorator==5.2.1
     # via ipython
 diff-match-patch==20241021
     # via django-import-export
-dj-database-url==2.2.0
+dj-database-url==2.3.0
     # via gsl (pyproject.toml)
-django==5.1.4
+django==5.1.7
     # via
     #   dj-database-url
     #   django-celery-beat
@@ -77,23 +76,23 @@ django-crispy-forms==2.3
     # via django-dsfr
 django-csp==3.8
     # via gsl (pyproject.toml)
-django-dsfr==2.0.0
+django-dsfr==2.2.0
     # via gsl (pyproject.toml)
 django-extensions==3.2.3
     # via gsl (pyproject.toml)
-django-filter==24.3
+django-filter==25.1
     # via gsl (pyproject.toml)
 django-fsm-2==4.0.0
     # via gsl (pyproject.toml)
-django-htmx==1.21.0
+django-htmx==1.22.0
     # via gsl (pyproject.toml)
-django-import-export==4.3.3
+django-import-export==4.3.7
     # via gsl (pyproject.toml)
 django-json-widget==2.0.1
     # via gsl (pyproject.toml)
 django-referrer-policy==1.0
     # via gsl (pyproject.toml)
-django-timezone-field==7.0
+django-timezone-field==7.1
     # via django-celery-beat
 django-widget-tweaks==1.5.0
     # via django-dsfr
@@ -103,11 +102,13 @@ gunicorn==23.0.0
     # via gsl (pyproject.toml)
 idna==3.10
     # via requests
-ipython==8.31.0
+ipython==9.0.1
     # via gsl (pyproject.toml)
+ipython-pygments-lexers==1.1.1
+    # via ipython
 jedi==0.19.2
     # via ipython
-josepy==1.14.0
+josepy==2.0.0
     # via mozilla-django-oidc
 kombu==5.4.2
     # via celery
@@ -115,19 +116,19 @@ matplotlib-inline==0.1.7
     # via ipython
 mozilla-django-oidc==4.0.1
     # via gsl (pyproject.toml)
-packaging==24.1
+packaging==24.2
     # via gunicorn
 parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   click-repl
     #   ipython
-psycopg[binary]==3.2.4
+psycopg[binary]==3.2.5
     # via gsl (pyproject.toml)
-psycopg-binary==3.2.4
+psycopg-binary==3.2.5
     # via psycopg
 ptyprocess==0.7.0
     # via pexpect
@@ -136,9 +137,9 @@ pure-eval==0.2.3
 pycparser==2.22
     # via cffi
 pygments==2.19.1
-    # via ipython
-pyopenssl==24.2.1
-    # via josepy
+    # via
+    #   ipython
+    #   ipython-pygments-lexers
 python-crontab==3.2.0
     # via django-celery-beat
 python-dateutil==2.9.0.post0
@@ -147,21 +148,21 @@ python-dateutil==2.9.0.post0
     #   python-crontab
 python-dotenv==1.0.1
     # via gsl (pyproject.toml)
-redis==5.1.0
+redis==5.2.1
     # via gsl (pyproject.toml)
 requests==2.32.3
     # via
     #   django-dsfr
     #   mozilla-django-oidc
-sentry-sdk==2.15.0
+sentry-sdk==2.22.0
     # via gsl (pyproject.toml)
-six==1.16.0
+six==1.17.0
     # via python-dateutil
-sqlparse==0.5.1
+sqlparse==0.5.3
     # via django
 stack-data==0.6.3
     # via ipython
-tablib==3.7.0
+tablib==3.8.0
     # via django-import-export
 traitlets==5.14.3
     # via
@@ -171,12 +172,12 @@ typing-extensions==4.12.2
     # via
     #   dj-database-url
     #   psycopg
-tzdata==2024.2
+tzdata==2025.1
     # via
     #   celery
     #   django-celery-beat
     #   kombu
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   requests
     #   sentry-sdk
@@ -187,5 +188,5 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.13
     # via prompt-toolkit
-whitenoise==6.8.2
+whitenoise==6.9.0
     # via gsl (pyproject.toml)


### PR DESCRIPTION
## 🌮 Objectif

Je voulais installer django-csp. En fait on l'avait déjà, juste c'était pas configuré.

En attendant j'ai constaté qu'il y a plein de dépendances à mettre à jour. Ça résoudra nos alertes dependabot (mineures, mais quand même).

## 🔍 Liste des modifications

- Vider les fichiers requirements.txt et requirements-dev.txt puis relancer les commandes pip-compile

## ⚠️ Informations supplémentaires

La MAJ qui porte l'impact le plus majeur est celle de ruff : j'ai mis à jour la configuration de precommit et commité les trois fichiers qui changent de format suite au changement de version.

Les quelques changements majeurs qui m'inquiétaient (surtout django-filters) sont tout à fait indolores.

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
