### PR TITLE
Correctif pour créer une enveloppe vide et programmer un projet sur cette enveloppe

### DIFF
--- a/gsl_programmation/services/programmation_projet_service.py
+++ b/gsl_programmation/services/programmation_projet_service.py
@@ -45,10 +45,13 @@ class ProgrammationProjetService:
             logging.error(f"Projet {projet} is missing perimetre")
             return
 
-        enveloppe = Enveloppe.objects.get(
+        enveloppe, _ = Enveloppe.objects.get_or_create(
             perimetre=perimetre,
             annee=projet.dossier_ds.ds_date_traitement.year,
             type=dotation,
+            defaults={
+                "montant": 0,
+            },
         )
 
         ProgrammationProjet.objects.filter(projet=projet).exclude(


### PR DESCRIPTION
## 🌮 Objectif

Création d'une enveloppe vide pour y programmer des projets, lorsqu'ils ont été acceptés dans le passé. Par exemple, un projet a été accepté en 2023, alors on crée une enveloppe vide pour l'y associer.