### PR TITLE
Migration des changements de status d'un projet de Projet à Dotation Projet

### DIFF
--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -414,6 +414,7 @@ class DotationProjet(models.Model):
         parent_enveloppe = EnveloppeService.get_parent_enveloppe(enveloppe)
 
         ProgrammationProjet.objects.update_or_create(
+            # TODO pr_dotation replace projet by dotation_projet
             projet=self.projet,
             enveloppe=parent_enveloppe,
             defaults={
@@ -422,3 +423,15 @@ class DotationProjet(models.Model):
                 "status": ProgrammationProjet.STATUS_REFUSED,
             },
         )
+
+    @transition(field=status, source="*", target=STATUS_DISMISSED)
+    def dismiss(self):
+        from gsl_programmation.models import ProgrammationProjet
+        from gsl_simulation.models import SimulationProjet
+
+        SimulationProjet.objects.filter(DOTATION_DSILprojet=self).update(
+            status=SimulationProjet.STATUS_DISMISSED, montant=0, taux=0
+        )
+
+        # TODO pr_dotation replace projet by dotation_projet
+        ProgrammationProjet.objects.filter(projet=self.projet).delete()

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -429,8 +429,24 @@ class DotationProjet(models.Model):
         from gsl_programmation.models import ProgrammationProjet
         from gsl_simulation.models import SimulationProjet
 
-        SimulationProjet.objects.filter(DOTATION_DSILprojet=self).update(
+        SimulationProjet.objects.filter(dotation_projet=self).update(
             status=SimulationProjet.STATUS_DISMISSED, montant=0, taux=0
+        )
+
+        # TODO pr_dotation replace projet by dotation_projet
+        ProgrammationProjet.objects.filter(projet=self.projet).delete()
+
+    @transition(
+        field=status,
+        source=[STATUS_ACCEPTED, STATUS_REFUSED, STATUS_DISMISSED],
+        target=STATUS_PROCESSING,
+    )
+    def set_back_status_to_processing(self):
+        from gsl_programmation.models import ProgrammationProjet
+        from gsl_simulation.models import SimulationProjet
+
+        SimulationProjet.objects.filter(dotation_projet=self).update(
+            status=SimulationProjet.STATUS_PROCESSING,
         )
 
         # TODO pr_dotation replace projet by dotation_projet

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -376,6 +376,8 @@ class DotationProjet(models.Model):
         from gsl_projet.services.projet_services import ProjetService
         from gsl_simulation.models import SimulationProjet
 
+        # TODO pr_dotation test enveloppe.dotation == self.dotation ??
+
         taux = ProjetService.compute_taux_from_montant(self, montant)
 
         SimulationProjet.objects.filter(dotation_projet=self).update(
@@ -387,7 +389,8 @@ class DotationProjet(models.Model):
         parent_enveloppe = EnveloppeService.get_parent_enveloppe(enveloppe)
 
         ProgrammationProjet.objects.update_or_create(
-            projet=self,
+            # TODO pr_dotation replace projet by dotation_projet
+            projet=self.projet,
             enveloppe=parent_enveloppe,
             defaults={
                 "montant": montant,

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -398,3 +398,27 @@ class DotationProjet(models.Model):
                 "status": ProgrammationProjet.STATUS_ACCEPTED,
             },
         )
+
+    @transition(field=status, source="*", target=STATUS_REFUSED)
+    def refuse(self, enveloppe: "Enveloppe"):
+        from gsl_programmation.models import ProgrammationProjet
+        from gsl_programmation.services.enveloppe_service import EnveloppeService
+        from gsl_simulation.models import SimulationProjet
+
+        SimulationProjet.objects.filter(dotation_projet=self).update(
+            status=SimulationProjet.STATUS_REFUSED,
+            montant=0,
+            taux=0,
+        )
+
+        parent_enveloppe = EnveloppeService.get_parent_enveloppe(enveloppe)
+
+        ProgrammationProjet.objects.update_or_create(
+            projet=self.projet,
+            enveloppe=parent_enveloppe,
+            defaults={
+                "montant": 0,
+                "taux": 0,
+                "status": ProgrammationProjet.STATUS_REFUSED,
+            },
+        )

--- a/gsl_projet/tests/models/test_dotation_projet.py
+++ b/gsl_projet/tests/models/test_dotation_projet.py
@@ -1,10 +1,21 @@
+from decimal import Decimal
+
 import pytest
 from django.db import IntegrityError
 from django.forms import ValidationError
 
-from gsl_projet.constants import DOTATION_DSIL, DOTATIONS
+from gsl_demarches_simplifiees.models import Dossier
+from gsl_programmation.models import ProgrammationProjet
+from gsl_programmation.tests.factories import (
+    DetrEnveloppeFactory,
+    DsilEnveloppeFactory,
+    ProgrammationProjetFactory,
+)
+from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL, DOTATIONS
 from gsl_projet.models import DotationProjet
 from gsl_projet.tests.factories import DotationProjetFactory, ProjetFactory
+from gsl_simulation.models import SimulationProjet
+from gsl_simulation.tests.factories import SimulationProjetFactory
 
 
 @pytest.mark.parametrize(("dotation"), DOTATIONS)
@@ -40,3 +51,130 @@ def test_assiette_or_cout_total():
         assiette=None, projet__dossier_ds__finance_cout_total=2_000
     )
     assert dotation_projet.assiette_or_cout_total == 2_000
+
+
+# Accept
+
+
+@pytest.mark.django_db
+def test_accept_projet_without_simulation_projet():
+    dotation_projet = DotationProjetFactory(assiette=10_000, dotation=DOTATION_DETR)
+    assert dotation_projet.projet.dossier_ds.ds_state == Dossier.STATE_EN_INSTRUCTION
+
+    enveloppe = DetrEnveloppeFactory(annee=2025)
+
+    dotation_projet.accept(montant=5_000, enveloppe=enveloppe)
+    dotation_projet.projet.save()
+    dotation_projet.projet.refresh_from_db()
+
+    assert dotation_projet.status == DotationProjet.STATUS_ACCEPTED
+    simulation_projets = SimulationProjet.objects.filter(
+        dotation_projet=dotation_projet, status=SimulationProjet.STATUS_ACCEPTED
+    )
+    assert simulation_projets.count() == 0
+
+    # TODO pr_dotation replace projet by dotation_projet
+    programmation_projets = ProgrammationProjet.objects.filter(
+        projet=dotation_projet.projet, enveloppe=enveloppe
+    )
+    assert programmation_projets.count() == 1
+    programmation_projet = programmation_projets.first()
+    assert programmation_projet.montant == 5_000
+    assert programmation_projet.taux == 50
+    assert programmation_projet.status == ProgrammationProjet.STATUS_ACCEPTED
+
+
+@pytest.mark.django_db
+def test_accept_projet():
+    dotation_projet = DotationProjetFactory(assiette=10_000, dotation=DOTATION_DETR)
+    assert dotation_projet.dossier_ds.ds_state == Dossier.STATE_EN_INSTRUCTION
+
+    SimulationProjetFactory(
+        dotation_projet=dotation_projet,
+        status=SimulationProjet.STATUS_PROVISOIRE,
+        montant=1_000,
+    )
+    SimulationProjetFactory(
+        dotation_projet=dotation_projet,
+        status=SimulationProjet.STATUS_REFUSED,
+        montant=2_000,
+    )
+    SimulationProjetFactory(
+        dotation_projet=dotation_projet,
+        status=SimulationProjet.STATUS_PROCESSING,
+        montant=3_000,
+    )
+    assert SimulationProjet.objects.filter(dotation_projet=dotation_projet).count() == 3
+
+    enveloppe = DetrEnveloppeFactory(annee=2025)
+
+    dotation_projet.accept(montant=5_000, enveloppe=enveloppe)
+    dotation_projet.save()
+    dotation_projet.refresh_from_db()
+
+    assert dotation_projet.status == DotationProjet.STATUS_ACCEPTED
+    simulation_projets = SimulationProjet.objects.filter(
+        dotation_projet=dotation_projet, status=SimulationProjet.STATUS_ACCEPTED
+    )
+    for simulation_projet in simulation_projets:
+        assert simulation_projet.status == SimulationProjet.STATUS_ACCEPTED
+        assert simulation_projet.montant == 5_000
+        assert simulation_projet.taux == 50
+
+    # TODO pr_dotation replace projet by dotation_projet
+    programmation_projets = ProgrammationProjet.objects.filter(
+        projet=dotation_projet.projet, enveloppe=enveloppe
+    )
+    assert programmation_projets.count() == 1
+    programmation_projet = programmation_projets.first()
+    assert programmation_projet.montant == 5_000
+    assert programmation_projet.taux == 50
+    assert programmation_projet.status == ProgrammationProjet.STATUS_ACCEPTED
+
+
+@pytest.mark.django_db
+def test_accept_projet_update_programmation_projet():
+    dotation_projet = DotationProjetFactory(
+        assiette=9_000, status=DotationProjet.STATUS_REFUSED, dotation=DOTATION_DETR
+    )
+
+    enveloppe = DetrEnveloppeFactory(annee=2025)
+    ProgrammationProjetFactory(
+        projet=dotation_projet.projet,
+        enveloppe=enveloppe,
+        montant=0,
+        status=ProgrammationProjet.STATUS_REFUSED,
+    )
+
+    dotation_projet.accept(montant=5_000, enveloppe=enveloppe)
+    dotation_projet.save()
+    dotation_projet.refresh_from_db()
+    assert dotation_projet.status == DotationProjet.STATUS_ACCEPTED
+
+    programmation_projets = ProgrammationProjet.objects.filter(
+        projet=dotation_projet.projet, enveloppe=enveloppe
+    )
+    assert programmation_projets.count() == 1
+    programmation_projet = programmation_projets.first()
+    assert programmation_projet.montant == 5_000
+    assert programmation_projet.taux == Decimal("55.56")
+    assert programmation_projet.status == ProgrammationProjet.STATUS_ACCEPTED
+
+
+@pytest.mark.django_db
+def test_accept_projet_select_parent_enveloppe():
+    dotation_projet = DotationProjetFactory(
+        assiette=9_000,
+        status=DotationProjet.STATUS_PROCESSING,
+        dotation=DOTATION_DSIL,
+    )
+    parent_enveloppe = DsilEnveloppeFactory()
+    child_enveloppe = DsilEnveloppeFactory(deleguee_by=parent_enveloppe)
+    dotation_projet.accept(montant=5_000, enveloppe=child_enveloppe)
+
+    programmation_projets = ProgrammationProjet.objects.filter(
+        projet=dotation_projet.projet
+    )
+
+    assert programmation_projets.count() == 1
+    assert programmation_projets.first().enveloppe == parent_enveloppe

--- a/gsl_projet/tests/models/test_projet.py
+++ b/gsl_projet/tests/models/test_projet.py
@@ -72,6 +72,7 @@ def test_is_asking_for_detr(demande_dispositif_sollicite, expected_is_asking_for
     assert projet.is_asking_for_detr is expected_is_asking_for_detr
 
 
+# TODO pr_dotation remove all tests above
 # Accept
 
 

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -160,9 +160,9 @@ class SimulationProjetService:
 
     @classmethod
     def _dismiss_a_simulation_projet(cls, simulation_projet: SimulationProjet):
-        projet = simulation_projet.projet
-        projet.dismiss()
-        projet.save()
+        dotation_projet = simulation_projet.dotation_projet
+        dotation_projet.dismiss()
+        dotation_projet.save()
 
         updated_simulation_projet = SimulationProjet.objects.get(
             pk=simulation_projet.pk

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 
 from gsl_core.models import Perimetre
 from gsl_projet.models import DotationProjet, Projet
+from gsl_projet.services.dotation_projet_services import DotationProjetService
 from gsl_projet.services.projet_services import ProjetService
 from gsl_simulation.models import Simulation, SimulationProjet
 
@@ -91,13 +92,11 @@ class SimulationProjetService:
         simulation_projet.save()
         return simulation_projet
 
+    # TODO pr_dotation update test
     @classmethod
     def update_taux(cls, simulation_projet: SimulationProjet, new_taux: float):
-        new_montant = (
-            (simulation_projet.projet.assiette_or_cout_total * Decimal(new_taux) / 100)
-            if simulation_projet.projet.assiette_or_cout_total
-            else 0
-        )
+        assiette = simulation_projet.dotation_projet.assiette_or_cout_total
+        new_montant = (assiette * Decimal(new_taux) / 100) if assiette else 0
         new_montant = round(new_montant, 2)
 
         simulation_projet.taux = new_taux
@@ -110,9 +109,9 @@ class SimulationProjetService:
         return simulation_projet
 
     @classmethod
-    def update_montant(cls, simulation_projet, new_montant: float):
-        new_taux = ProjetService.compute_taux_from_montant(
-            simulation_projet.projet, new_montant
+    def update_montant(cls, simulation_projet: SimulationProjet, new_montant: float):
+        new_taux = DotationProjetService.compute_taux_from_montant(
+            simulation_projet.dotation_projet, new_montant
         )
 
         simulation_projet.taux = new_taux
@@ -137,11 +136,11 @@ class SimulationProjetService:
 
     @classmethod
     def _accept_a_simulation_projet(cls, simulation_projet: SimulationProjet):
-        projet = simulation_projet.projet
-        projet.accept(
+        dotation_projet = simulation_projet.dotation_projet
+        dotation_projet.accept(
             montant=simulation_projet.montant, enveloppe=simulation_projet.enveloppe
         )
-        projet.save()
+        dotation_projet.save()
 
         updated_simulation_projet = SimulationProjet.objects.get(
             pk=simulation_projet.pk

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -149,9 +149,9 @@ class SimulationProjetService:
 
     @classmethod
     def _refuse_a_simulation_projet(cls, simulation_projet: SimulationProjet):
-        projet = simulation_projet.projet
-        projet.refuse(enveloppe=simulation_projet.enveloppe)
-        projet.save()
+        dotation_projet = simulation_projet.dotation_projet
+        dotation_projet.refuse(enveloppe=simulation_projet.enveloppe)
+        dotation_projet.save()
 
         updated_simulation_projet = SimulationProjet.objects.get(
             pk=simulation_projet.pk

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -171,9 +171,9 @@ class SimulationProjetService:
 
     @classmethod
     def _set_back_to_processing(cls, simulation_projet: SimulationProjet):
-        projet = simulation_projet.projet
-        projet.set_back_status_to_processing()
-        projet.save()
+        dotation_projet = simulation_projet.dotation_projet
+        dotation_projet.set_back_status_to_processing()
+        dotation_projet.save()
 
         updated_simulation_projet = SimulationProjet.objects.get(
             pk=simulation_projet.pk

--- a/gsl_simulation/tests/services/test_simulation_projet_services.py
+++ b/gsl_simulation/tests/services/test_simulation_projet_services.py
@@ -605,27 +605,30 @@ def test_get_simulation_projet_status(projet_status, simulation_projet_status_ex
 
 
 @pytest.mark.parametrize(
-    ("dotation_projet_transition, method, with_montant"),
+    ("dotation_projet_transition, method, with_enveloppe, with_montant"),
     (
-        ("accept", SimulationProjetService._accept_a_simulation_projet, True),
-        ("refuse", SimulationProjetService._refuse_a_simulation_projet, False),
-        ("dismiss", SimulationProjetService._dismiss_a_simulation_projet, False),
+        ("accept", SimulationProjetService._accept_a_simulation_projet, True, True),
+        ("refuse", SimulationProjetService._refuse_a_simulation_projet, True, False),
+        ("dismiss", SimulationProjetService._dismiss_a_simulation_projet, False, False),
         (
             "set_back_status_to_processing",
             SimulationProjetService._set_back_to_processing,
+            False,
             False,
         ),
     ),
 )
 @pytest.mark.django_db
 def test_simulation_projet_transition_are_called(
-    dotation_projet_transition, method, with_montant
+    dotation_projet_transition, method, with_enveloppe, with_montant
 ):
     with mock.patch(
         f"gsl_projet.models.DotationProjet.{dotation_projet_transition}"
     ) as mock_transition_dotation_projet:
         simulation_projet = SimulationProjetFactory()
-        args = {"enveloppe": simulation_projet.enveloppe}
+        args = {}
+        if with_enveloppe:
+            args["enveloppe"] = simulation_projet.enveloppe
         if with_montant:
             args["montant"] = simulation_projet.montant
 

--- a/gsl_simulation/tests/services/test_simulation_projet_services.py
+++ b/gsl_simulation/tests/services/test_simulation_projet_services.py
@@ -242,14 +242,23 @@ SIMULATION_PROJET_STATUS_TO_DOTATION_PROJET_STATUS = {
 def test_update_status_with_provisoire_from_refused_or_accepted_or_dismissed(
     initial_status,
 ):
+    dotation_projet = DotationProjetFactory(
+        status=SIMULATION_PROJET_STATUS_TO_DOTATION_PROJET_STATUS[initial_status]
+    )
     simulation_projet = SimulationProjetFactory(
         status=initial_status,
-        dotation_projet__status=SIMULATION_PROJET_STATUS_TO_DOTATION_PROJET_STATUS[
-            initial_status
-        ],
+        dotation_projet=dotation_projet,
+        simulation__enveloppe__dotation=dotation_projet.dotation,
+    )
+    assert (
+        dotation_projet.status
+        == SIMULATION_PROJET_STATUS_TO_DOTATION_PROJET_STATUS[initial_status]
     )
     SimulationProjetFactory.create_batch(
-        3, dotation_projet=simulation_projet.dotation_projet, status=initial_status
+        3,
+        dotation_projet=dotation_projet,
+        status=initial_status,
+        simulation__enveloppe__dotation=dotation_projet.dotation,
     )
 
     SimulationProjetService.update_status(
@@ -277,11 +286,13 @@ def test_update_status_with_provisoire_from_refused_or_accepted_or_dismissed(
 def test_update_status_with_provisoire_remove_programmation_projet_from_accepted_or_refused(
     initial_status,
 ):
+    dotation_projet = DotationProjetFactory(
+        status=SIMULATION_PROJET_STATUS_TO_DOTATION_PROJET_STATUS[initial_status]
+    )
     simulation_projet = SimulationProjetFactory(
         status=initial_status,
-        dotation_projet__status=SIMULATION_PROJET_STATUS_TO_DOTATION_PROJET_STATUS[
-            initial_status
-        ],
+        dotation_projet=dotation_projet,
+        simulation__enveloppe__dotation=dotation_projet.dotation,
     )
     # TODO pr_dotation use dotation_projet
     ProgrammationProjetFactory(projet=simulation_projet.projet)

--- a/gsl_simulation/tests/services/test_simulation_projet_services.py
+++ b/gsl_simulation/tests/services/test_simulation_projet_services.py
@@ -127,9 +127,15 @@ def test_get_initial_montant_from_projet():
     assert montant == 0
 
 
+# TODO pr_dotation remove it ??
 @pytest.fixture
 def projet():
     return ProjetFactory(assiette=1000)
+
+
+@pytest.fixture
+def dotation_projet():
+    return DotationProjetFactory(assiette=1000)
 
 
 @pytest.mark.django_db
@@ -297,8 +303,9 @@ def test_accept_a_simulation_projet():
         status=SimulationProjet.STATUS_PROCESSING
     )
     other_projet_simulation_projet = SimulationProjetFactory(
-        projet=simulation_projet.projet
+        dotation_projet=simulation_projet.dotation_projet
     )
+    # TODO pr_dotation use dotation_projet instead of projet
     pp_qs = ProgrammationProjet.objects.filter(projet=simulation_projet.projet)
     assert pp_qs.count() == 0
 
@@ -340,7 +347,7 @@ def test_accept_a_simulation_projet_has_created_a_programmation_projet_with_moth
 
 
 @pytest.mark.parametrize(
-    "initial_progrogrammation_status, new_projet_status, programmation_status_expected",
+    "initial_programmation_status, new_projet_status, programmation_status_expected",
     (
         (
             ProgrammationProjet.STATUS_REFUSED,
@@ -356,22 +363,26 @@ def test_accept_a_simulation_projet_has_created_a_programmation_projet_with_moth
 )
 @pytest.mark.django_db
 def test_accept_a_simulation_projet_has_updated_a_programmation_projet_with_mother_enveloppe(
-    initial_progrogrammation_status,
+    initial_programmation_status,
     new_projet_status,
     programmation_status_expected,
 ):
     mother_enveloppe = DetrEnveloppeFactory()
     child_enveloppe = DetrEnveloppeFactory(deleguee_by=mother_enveloppe)
-    projet = ProjetFactory(perimetre=child_enveloppe.perimetre)
+    dotation_projet = DotationProjetFactory(
+        projet__perimetre=child_enveloppe.perimetre, dotation=DOTATION_DETR
+    )
+
     simulation_projet = SimulationProjetFactory(
-        projet=projet,
+        dotation_projet=dotation_projet,
         status=SimulationProjet.STATUS_PROCESSING,
         simulation__enveloppe=child_enveloppe,
     )
+    # TODO pr_dotation use dotation_projet instead of projet
     ProgrammationProjetFactory(
         projet=simulation_projet.projet,
         enveloppe=mother_enveloppe,
-        status=initial_progrogrammation_status,
+        status=initial_programmation_status,
     )
     programmation_projets_qs = ProgrammationProjet.objects.filter(
         projet=simulation_projet.projet
@@ -391,8 +402,13 @@ def test_accept_a_simulation_projet_has_updated_a_programmation_projet_with_moth
 
 
 @pytest.mark.django_db
-def test_update_taux(projet):
-    simulation_projet = SimulationProjetFactory(projet=projet, taux=10.0)
+def test_update_taux(dotation_projet):
+    simulation_projet = SimulationProjetFactory(
+        # TODO PR dotation => make simulation__enveloppe__dotation=dotation_projet.dotation directly in factory ?
+        dotation_projet=dotation_projet,
+        taux=10.0,
+        simulation__enveloppe__dotation=dotation_projet.dotation,
+    )
     new_taux = 15.0
 
     SimulationProjetService.update_taux(simulation_projet, new_taux)
@@ -402,19 +418,23 @@ def test_update_taux(projet):
 
 
 @pytest.mark.django_db
-def test_update_taux_of_accepted_montat(projet):
+def test_update_taux_of_accepted_montat(dotation_projet):
     simulation_projet = SimulationProjetFactory(
-        projet=projet, status=SimulationProjet.STATUS_ACCEPTED, taux=20.0
-    )
-    other_simulation_projet = SimulationProjetFactory(
-        simulation__enveloppe=simulation_projet.enveloppe,
-        projet=projet,
+        dotation_projet=dotation_projet,
+        simulation__enveloppe__dotation=dotation_projet.dotation,
         status=SimulationProjet.STATUS_ACCEPTED,
         taux=20.0,
     )
+    other_simulation_projet = SimulationProjetFactory(
+        simulation__enveloppe=simulation_projet.enveloppe,
+        dotation_projet=dotation_projet,
+        status=SimulationProjet.STATUS_ACCEPTED,
+        taux=20.0,
+    )
+    # TODO pr_dotation use dotation_projet instead of projet
     programmation_projet = ProgrammationProjetFactory(
         enveloppe=simulation_projet.enveloppe,
-        projet=projet,
+        projet=dotation_projet.projet,
         status=ProgrammationProjet.STATUS_ACCEPTED,
         taux=20.0,
     )
@@ -435,8 +455,12 @@ def test_update_taux_of_accepted_montat(projet):
 
 
 @pytest.mark.django_db
-def test_update_montant(projet):
-    simulation_projet = SimulationProjetFactory(projet=projet, montant=1000.0)
+def test_update_montant(dotation_projet):
+    simulation_projet = SimulationProjetFactory(
+        dotation_projet=dotation_projet,
+        simulation__enveloppe__dotation=dotation_projet.dotation,
+        montant=1000.0,
+    )
     new_montant = 500.0
 
     SimulationProjetService.update_montant(simulation_projet, new_montant)
@@ -446,19 +470,23 @@ def test_update_montant(projet):
 
 
 @pytest.mark.django_db
-def test_update_montant_of_accepted_montant(projet):
+def test_update_montant_of_accepted_montant(dotation_projet):
     simulation_projet = SimulationProjetFactory(
-        projet=projet, status=SimulationProjet.STATUS_ACCEPTED, montant=1_000
-    )
-    other_simulation_projet = SimulationProjetFactory(
-        simulation__enveloppe=simulation_projet.enveloppe,
-        projet=projet,
+        dotation_projet=dotation_projet,
+        simulation__enveloppe__dotation=dotation_projet.dotation,
         status=SimulationProjet.STATUS_ACCEPTED,
         montant=1_000,
     )
+    other_simulation_projet = SimulationProjetFactory(
+        simulation__enveloppe=simulation_projet.enveloppe,
+        dotation_projet=dotation_projet,
+        status=SimulationProjet.STATUS_ACCEPTED,
+        montant=1_000,
+    )
+    # TODO pr_dotation use dotation_projet instead of projet
     programmation_projet = ProgrammationProjetFactory(
         enveloppe=simulation_projet.enveloppe,
-        projet=projet,
+        projet=dotation_projet.projet,
         status=ProgrammationProjet.STATUS_ACCEPTED,
         montant=1_000,
     )

--- a/gsl_simulation/tests/views/test_enveloppe_data.py
+++ b/gsl_simulation/tests/views/test_enveloppe_data.py
@@ -43,7 +43,7 @@ def submitted_projets(perimetre_departemental):
         dossier_ds__ds_date_depot=datetime(2021, 12, 1, tzinfo=UTC),
         dossier_ds__demande_dispositif_sollicite="DETR",
     )
-    # TODO pr_dotationremove this when we add a link between programmation tion and dotation projet ?
+    # TODO pr_dotation remove this when we add a link between programmation and dotation projet ?
     for projet in projets:
         DotationProjetService.create_or_update_dotation_projet_from_projet(projet)
     return projets
@@ -61,7 +61,7 @@ def programmation_projets(perimetre_departemental, detr_enveloppe):
         projet__dossier_ds__ds_date_traitement=datetime(2021, 10, 1, tzinfo=UTC),
         projet__dossier_ds__demande_dispositif_sollicite="DETR",
     )
-    # TODO pr_dotationremove this when we add a link between programmation tion and dotation projet ?
+    # TODO pr_dotation remove this when we add a link between programmation tion and dotation projet ?
     for pp in programmation_projets:
         DotationProjetService.create_or_update_dotation_projet_from_projet(pp.projet)
 
@@ -76,7 +76,7 @@ def programmation_projets(perimetre_departemental, detr_enveloppe):
             projet__dossier_ds__ds_date_traitement=datetime(2021, 7, 1, tzinfo=UTC),
             projet__dossier_ds__demande_dispositif_sollicite="DETR",
         )
-        # TODO pr_dotationremove this when we add a link between programmation tion and dotation projet ?
+        # TODO pr_dotation remove this when we add a link between programmation tion and dotation projet ?
         pp = DotationProjetService.create_or_update_dotation_projet_from_projet(
             pp.projet
         )

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -79,6 +79,7 @@ class SimulationProjetDetailView(CorrectUserPerimeterRequiredMixin, DetailView):
         self.simulation_projet = SimulationProjet.objects.select_related(
             "simulation",
             "simulation__enveloppe",
+            "dotation_projet",  # TODO pr_dotation add dotation_projet__projet ?
             "projet",
             "projet__dossier_ds",
         ).get(id=request.resolver_match.kwargs.get("pk"))
@@ -103,7 +104,9 @@ class SimulationProjetDetailView(CorrectUserPerimeterRequiredMixin, DetailView):
             ],
             "current": context["title"],
         }
+        # TODO pr_dotation remove it ??
         context["projet"] = self.simulation_projet.projet
+        context["dotation_projet"] = self.simulation_projet.dotation_projet
         context["simu"] = self.simulation_projet
         context["enveloppe"] = self.simulation_projet.simulation.enveloppe
         context["dossier"] = self.simulation_projet.projet.dossier_ds
@@ -144,6 +147,8 @@ def redirect_to_simulation_projet(
             "htmx/projet_update.html",
             {
                 "simu": simulation_projet,
+                "dotation_projet": simulation_projet.dotation_projet,
+                # TODO pr_dotation remove it ??
                 "projet": simulation_projet.projet,
                 "available_states": SimulationProjet.STATUS_CHOICES,
                 "status_summary": simulation_projet.simulation.get_projet_status_summary(),


### PR DESCRIPTION
## 🌮 Objectif

Copier les transitions de `Projet` vers `Dotation Projet`, et les utiliser dans les vues de l'app `Simulation`.

## 🔍 Liste des modifications

- Copie des transitions de `status` dans le modèle `DotationProjet` (on pourra virer les transitions et la colonne `status` de `Projet`plus tard)
- Copie des tests sur le modèle et sur les vues de l'app `Simulation`