### PR TITLE
Mise à jour du fil d'Ariane pour avoir "Accueil - Liste des projets" à la place de  "Accueil"

### DIFF
--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -70,7 +70,7 @@
 
         <div class="fr-container fr-mt-4w fr-mb-6w">
             {% block breadcrumb %}
-                {# no dsfr_breadcrumb by default #}
+                {% include "blocks/breadcrumb.html" %}
             {% endblock breadcrumb %}
             <main id="content" role="main">
                 {% block content %}

--- a/gsl_core/templates/blocks/breadcrumb.html
+++ b/gsl_core/templates/blocks/breadcrumb.html
@@ -1,0 +1,25 @@
+<nav role="navigation" class="fr-breadcrumb" aria-label="Vous êtes ici :">
+    <button type="button"
+            class="fr-breadcrumb__button"
+            aria-expanded="false"
+            aria-controls="breadcrumb-1">
+        Voir le fil d’Ariane
+    </button>
+    <div class="fr-collapse" id="breadcrumb-1">
+        <ol class="fr-breadcrumb__list">
+            <li>
+                <a class="fr-breadcrumb__link" href="{{ self.root_dir | default:'/' }}">Accueil - Liste des projets</a>
+            </li>
+            {% for link in breadcrumb_dict.links %}
+                <li>
+                    <a class="fr-breadcrumb__link" href="{{ link.url }}">{{ link.title }}</a>
+                </li>
+            {% endfor %}
+            {% if breadcrumb_dict.current %}
+                <li>
+                    <a class="fr-breadcrumb__link" aria-current="page">{{ breadcrumb_dict.current }}</a>
+                </li>
+            {% endif %}
+        </ol>
+    </div>
+</nav>

--- a/gsl_projet/templates/gsl_projet/projet.html
+++ b/gsl_projet/templates/gsl_projet/projet.html
@@ -1,9 +1,5 @@
 {% extends "base.html" %}
-{% load static dsfr_tags gsl_filters %}
-
-{% block breadcrumb %}
-    {% dsfr_breadcrumb breadcrumb_dict %}
-{% endblock breadcrumb %}
+{% load static gsl_filters %}
 
 {% block content %}
     {% block go_back_button %}

--- a/gsl_projet/templates/gsl_projet/projet_list.html
+++ b/gsl_projet/templates/gsl_projet/projet_list.html
@@ -1,10 +1,6 @@
 {% extends "base.html" %}
 {% load static dsfr_tags gsl_filters %}
 
-{% block breadcrumb %}
-    {% dsfr_breadcrumb breadcrumb_dict %}
-{% endblock breadcrumb %}
-
 {% block content %}
     <h1>
         Liste des projets

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -1,6 +1,5 @@
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
-from django.urls import reverse
 from django.views.decorators.http import require_GET
 from django.views.generic import ListView
 from django_filters.views import FilterView
@@ -41,7 +40,6 @@ def get_projet(request, projet_id):
         "projet": projet,
         "dossier": projet.dossier_ds,
         "breadcrumb_dict": {
-            "links": [{"url": reverse("projet:list"), "title": "Liste des projets"}],
             "current": title,
         },
         "menu_dict": PROJET_MENU,
@@ -96,7 +94,7 @@ class ProjetListView(FilterView, ListView, FilterUtils):
         qs = context["object_list"]
         context["title"] = "Projets 2025"
         context["porteur_mappings"] = ProjetService.PORTEUR_MAPPINGS
-        context["breadcrumb_dict"] = {"current": "Liste des projets"}
+        context["breadcrumb_dict"] = {}
         context["total_cost"] = ProjetService.get_total_cost(qs)
         context["total_amount_asked"] = ProjetService.get_total_amount_asked(qs)
         context["total_amount_granted"] = 0  # TODO

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -1,10 +1,6 @@
 {% extends "base.html" %}
 {% load static dsfr_tags gsl_filters %}
 
-{% block breadcrumb %}
-    {% dsfr_breadcrumb breadcrumb_dict %}
-{% endblock breadcrumb %}
-
 {% block extra_css %}
     <link rel="stylesheet" href="{% static 'css/simulation_detail.css' %}">
 {% endblock extra_css %}

--- a/gsl_simulation/templates/gsl_simulation/simulation_form.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_form.html
@@ -1,8 +1,4 @@
 {% extends "base.html" %}
-{% load dsfr_tags %}
-{% block breadcrumb %}
-    {% dsfr_breadcrumb breadcrumb_dict %}
-{% endblock breadcrumb %}
 
 {% block content %}
     <h1>

--- a/gsl_simulation/templates/gsl_simulation/simulation_list.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_list.html
@@ -1,10 +1,6 @@
 {% extends "base.html" %}
 {% load static dsfr_tags %}
 
-{% block breadcrumb %}
-    {% dsfr_breadcrumb breadcrumb_dict %}
-{% endblock breadcrumb %}
-
 {% block extra_css %}
     <link rel="stylesheet" href="{% static 'css/simulation_list.css' %}">
 {% endblock extra_css %}


### PR DESCRIPTION
## 🌮 Objectif

Définir la page des projets comme notre racine

## 🖼️ Images

![image](https://github.com/user-attachments/assets/de9b5eab-2ded-4b08-8866-b36b6243ff0f)
![image](https://github.com/user-attachments/assets/c866f1bc-7af0-4fb3-abae-e38148c5eb2b)

