### PR TITLE
Mise à jour du style des blocs "avis commission DETR"

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -286,3 +286,7 @@ ul.no-list-style li {
     position: sticky;
     top: 1.5rem;
 }
+
+.callout-without-left-border {
+  background-image: none;
+}

--- a/gsl_projet/static/css/projet_list_filters.css
+++ b/gsl_projet/static/css/projet_list_filters.css
@@ -9,6 +9,14 @@
   text-align: start;
 }
 
+.filter-dropdown > .fr-input {
+  display: flex;
+}
+
+.filter-dropdown > button > span {
+  margin-top: 1px; /* Alignement vertical de l'icône */
+}
+
 .filter-dropdown .filter-content {
   gap: 6px;
   min-width: auto;

--- a/gsl_projet/templates/gsl_projet/projet/tab_projet.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_projet.html
@@ -56,7 +56,7 @@
 
 {% block avis_commission_detr %}
     {% if projet.is_asking_for_detr %}
-        <div class="fr-callout fr-background-alt--blue-france block-avis-commission-detr">
+        <div class="fr-callout fr-background-alt--blue-france callout-without-left-border block-avis-commission-detr fr-p-2w">
             <h2 class="fr-callout__title fr-text--lg">
                 <span class="fr-icon fr-icon-team-fill blue-color fr-mr-3v"
                       aria-hidden="true"></span>Avis de la commission DETR

--- a/gsl_simulation/static/css/simulation_projet_detail.css
+++ b/gsl_simulation/static/css/simulation_projet_detail.css
@@ -8,6 +8,10 @@
 
 }
 
+.callout-without-left-border {
+  background-image: none;
+}
+
 .fr-fieldset__element .fr-radio-rich input[type="radio"] ~ label {
   flex-direction: row;
   gap: 8px;

--- a/gsl_simulation/static/css/simulation_projet_detail.css
+++ b/gsl_simulation/static/css/simulation_projet_detail.css
@@ -8,10 +8,6 @@
 
 }
 
-.callout-without-left-border {
-  background-image: none;
-}
-
 .fr-fieldset__element .fr-radio-rich input[type="radio"] ~ label {
   flex-direction: row;
   gap: 8px;

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_projet.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_projet.html
@@ -14,7 +14,7 @@
 {% endblock avis_commission_detr %}
 
 {% block status_action %}
-    <div class="fr-callout fr-background-alt--blue-france">
+    <div class="fr-callout fr-background-alt--blue-france callout-without-left-border fr-container fr-pb-1w fr-pt-3w fr-px-3w">
         <h2 class="fr-callout__title">
             <i class="fr-icon-coin-fill blue-color" aria-hidden="true"></i>
             Décision de financement du projet

--- a/gsl_simulation/templates/includes/forms/_avis_commission_detr_form.html
+++ b/gsl_simulation/templates/includes/forms/_avis_commission_detr_form.html
@@ -1,5 +1,5 @@
-<div class="fr-callout fr-background-alt--blue-france fr-container--fluid">
-    <div class="fr-grid-row fr-grid-row--gutters avis-commission-detr-block">
+<div class="fr-callout fr-background-alt--blue-france callout-without-left-border fr-container fr-p-3w">
+    <div class="fr-grid-row avis-commission-detr-block">
         <h2 class="fr-callout__title fr-text--lg">
             <span class="fr-icon fr-icon-team-fill blue-color fr-mr-3v"
                   aria-hidden="true"></span>Commission DETR (projet à + de 50k)


### PR DESCRIPTION
## 🌮 Objectif

Mettre à jour le style du bloc "avis commission DETR" dans la page projet non-modifiable et modifiable


## 🖼️ Images
Ici sur la page projet modifiable
<img width="1197" alt="image" src="https://github.com/user-attachments/assets/0e8a9712-9abf-4364-bd96-35a7667c28c8" />

Ici sur la page projet non-modifiable
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/6edbed88-48c9-411b-bb04-30082a62decc" />

