### PR TITLE
Ajout d'un lien vers l'admin, pour les administrateur·ices métier et techniques

### DIFF
--- a/gsl_core/templates/blocks/main_menu.html
+++ b/gsl_core/templates/blocks/main_menu.html
@@ -73,6 +73,9 @@
                             </ul>
                         </div>
                     </li>
+                    <li class="fr-nav__item">
+                        <a class="fr-nav__link" href="{% url "admin:index" %}">⚙️ Administration Django ⚙️</a>
+                    </li>
                 {% endif %}
             </ul>
         </nav>


### PR DESCRIPTION
## 🌮 Objectif

Permettre d'accéder facilement à l'admin, sans devoir taper l'URL dans la barre d'adresse.


## 🖼️ Images

<img width="1280" alt="Capture d’écran 2025-03-26 à 17 17 52" src="https://github.com/user-attachments/assets/edace8eb-84bc-4891-9257-2d8c482c352b" />

(Oui je t'avais prévenu que ça n'allait pas être aussi grandiose que ça ^^)
