### PR TITLE
Utilisation de vues séparées pour les onglets des deux pages détail projet

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -43,9 +43,11 @@ ul.no-list-style li {
 .color-red {
     color: var(--status-color-red);
 }
+
 .color-green {
     color: var(--status-color-green);
 }
+
 .color-blue {
     color: var(--status-color-blue);
 }
@@ -195,7 +197,7 @@ ul.no-list-style li {
 }
 
 
-.gsl-tooltip{
+.gsl-tooltip {
     padding-top: 0;
     padding-bottom: 4px;
     max-height: 28px;
@@ -253,4 +255,20 @@ ul.no-list-style li {
 .success-color {
     color: var(--text-default-success);
 }
-  
+
+/* detail projet */
+
+.fr-tabs__list.fake {
+    list-style-type: none;
+}
+
+.fake-tab-panel {
+    border: 1px solid #ddd;
+    padding: 2rem;
+    transform: translateY(-5px);
+}
+
+.sticky-menu {
+    position: sticky;
+    top: 1.5rem;
+}

--- a/gsl_projet/templates/gsl_projet/projet.html
+++ b/gsl_projet/templates/gsl_projet/projet.html
@@ -36,77 +36,23 @@
         {% endcomment %}
     </ul>
 
-    <div class="fr-tabs">
-        <ul class="fr-tabs__list" role="tablist" aria-label="Sections de la page">
-            <li role="presentation">
-                <button id="projet"
-                        class="fr-tabs__tab fr-icon-article-line fr-tabs__tab--icon-left"
-                        tabindex="0"
-                        role="tab"
-                        aria-selected="true"
-                        aria-controls="projet-panel">
-                    Projet
-                </button>
-            </li>
-            <li role="presentation">
-                <button id="annotations"
-                        class="fr-tabs__tab fr-icon-edit-line fr-tabs__tab--icon-left"
-                        tabindex="-1"
-                        role="tab"
-                        aria-selected="false"
-                        aria-controls="annotations-panel">
-                    Annotations
-                </button>
-            </li>
-            <li role="presentation">
-                <button id="demandeur"
-                        class="fr-tabs__tab fr-icon-bank-line fr-tabs__tab--icon-left"
-                        tabindex="-1"
-                        role="tab"
-                        aria-selected="false"
-                        aria-controls="demandeur-panel">
-                    Demandeur
-                </button>
-            </li>
-            <li role="presentation">
-                <button id="historique"
-                        class="fr-tabs__tab fr-icon-archive-line fr-tabs__tab--icon-left"
-                        tabindex="-1"
-                        role="tab"
-                        aria-selected="false"
-                        aria-controls="historique-panel">
-                    Historique du demandeur
-                </button>
-            </li>
-        </ul>
-        <div id="projet-panel"
-             class="fr-tabs__panel fr-tabs__panel--selected  with-sticky-menu"
-             role="tabpanel"
-             tabindex="0">
-            {% block tab_projet %}
-                {% include "gsl_projet/projet/tab_projet.html" %}
-            {% endblock tab_projet %}
-        </div>
-        <div id="annotations-panel"
-             class="fr-tabs__panel"
-             role="tabpanel"
-             aria-labelledby="annotations"
-             tabindex="0">
+    {% block tabs_list %}
+        {% include "gsl_projet/projet/tabs.html" %}
+    {% endblock tabs_list %}
+    <div id="projet-panel" class="fake-tab-panel" role="tabpanel" tabindex="0">
+        {% block tab_projet %}
+            {% include "gsl_projet/projet/tab_projet.html" %}
+        {% endblock tab_projet %}
+    </div>
+    {% comment %}
+        <div id="annotations-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="annotations" tabindex="0">
             {% include "gsl_projet/projet/tab_annotations.html" %}
         </div>
-        <div id="demandeur-panel"
-             class="fr-tabs__panel"
-             role="tabpanel"
-             aria-labelledby="demandeur"
-             tabindex="0">
+        <div id="demandeur-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="demandeur" tabindex="0">
             {% include "gsl_projet/projet/tab_demandeur.html" %}
         </div>
-        <div id="historique-panel"
-             class="fr-tabs__panel"
-             role="tabpanel"
-             aria-labelledby="historique"
-             tabindex="0">
+        <div id="historique-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="historique" tabindex="0">
             {% include "gsl_projet/projet/tab_historique.html" %}
         </div>
-    </div>
+    {% endcomment %}
 {% endblock content %}

--- a/gsl_projet/templates/gsl_projet/projet.html
+++ b/gsl_projet/templates/gsl_projet/projet.html
@@ -44,15 +44,4 @@
             {% include "gsl_projet/projet/tab_projet.html" %}
         {% endblock tab_projet %}
     </div>
-    {% comment %}
-        <div id="annotations-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="annotations" tabindex="0">
-            {% include "gsl_projet/projet/tab_annotations.html" %}
-        </div>
-        <div id="demandeur-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="demandeur" tabindex="0">
-            {% include "gsl_projet/projet/tab_demandeur.html" %}
-        </div>
-        <div id="historique-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="historique" tabindex="0">
-            {% include "gsl_projet/projet/tab_historique.html" %}
-        </div>
-    {% endcomment %}
 {% endblock content %}

--- a/gsl_projet/templates/gsl_projet/projet/tab_annotations.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_annotations.html
@@ -1,1 +1,5 @@
-annotations
+{% extends "gsl_projet/projet.html" %}
+
+{% block tab_projet %}
+    Annotations !!
+{% endblock tab_projet %}

--- a/gsl_projet/templates/gsl_projet/projet/tab_demandeur.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_demandeur.html
@@ -1,1 +1,5 @@
-demandeur
+{% extends "gsl_projet/projet.html" %}
+
+{% block tab_projet %}
+    Demandeur !!
+{% endblock tab_projet %}

--- a/gsl_projet/templates/gsl_projet/projet/tab_historique.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_historique.html
@@ -1,1 +1,5 @@
-historique
+{% extends "gsl_projet/projet.html" %}
+
+{% block tab_projet %}
+    Historique !!
+{% endblock tab_projet %}

--- a/gsl_projet/templates/gsl_projet/projet/tab_projet.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_projet.html
@@ -57,7 +57,9 @@
 <div class="fr-container fr-mt-5w">
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center gsl-projet-container">
         <div class="fr-col-4 gsl-projet-menu">
-            {% dsfr_sidemenu menu_dict %}
+            <div class="sticky-menu">
+                {% dsfr_sidemenu menu_dict %}
+            </div>
         </div>
         <div class="fr-col gsl-projet">
             <section>

--- a/gsl_projet/templates/gsl_projet/projet/tabs.html
+++ b/gsl_projet/templates/gsl_projet/projet/tabs.html
@@ -7,20 +7,20 @@
                class="fr-tabs__tab fr-icon-article-line fr-tabs__tab--icon-left">Projet</a>
         </li>
         <li>
-            {% url "projet:get-projet-annotations" projet_id=projet.id as annotations_url %}
+            {% url "projet:get-projet-tab" projet_id=projet.id tab="annotations" as annotations_url %}
             <a href="{{ annotations_url }}"
                {% if request.path == annotations_url %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-edit-line fr-tabs__tab--icon-left">Annotations</a>
         </li>
         <li>
-            {% url "projet:get-projet-demandeur" projet_id=projet.id as demandeur_url %}
+            {% url "projet:get-projet-tab" projet_id=projet.id tab="demandeur" as demandeur_url %}
             <a href="{{ demandeur_url }}"
                {% if request.path == demandeur_url %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-bank-line fr-tabs__tab--icon-left">Demandeur</a>
 
         </li>
         <li role="presentation">
-            {% url "projet:get-projet-historique" projet_id=projet.id as historique_url %}
+            {% url "projet:get-projet-tab" projet_id=projet.id tab="historique" as historique_url %}
 
             <a href="{{ historique_url }}"
                {% if request.path == historique_url %}aria-selected="true"{% endif %}

--- a/gsl_projet/templates/gsl_projet/projet/tabs.html
+++ b/gsl_projet/templates/gsl_projet/projet/tabs.html
@@ -1,0 +1,32 @@
+<nav aria-label="sections projet">
+    <ul class="fake fr-tabs__list ul-list">
+        <li>
+            {% url "projet:get-projet" projet_id=projet.id as projet_url %}
+            <a href="{{ projet_url }}"
+               {% if request.path == projet_url %}aria-selected="true"{% endif %}
+               class="fr-tabs__tab fr-icon-article-line fr-tabs__tab--icon-left">Projet</a>
+        </li>
+        <li>
+            {% url "projet:get-projet-annotations" projet_id=projet.id as annotations_url %}
+            <a href="{{ annotations_url }}"
+               {% if request.path == annotations_url %}aria-selected="true"{% endif %}
+               class="fr-tabs__tab fr-icon-edit-line fr-tabs__tab--icon-left">Annotations</a>
+        </li>
+        <li>
+            {% url "projet:get-projet-demandeur" projet_id=projet.id as demandeur_url %}
+            <a href="{{ demandeur_url }}"
+               {% if request.path == demandeur_url %}aria-selected="true"{% endif %}
+               class="fr-tabs__tab fr-icon-bank-line fr-tabs__tab--icon-left">Demandeur</a>
+
+        </li>
+        <li role="presentation">
+            {% url "projet:get-projet-historique" projet_id=projet.id as historique_url %}
+
+            <a href="{{ historique_url }}"
+               {% if request.path == historique_url %}aria-selected="true"{% endif %}
+               class="fr-tabs__tab fr-icon-archive-line fr-tabs__tab--icon-left">Historique du
+            demandeur</a>
+
+        </li>
+    </ul>
+</nav>

--- a/gsl_projet/tests/test_urls.py
+++ b/gsl_projet/tests/test_urls.py
@@ -62,27 +62,37 @@ def test_projet_detail_visible_by_user_with_correct_perimetre(
     url = reverse("projet:get-projet", args=[projet.id])
     response = client_with_55_user_logged.get(url, follow=True)
     assert response.status_code == 200
+    assertTemplateUsed(response, "gsl_projet/projet.html")
 
 
 @pytest.mark.parametrize(
-    "url_name,template",
+    "tab_name,template",
     (
-        ("", "gsl_projet/projet/tab_projet.html"),
-        ("-annotations", "gsl_projet/projet/tab_annotations.html"),
-        ("-historique", "gsl_projet/projet/tab_historique.html"),
-        ("-demandeur", "gsl_projet/projet/tab_demandeur.html"),
+        ("annotations", "gsl_projet/projet/tab_annotations.html"),
+        ("historique", "gsl_projet/projet/tab_historique.html"),
+        ("demandeur", "gsl_projet/projet/tab_demandeur.html"),
     ),
 )
 @pytest.mark.django_db
 def test_projet_tabs_use_the_right_templates(
-    client_with_55_user_logged, projets_from_55, url_name, template
+    client_with_55_user_logged, projets_from_55, tab_name, template
 ):
     projet = projets_from_55[0]
-    url = reverse(f"projet:get-projet{url_name}", args=[projet.id])
+    url = reverse("projet:get-projet-tab", args=[projet.id, tab_name])
     response = client_with_55_user_logged.get(url, follow=True)
     assert response.status_code == 200
     assertTemplateUsed(response, template)
     assertTemplateUsed(response, "gsl_projet/projet.html")
+
+
+@pytest.mark.django_db
+def test_projet_tab_404_with_unknown_tab_name(
+    client_with_55_user_logged, projets_from_55
+):
+    projet = projets_from_55[0]
+    url = reverse("projet:get-projet-tab", args=[projet.id, "nothing"])
+    response = client_with_55_user_logged.get(url, follow=True)
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/gsl_projet/tests/test_urls.py
+++ b/gsl_projet/tests/test_urls.py
@@ -1,5 +1,6 @@
 import pytest
 from django.urls import reverse
+from pytest_django.asserts import assertTemplateUsed
 
 from gsl_core.tests.factories import (
     ClientWithLoggedStaffUserFactory,
@@ -61,6 +62,27 @@ def test_projet_detail_visible_by_user_with_correct_perimetre(
     url = reverse("projet:get-projet", args=[projet.id])
     response = client_with_55_user_logged.get(url, follow=True)
     assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "url_name,template",
+    (
+        ("", "gsl_projet/projet/tab_projet.html"),
+        ("-annotations", "gsl_projet/projet/tab_annotations.html"),
+        ("-historique", "gsl_projet/projet/tab_historique.html"),
+        ("-demandeur", "gsl_projet/projet/tab_demandeur.html"),
+    ),
+)
+@pytest.mark.django_db
+def test_projet_tabs_use_the_right_templates(
+    client_with_55_user_logged, projets_from_55, url_name, template
+):
+    projet = projets_from_55[0]
+    url = reverse(f"projet:get-projet{url_name}", args=[projet.id])
+    response = client_with_55_user_logged.get(url, follow=True)
+    assert response.status_code == 200
+    assertTemplateUsed(response, template)
+    assertTemplateUsed(response, "gsl_projet/projet.html")
 
 
 @pytest.mark.django_db

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -54,21 +54,6 @@ def view() -> ProjetListView:
     return ProjetListView()
 
 
-### Tests templates
-
-
-@pytest.fixture
-def one_projet():
-    return ProjetFactory()
-
-
-def test_right_template_is_used_on_projet_tabs(client, one_projet):
-    resp = client.get(
-        reverse("projet:get-projet", kwargs={"projet_id": one_projet.id}),
-    )
-    assert resp.status_code == 200
-
-
 ### Test du tri
 
 

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -54,6 +54,21 @@ def view() -> ProjetListView:
     return ProjetListView()
 
 
+### Tests templates
+
+
+@pytest.fixture
+def one_projet():
+    return ProjetFactory()
+
+
+def test_right_template_is_used_on_projet_tabs(client, one_projet):
+    resp = client.get(
+        reverse("projet:get-projet", kwargs={"projet_id": one_projet.id}),
+    )
+    assert resp.status_code == 200
+
+
 ### Test du tri
 
 

--- a/gsl_projet/urls.py
+++ b/gsl_projet/urls.py
@@ -9,19 +9,9 @@ urlpatterns = [
         name="get-projet",
     ),
     path(
-        "voir/<int:projet_id>/annotations/",
-        views.get_projet_annotations,
-        name="get-projet-annotations",
-    ),
-    path(
-        "voir/<int:projet_id>/demandeur/",
-        views.get_projet_demandeur,
-        name="get-projet-demandeur",
-    ),
-    path(
-        "voir/<int:projet_id>/historique_demandeur/",
-        views.get_projet_historique_demandeur,
-        name="get-projet-historique",
+        "voir/<int:projet_id>/<str:tab>/",
+        views.get_projet_tab,
+        name="get-projet-tab",
     ),
     path("liste", views.ProjetListView.as_view(), name="list"),
 ]

--- a/gsl_projet/urls.py
+++ b/gsl_projet/urls.py
@@ -8,5 +8,20 @@ urlpatterns = [
         views.get_projet,
         name="get-projet",
     ),
+    path(
+        "voir/<int:projet_id>/annotations/",
+        views.get_projet_annotations,
+        name="get-projet-annotations",
+    ),
+    path(
+        "voir/<int:projet_id>/demandeur/",
+        views.get_projet_demandeur,
+        name="get-projet-demandeur",
+    ),
+    path(
+        "voir/<int:projet_id>/historique_demandeur/",
+        views.get_projet_historique_demandeur,
+        name="get-projet-historique",
+    ),
     path("liste", views.ProjetListView.as_view(), name="list"),
 ]

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -31,9 +31,7 @@ def visible_by_user(func):
     return wrapper
 
 
-@visible_by_user
-@require_GET
-def get_projet(request, projet_id):
+def _get_projet_context_info(projet_id):
     projet = get_object_or_404(Projet, id=projet_id)
     title = projet.dossier_ds.projet_intitule
     context = {
@@ -45,7 +43,35 @@ def get_projet(request, projet_id):
         },
         "menu_dict": PROJET_MENU,
     }
+    return context
+
+
+@visible_by_user
+@require_GET
+def get_projet(request, projet_id):
+    context = _get_projet_context_info(projet_id)
     return render(request, "gsl_projet/projet.html", context)
+
+
+@visible_by_user
+@require_GET
+def get_projet_annotations(request, projet_id):
+    context = _get_projet_context_info(projet_id)
+    return render(request, "gsl_projet/projet/tab_annotations.html", context)
+
+
+@visible_by_user
+@require_GET
+def get_projet_demandeur(request, projet_id):
+    context = _get_projet_context_info(projet_id)
+    return render(request, "gsl_projet/projet/tab_demandeur.html", context)
+
+
+@visible_by_user
+@require_GET
+def get_projet_historique_demandeur(request, projet_id):
+    context = _get_projet_context_info(projet_id)
+    return render(request, "gsl_projet/projet/tab_historique.html", context)
 
 
 class ProjetListViewFilters(ProjetFilters):

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -53,25 +53,16 @@ def get_projet(request, projet_id):
     return render(request, "gsl_projet/projet.html", context)
 
 
-@visible_by_user
-@require_GET
-def get_projet_annotations(request, projet_id):
-    context = _get_projet_context_info(projet_id)
-    return render(request, "gsl_projet/projet/tab_annotations.html", context)
+PROJET_TABS = {"annotations", "demandeur", "historique"}
 
 
 @visible_by_user
 @require_GET
-def get_projet_demandeur(request, projet_id):
+def get_projet_tab(request, projet_id, tab):
+    if tab not in PROJET_TABS:
+        raise Http404
     context = _get_projet_context_info(projet_id)
-    return render(request, "gsl_projet/projet/tab_demandeur.html", context)
-
-
-@visible_by_user
-@require_GET
-def get_projet_historique_demandeur(request, projet_id):
-    context = _get_projet_context_info(projet_id)
-    return render(request, "gsl_projet/projet/tab_historique.html", context)
+    return render(request, f"gsl_projet/projet/tab_{tab}.html", context)
 
 
 class ProjetListViewFilters(ProjetFilters):

--- a/gsl_simulation/templates/gsl_simulation/simulation_projet_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_projet_detail.html
@@ -20,6 +20,10 @@
     <span class="fr-badge fr-text--xl gsl-pull-right fr-mt-2v fr-ml-5w badge-projet-status__{{ simu.status }}">{{ simu.get_status_display|remove_first_word }}</span>
 {% endblock status_badge %}
 
+{% block tabs_list %}
+    {% include "gsl_simulation/tab_simulation_projet/tabs.html" %}
+{% endblock tabs_list %}
+
 {% block tab_projet %}
     {% include "gsl_simulation/tab_simulation_projet/tab_projet.html" %}
 {% endblock tab_projet %}

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_annotations.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_annotations.html
@@ -1,0 +1,5 @@
+{% extends "gsl_simulation/simulation_projet_detail.html" %}
+
+{% block tab_projet %}
+    Annotations !!
+{% endblock tab_projet %}

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_demandeur.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_demandeur.html
@@ -1,0 +1,5 @@
+{% extends "gsl_simulation/simulation_projet_detail.html" %}
+
+{% block tab_projet %}
+    Demandeur !!
+{% endblock tab_projet %}

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_historique.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_historique.html
@@ -1,0 +1,5 @@
+{% extends "gsl_simulation/simulation_projet_detail.html" %}
+
+{% block tab_projet %}
+    Historique !!
+{% endblock tab_projet %}

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tabs.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tabs.html
@@ -1,0 +1,32 @@
+<nav aria-label="sections projet">
+    <ul class="fake fr-tabs__list ul-list">
+        <li>
+            {% url "simulation:simulation-projet-detail" pk=simu.id as projet_url %}
+            <a href="{{ projet_url }}"
+               {% if request.path == projet_url %}aria-selected="true"{% endif %}
+               class="fr-tabs__tab fr-icon-article-line fr-tabs__tab--icon-left">Projet</a>
+        </li>
+        <li>
+            {% url "simulation:simulation-projet-tab" pk=simu.id tab="annotations" as annotations_url %}
+            <a href="{{ annotations_url }}"
+               {% if request.path == annotations_url %}aria-selected="true"{% endif %}
+               class="fr-tabs__tab fr-icon-edit-line fr-tabs__tab--icon-left">Annotations</a>
+        </li>
+        <li>
+            {% url "simulation:simulation-projet-tab" pk=simu.id tab="demandeur" as demandeur_url %}
+            <a href="{{ demandeur_url }}"
+               {% if request.path == demandeur_url %}aria-selected="true"{% endif %}
+               class="fr-tabs__tab fr-icon-bank-line fr-tabs__tab--icon-left">Demandeur</a>
+
+        </li>
+        <li role="presentation">
+            {% url "simulation:simulation-projet-tab" pk=simu.id tab="historique" as historique_url %}
+
+            <a href="{{ historique_url }}"
+               {% if request.path == historique_url %}aria-selected="true"{% endif %}
+               class="fr-tabs__tab fr-icon-archive-line fr-tabs__tab--icon-left">Historique du
+            demandeur</a>
+
+        </li>
+    </ul>
+</nav>

--- a/gsl_simulation/urls.py
+++ b/gsl_simulation/urls.py
@@ -31,6 +31,11 @@ urlpatterns = [
         name="simulation-projet-detail",
     ),
     path(
+        "projet-detail/<int:pk>/<str:tab>/",
+        simulation_projet_must_be_visible_by_user(SimulationProjetDetailView.as_view()),
+        name="simulation-projet-tab",
+    ),
+    path(
         "modifier-le-taux-d-un-projet-de-simulation/<int:pk>/",
         patch_taux_simulation_projet,
         name="patch-simulation-projet-taux",

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -1,4 +1,4 @@
-from django.http import HttpRequest
+from django.http import Http404, HttpRequest
 from django.http.request import QueryDict
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import resolve, reverse
@@ -118,7 +118,16 @@ def patch_status_simulation_projet(request, pk):
 
 class SimulationProjetDetailView(DetailView):
     model = SimulationProjet
-    template_name = "gsl_simulation/simulation_projet_detail.html"
+
+    ALLOWED_TABS = {"annotations", "demandeur", "historique"}
+
+    def get_template_names(self):
+        if "tab" in self.kwargs:
+            tab = self.kwargs["tab"]
+            if tab not in self.ALLOWED_TABS:
+                raise Http404
+            return [f"gsl_simulation/tab_simulation_projet/tab_{tab}.html"]
+        return ["gsl_simulation/simulation_projet_detail.html"]
 
     def get(self, request, *args, **kwargs):
         self.simulation_projet = SimulationProjet.objects.select_related(


### PR DESCRIPTION
## 🌮 Objectif

Permettre d'avoir un menu "sticky" sur la page de détail projet, ce qui est compromis par un `overflow:hidden` ajouté par les tabs du DSFR pour les "onglets" : 

![Capture d’écran 2025-03-19 à 11 38 04](https://github.com/user-attachments/assets/cd8ae056-d80b-4ec8-80eb-f4aedb19e940)


## 🔍 Liste des modifications

- Séparation de chacune de ces deux pages en 4 pages avec URL distinctes.
- Ajout d'une seule route pour les 3 onglets supplémentaires de chaque page et autres petits arrangements pour ne pas dupliquer trop de code.
- Ajustement du CSS pour que le menu sticky colle bien comme il faut.

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

Ici, on voit l'URL distincte pour l'onglet "demandeur" : 

![Capture d’écran 2025-03-19 à 11 36 22](https://github.com/user-attachments/assets/9bca0a22-ca74-477d-9e56-ccee13802478)

Illustration de la collance™ du menu : 

![Capture d’écran 2025-03-19 à 11 36 06](https://github.com/user-attachments/assets/7401fac4-8def-4a8b-83a6-c7d3a42f00b7)


