### PR TITLE
Réinitialisation des formulaires taux et montant en cas de valeurs non valides

### DIFF
--- a/gsl_projet/services.py
+++ b/gsl_projet/services.py
@@ -116,6 +116,17 @@ class ProjetService:
             raise ValueError(f"Taux {taux} must be between 0 and 100")
 
     @classmethod
+    def validate_montant(cls, montant: float | Decimal, projet: Projet) -> None:
+        if (
+            type(montant) not in [float, Decimal, int]
+            or montant < 0
+            or montant > projet.assiette_or_cout_total
+        ):
+            raise ValueError(
+                f"Montant {montant} must be greatear or equal to 0 and less than or equal to {projet.assiette_or_cout_total}"
+            )
+
+    @classmethod
     def get_avis_commission_detr(cls, ds_dossier: Dossier):
         if ds_dossier.ds_state == Dossier.STATE_ACCEPTE:
             if "DETR" in ds_dossier.demande_dispositif_sollicite:

--- a/gsl_projet/services.py
+++ b/gsl_projet/services.py
@@ -120,6 +120,7 @@ class ProjetService:
         if (
             type(montant) not in [float, Decimal, int]
             or montant < 0
+            or projet.assiette_or_cout_total is None
             or montant > projet.assiette_or_cout_total
         ):
             raise ValueError(

--- a/gsl_simulation/static/js/handleInteractionsInSimulation.js
+++ b/gsl_simulation/static/js/handleInteractionsInSimulation.js
@@ -23,3 +23,12 @@ document.querySelector(".gsl-projet-table").addEventListener("change", (ev) => {
     }
     return handleStatusChangeWithHtmx(target, target.dataset.originalValue);
 })
+
+document.addEventListener('htmx:responseError', evt => {
+    const xhr = evt.detail.xhr;
+  
+    if (xhr.status == 400) {
+        evt.detail.elt.form.reset()
+    }
+  });
+  

--- a/gsl_simulation/static/js/handleInteractionsInSimulation.js
+++ b/gsl_simulation/static/js/handleInteractionsInSimulation.js
@@ -27,7 +27,7 @@ document.querySelector(".gsl-projet-table").addEventListener("change", (ev) => {
 document.addEventListener('htmx:responseError', evt => {
     const xhr = evt.detail.xhr;
   
-    if (xhr.status == 400) {
+    if (xhr.status >= 400) {
         evt.detail.elt.form.reset()
     }
   });

--- a/gsl_simulation/tests/test_urls.py
+++ b/gsl_simulation/tests/test_urls.py
@@ -81,7 +81,9 @@ def client_with_cote_d_or_user_logged(cote_d_or_perimetre):
 
 @pytest.fixture
 def cote_dorien_simulation_projet(cote_d_or_perimetre):
-    projet = ProjetFactory(perimetre=cote_d_or_perimetre)
+    projet = ProjetFactory(
+        perimetre=cote_d_or_perimetre, dossier_ds__finance_cout_total=500_000
+    )
     simulation = SimulationFactory(
         enveloppe=DetrEnveloppeFactory(perimetre=cote_d_or_perimetre)
     )
@@ -118,7 +120,7 @@ def test_patch_taux_simulation_projet_url(
     assert response.context["projet"] == cote_dorien_simulation_projet.projet
     assert response.context["available_states"] == SimulationProjet.STATUS_CHOICES
     assert response.context["status_summary"] == expected_status_summary
-    assert response.context["total_amount_granted"] == Decimal("0.00")
+    assert response.context["total_amount_granted"] == Decimal("2500.00")
     assert response.context["filter_params"] == ""
 
     cote_dorien_simulation_projet.refresh_from_db()
@@ -142,7 +144,7 @@ def test_patch_taux_simulation_projet_url_with_htmx(
     assert response.context["projet"] == cote_dorien_simulation_projet.projet
     assert response.context["available_states"] == SimulationProjet.STATUS_CHOICES
     assert response.context["status_summary"] == expected_status_summary
-    assert response.context["total_amount_granted"] == Decimal("0.00")
+    assert response.context["total_amount_granted"] == Decimal("2500.00")
 
     cote_dorien_simulation_projet.refresh_from_db()
     assert cote_dorien_simulation_projet.taux == 0.5
@@ -359,7 +361,7 @@ def test_regional_user_cant_patch_projet_if_simulation_projet_is_associated_to_d
 
 @pytest.fixture
 def cote_dorien_dsil_simulation_projet(cote_d_or_perimetre):
-    projet = ProjetFactory(perimetre=cote_d_or_perimetre)
+    projet = ProjetFactory(perimetre=cote_d_or_perimetre, assiette=1_000)
     simulation = SimulationFactory(
         enveloppe=DsilEnveloppeFactory(perimetre=cote_d_or_perimetre)
     )

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -96,6 +96,7 @@ def patch_taux_simulation_projet(request, pk):
 def patch_montant_simulation_projet(request, pk):
     simulation_projet = get_object_or_404(SimulationProjet, id=pk)
     new_montant = replace_comma_by_dot(request.POST.get("montant"))
+    ProjetService.validate_montant(new_montant, simulation_projet.projet)
     SimulationProjetService.update_montant(simulation_projet, new_montant)
     return redirect_to_simulation_projet(request, simulation_projet)
 


### PR DESCRIPTION
## 🌮 Objectif

Si le taux ou le montant n'est pas valide, il n'est pas enregistré. Nous voulons faire en sorte que l'utilisateur voit donc la réalité en réinitialisant le formulaire pour voir la valeur d'origine

## 🔍 Liste des modifications

- Gestion d'erreur avec htmx
- Ajout d'un contrôle sur le montant
