### PR TITLE
Résolution d'un bug dans l'import des listes déroulantes DS

### DIFF
--- a/gsl_demarches_simplifiees/importer/dossier_converter.py
+++ b/gsl_demarches_simplifiees/importer/dossier_converter.py
@@ -126,7 +126,9 @@ class DossierConverter:
         self, dossier: Dossier, django_field_object: models.Field, injectable_value
     ):
         if isinstance(django_field_object, models.ManyToManyField):
-            if not isinstance(injectable_value, Iterable):
+            if isinstance(injectable_value, str) or not isinstance(
+                injectable_value, Iterable
+            ):
                 injectable_value = [injectable_value]
             if not issubclass(django_field_object.related_model, DsChoiceLibelle):
                 raise NotImplementedError("Can only inject DsChoiceLibelle objects")

--- a/gsl_demarches_simplifiees/tests/test_dossier_converter.py
+++ b/gsl_demarches_simplifiees/tests/test_dossier_converter.py
@@ -340,6 +340,16 @@ def test_inject_manytomany_value(dossier_converter, dossier):
     assert len(dossier.projet_zonage.all()) == 3
 
 
+def test_inject_string_into_manytomany_value(dossier_converter, dossier):
+    dossier_converter.inject_into_field(
+        dossier,
+        Dossier._meta.get_field("projet_zonage"),
+        "Territoires d'industrie (TI)",
+    )
+    dossier.save()
+    assert len(dossier.projet_zonage.all()) == 1
+
+
 def test_inject_address_value(dossier_converter, dossier):
     dossier_converter.inject_into_field(
         dossier,


### PR DESCRIPTION
## 🌮 Objectif

Éviter de renouveler ce bug-ci : 

<img width="719" alt="Capture d’écran 2025-03-27 à 10 58 53" src="https://github.com/user-attachments/assets/3925bb4e-113e-4623-8301-4445bc7aa331" />

Il se produit quand on essaie d'importer une simple chaîne de caractères dans un champ marqué "manytomany" dans Django (notamment les catégories DETR/DSIL). Eh oui, car les chaînes de caractères sont des itérables…

## 🔍 Liste des modifications

- Ajout d'un test pour vérifier que le bug était bien là.
- Correction du bug pour faire passer le test.

