### PR TITLE
Modification de la colonne "Commune" pour la renommer "Demandeur"

### DIFF
--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -1,3 +1,4 @@
+import re
 from decimal import Decimal
 
 from django import template
@@ -51,3 +52,45 @@ def create_alert_data(status: str | None, arg: str) -> dict[str, str | bool]:
         data_dict["title"] = STATUS_TO_ALERT_TITLE[status]
 
     return data_dict
+
+
+@register.filter
+def format_demandeur_nom(nom):
+    MOTS_MIN = (
+        "de",
+        "du",
+        "des",
+        "sur",
+        "et",
+        "la",
+        "le",
+        "les",
+        "d",
+        "en",
+        "l",
+        "au",
+        "aux",
+        "a",
+        "un",
+        "une",
+        "l",
+    )
+    ABREVIATIONS = ("cc", "ca", "cte")
+
+    # Sépare les mots tout en conservant les tirets et les apostrophes
+    mots = re.split(r"(\s+|-|\')", nom.lower().strip())
+
+    resultat = []
+    for mot in mots:
+        if mot in ABREVIATIONS:
+            resultat.append(mot.upper())
+        elif mot.strip() in MOTS_MIN:
+            resultat.append(mot.lower())  # Garde en minuscule
+        else:
+            resultat.append(mot.capitalize())  # Met la première lettre en majuscule
+
+    # Correction de l'apostrophe
+    texte_final = "".join(resultat)
+    texte_final = texte_final.replace(" d ", " d'").replace(" d' ", " d'")
+
+    return texte_final

--- a/gsl_core/templatetags/tests/test_gsl_filters.py
+++ b/gsl_core/templatetags/tests/test_gsl_filters.py
@@ -1,8 +1,11 @@
 from decimal import Decimal
 
+import pytest
+
 from gsl_core.templatetags.gsl_filters import (
     create_alert_data,
     euro,
+    format_demandeur_nom,
     percent,
     remove_first_word,
 )
@@ -58,3 +61,40 @@ def test_create_alert_data():
         "is_collapsible": True,
         "description": "Test description",
     }
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    (
+        (
+            "CTE DE COMMUNES DE LA PLAINE DE L'AIN",
+            "CTE de Communes de la Plaine de l'Ain",
+        ),
+        ("MAISON DE RETRAITE LA MONTAGNE", "Maison de Retraite la Montagne"),
+        ("COMMUNE DE FAREINS", "Commune de Fareins"),
+        ("COMMUNE DE SAINT-BERNARD", "Commune de Saint-Bernard"),
+        ("CA DU BASSIN DE BOURG-EN-BRESSE", "CA du Bassin de Bourg-en-Bresse"),
+        ("COMMUNE DE SAINT-MARTIN-DE-BAVEL", "Commune de Saint-Martin-de-Bavel"),
+        ("CC BRESSE ET SAONE", "CC Bresse et Saone"),
+        ("COMMUNE DE MONTMERLE SUR SAONE", "Commune de Montmerle sur Saone"),
+        ("COMMUNE DE CHEVROUX", "Commune de Chevroux"),
+        ("COMMUNE DE DIVONNE-LES-BAINS", "Commune de Divonne-les-Bains"),
+        ("COMMUNE DES NEYROLLES", "Commune des Neyrolles"),
+        ("COMMUNE DE TOUSSIEUX", "Commune de Toussieux"),
+        ("COMMUNE DE NEUVILLE LES DAMES", "Commune de Neuville les Dames"),
+        ("COMMUNE DE MANZIAT", "Commune de Manziat"),
+        ("COMMUNE DE SAINTE EUPHEMIE", "Commune de Sainte Euphemie"),
+        ("COMMUNE DE BENY", "Commune de Beny"),
+        (
+            "COMMUNE DE SAINT-ETIENNE-SUR-CHALARONNE",
+            "Commune de Saint-Etienne-sur-Chalaronne",
+        ),
+        ("COMMUNE DE TREVOUX", "Commune de Trevoux"),
+        ("CC BUGEY SUD", "CC Bugey Sud"),
+        ("COMMUNE DE THOISSEY", "Commune de Thoissey"),
+        ("COMMUNE D ARGIS", "Commune d'Argis"),
+        ("COMMUNE DOUARD A MENEZ", "Commune Douard a Menez"),
+    ),
+)
+def test_format_demandeur_nom(input, expected):
+    assert format_demandeur_nom(input) == expected

--- a/gsl_projet/templates/includes/_filter_porteur.html
+++ b/gsl_projet/templates/includes/_filter_porteur.html
@@ -1,7 +1,7 @@
 <div class="filter-field fr-col-12 fr-col-md-4 fr-col-lg-2">
     <div class="filter-dropdown">
         <label class="fr-label" for="porteur">
-            Porteur de projet
+            Demandeur
         </label>
         <button type="button"
                 class="fr-select {% if is_porteur_active %}filter-dropdown-button-active{% endif %}">

--- a/gsl_projet/templates/includes/_projets_table.html
+++ b/gsl_projet/templates/includes/_projets_table.html
@@ -15,7 +15,7 @@
                     Intitulé du projet
                 </th>
                 <th>
-                    Commune
+                    Demandeur
                 </th>
                 <th>
                     N° D.S.
@@ -62,7 +62,7 @@
                         {{ projet.dossier_ds.projet_intitule }}
                     </td>
                     <td>
-                        {{ projet.address.commune.name }}
+                        {{ projet.demandeur.name | format_demandeur_nom }}
                     </td>
                     <td>
                         {{ projet.dossier_ds.ds_number }}

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -27,7 +27,7 @@
                         Intitulé du projet
                     </th>
                     <th>
-                        Commune
+                        Demandeur
                     </th>
                     <th>
                         Dotation

--- a/gsl_simulation/templates/includes/_simulation_detail_row.html
+++ b/gsl_simulation/templates/includes/_simulation_detail_row.html
@@ -13,7 +13,7 @@
         {{ projet.dossier_ds.projet_intitule }}
     </td>
     <td>
-        {{ projet.address.commune.name }}
+        {{ projet.demandeur.name | format_demandeur_nom }}
     </td>
     <td>
         {{ projet.dossier_ds.demande_dispositif_sollicite }}


### PR DESCRIPTION
## 🌮 Objectif

Modification de la colonne "Commune" pour la renommer "Demandeur", sur la page projet et simulation

## 🔍 Liste des modifications

- Ajout d'un filtre pour essayer d'afficher un nom de demandeur correct

## 🖼️ Images

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/b9447f79-d1ae-4265-9a0d-6956e1e7f3e3" />
