### PR TITLE
Ajustement du bouton "Je donne mon avis"

### DIFF
--- a/gsl_core/templates/blocks/header.html
+++ b/gsl_core/templates/blocks/header.html
@@ -8,8 +8,7 @@
            target='_blank'
            title="Je donne mon avis - nouvelle fenêtre"
            class="fr-btn">
-            <img src="https://jedonnemonavis.numerique.gouv.fr/static/bouton-bleu.svg"
-                 alt="Je donne mon avis" />
+            Je donne mon avis
         </a>
     </li>
     <li>


### PR DESCRIPTION
## 🌮 Objectif

On retire l'image en laissant de la place pour le texte "Je donne mon avis". => en bonus, ça permet de ne plus avoir l'erreur CSP

## 🖼️ Images

<img width="247" alt="image" src="https://github.com/user-attachments/assets/f58bb077-05ec-4c2c-badb-225842b4aefd" />
