### PR TITLE
Ajout d'un bouton pour réinitialiser les filtres sur la page projet et la page simulation

### DIFF
--- a/gsl_projet/static/css/projet_list_filters.css
+++ b/gsl_projet/static/css/projet_list_filters.css
@@ -137,3 +137,13 @@
 #filter-territoire {
   gap: 6px;
 }
+
+.reinit-filters {
+  place-content: end;
+}
+
+.reinit-filters > button {
+  width: 100%;
+  gap: 8px;
+  justify-content: center;
+}

--- a/gsl_projet/templates/includes/_filter_trier_par.html
+++ b/gsl_projet/templates/includes/_filter_trier_par.html
@@ -1,4 +1,4 @@
-<div class="filter-field fr-col-12 fr-col-md-6 fr-col-lg-3">
+<div class="filter-field fr-col-12 fr-col-md-4 fr-col-lg-2">
     <label class="fr-label" for="tri">
         Trier par
     </label>

--- a/gsl_projet/templates/includes/_projet_list_filters.html
+++ b/gsl_projet/templates/includes/_projet_list_filters.html
@@ -8,8 +8,8 @@
       action="{{ request.path }}{% querystring %}"
       class="fr-background-alt--blue-france">
     {% comment %}
-      Le premier boutton est utile lorsqu'on tape sur Entrée. Le formulaire agit alors en fonction du premier bouton rencontrée
-      ça évite que le bouton Entrée ne réinitialise les filtres
+      Le premier bouton est utile lorsqu'on tape sur Entrée. Le formulaire agit alors en fonction du premier bouton rencontré.
+      Ça évite que le bouton Entrée ne réinitialise les filtres
     {% endcomment %}
     <button type="submit" hidden>
     </button>

--- a/gsl_projet/templates/includes/_projet_list_filters.html
+++ b/gsl_projet/templates/includes/_projet_list_filters.html
@@ -7,9 +7,22 @@
 <form method="get"
       action="{{ request.path }}{% querystring %}"
       class="fr-background-alt--blue-france">
-
+    {% comment %}
+      Le premier boutton est utile lorsqu'on tape sur Entrée. Le formulaire agit alors en fonction du premier bouton rencontrée
+      ça évite que le bouton Entrée ne réinitialise les filtres
+    {% endcomment %}
+    <button type="submit" hidden>
+    </button>
     <div class="projets-filters-layout fr-container--fluid">
         <div class="fr-grid-row fr-grid-row--gutters">
+            <div class="fr-col-12 fr-col-md-4 fr-col-lg-3 reinit-filters">
+                <button class="fr-btn fr-btn--secondary"
+                        type="submit"
+                        name="reset_filters"
+                        value="1">
+                    <span class="fr-icon-arrow-go-back-fill"></span> Réinitialiser les filtres
+                </button>
+            </div>
             {% include "includes/_filter_trier_par.html" %}
             {% for filter_name in filter_templates %}
                 {% include filter_name %}

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_GET
 from django.views.generic import ListView
 from django_filters.views import FilterView
-
+from django.utils.http import url_has_allowed_host_and_scheme
 from gsl_projet.services import ProjetService
 from gsl_projet.utils.filter_utils import FilterUtils
 from gsl_projet.utils.projet_filters import ProjetFilters
@@ -118,7 +118,10 @@ class ProjetListView(FilterView, ListView, FilterUtils):
 
     def get(self, request, *args, **kwargs):
         if "reset_filters" in request.GET:
-            return redirect(request.path)
+            if url_has_allowed_host_and_scheme(request.path, allowed_hosts=None):
+                return redirect(request.path)
+            else:
+                return redirect('/')
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -1,6 +1,6 @@
 from django.db.models import Prefetch
 from django.http import Http404
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_GET
 from django.views.generic import ListView
 from django_filters.views import FilterView
@@ -115,6 +115,11 @@ class ProjetListView(FilterView, ListView, FilterUtils):
     filterset_class = ProjetListViewFilters
     template_name = "gsl_projet/projet_list.html"
     STATE_MAPPINGS = {key: value for key, value in Projet.STATUS_CHOICES}
+
+    def get(self, request, *args, **kwargs):
+        if "reset_filters" in request.GET:
+            return redirect(request.path)
+        return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -1,12 +1,11 @@
 from django.db.models import Prefetch
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.http import url_has_allowed_host_and_scheme
+from django.urls import reverse
 from django.views.decorators.http import require_GET
 from django.views.generic import ListView
 from django_filters.views import FilterView
 
-from gsl.settings import ALLOWED_HOSTS
 from gsl_projet.services import ProjetService
 from gsl_projet.utils.filter_utils import FilterUtils
 from gsl_projet.utils.projet_filters import ProjetFilters
@@ -97,6 +96,7 @@ class ProjetListViewFilters(ProjetFilters):
             "address",
             "address__commune",
             "perimetre",
+            "demandeur",
         ).prefetch_related(
             "dossier_ds__demande_eligibilite_detr",
             "dossier_ds__demande_eligibilite_dsil",
@@ -120,9 +120,7 @@ class ProjetListView(FilterView, ListView, FilterUtils):
 
     def get(self, request, *args, **kwargs):
         if "reset_filters" in request.GET:
-            if url_has_allowed_host_and_scheme(
-                request.path, allowed_hosts=ALLOWED_HOSTS
-            ):
+            if request.path == reverse("gsl_projet:list"):
                 return redirect(request.path)
             else:
                 return redirect("/")

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -1,10 +1,12 @@
 from django.db.models import Prefetch
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_GET
 from django.views.generic import ListView
 from django_filters.views import FilterView
-from django.utils.http import url_has_allowed_host_and_scheme
+
+from gsl.settings import ALLOWED_HOSTS
 from gsl_projet.services import ProjetService
 from gsl_projet.utils.filter_utils import FilterUtils
 from gsl_projet.utils.projet_filters import ProjetFilters
@@ -118,10 +120,12 @@ class ProjetListView(FilterView, ListView, FilterUtils):
 
     def get(self, request, *args, **kwargs):
         if "reset_filters" in request.GET:
-            if url_has_allowed_host_and_scheme(request.path, allowed_hosts=None):
+            if url_has_allowed_host_and_scheme(
+                request.path, allowed_hosts=ALLOWED_HOSTS
+            ):
                 return redirect(request.path)
             else:
-                return redirect('/')
+                return redirect("/")
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -3,13 +3,11 @@ from django.db.models import Prefetch, Sum
 from django.forms import NumberInput
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 from django_filters import MultipleChoiceFilter, NumberFilter
 from django_filters.views import FilterView
 
-from gsl.settings import ALLOWED_HOSTS
 from gsl_core.models import Perimetre
 from gsl_programmation.models import ProgrammationProjet
 from gsl_programmation.services.enveloppe_service import EnveloppeService
@@ -152,9 +150,7 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
 
     def get(self, request, *args, **kwargs):
         if "reset_filters" in request.GET:
-            if url_has_allowed_host_and_scheme(
-                request.path, allowed_hosts=ALLOWED_HOSTS
-            ):
+            if request.path.startswith("/simulation/voir/"):
                 return redirect(request.path)
             else:
                 return redirect("/")

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -149,6 +149,9 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
     STATE_MAPPINGS = {key: value for key, value in SimulationProjet.STATUS_CHOICES}
 
     def get(self, request, *args, **kwargs):
+        if "reset_filters" in request.GET:
+            return redirect(request.path)
+
         self.object = self.get_object()
         self.simulation = Simulation.objects.select_related(
             "enveloppe",

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -7,7 +7,7 @@ from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 from django_filters import MultipleChoiceFilter, NumberFilter
 from django_filters.views import FilterView
-
+from django.utils.http import url_has_allowed_host_and_scheme
 from gsl_core.models import Perimetre
 from gsl_programmation.models import ProgrammationProjet
 from gsl_programmation.services.enveloppe_service import EnveloppeService
@@ -150,7 +150,10 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
 
     def get(self, request, *args, **kwargs):
         if "reset_filters" in request.GET:
-            return redirect(request.path)
+            if url_has_allowed_host_and_scheme(request.path, allowed_hosts=None):
+                return redirect(request.path)
+            else:
+                return redirect('/')
 
         self.object = self.get_object()
         self.simulation = Simulation.objects.select_related(

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -3,11 +3,13 @@ from django.db.models import Prefetch, Sum
 from django.forms import NumberInput
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 from django_filters import MultipleChoiceFilter, NumberFilter
 from django_filters.views import FilterView
-from django.utils.http import url_has_allowed_host_and_scheme
+
+from gsl.settings import ALLOWED_HOSTS
 from gsl_core.models import Perimetre
 from gsl_programmation.models import ProgrammationProjet
 from gsl_programmation.services.enveloppe_service import EnveloppeService
@@ -150,10 +152,12 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
 
     def get(self, request, *args, **kwargs):
         if "reset_filters" in request.GET:
-            if url_has_allowed_host_and_scheme(request.path, allowed_hosts=None):
+            if url_has_allowed_host_and_scheme(
+                request.path, allowed_hosts=ALLOWED_HOSTS
+            ):
                 return redirect(request.path)
             else:
-                return redirect('/')
+                return redirect("/")
 
         self.object = self.get_object()
         self.simulation = Simulation.objects.select_related(


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir repartir de 0, après avoir défini des filtres dans la page projet ou la page simulation

## 🔍 Liste des modifications

- On a rajouté un bouton qui envoie un `reset_filters` dans le formulaire et bim, on redirige vers la page sans paramètre !

## 🖼️ Images

![image](https://github.com/user-attachments/assets/822ed381-1e2a-44f0-915f-93515209f04a)
