### PR TITLE
Affichage dans l'admin de la date de dernière connexion des agent·e·s

### DIFF
--- a/gsl_core/admin.py
+++ b/gsl_core/admin.py
@@ -48,6 +48,7 @@ class CollegueAdmin(AllPermsForStaffUser, UserAdmin, admin.ModelAdmin):
         "last_name",
         "is_staff",
         "perimetre",
+        "last_login",
     )
     fieldsets = (
         (None, {"fields": ("username", "password")}),


### PR DESCRIPTION
## 🌮 Objectif

Avoir une idée rapide de qui sont les utilisateurs qui se connectent réellement à notre outil, et à quelle fréquence

## 🖼️ Images

![Capture d’écran 2025-03-24 à 16 17 58](https://github.com/user-attachments/assets/cfd6690c-ee05-4a51-97b2-f0bd65dd6b6c)

