### PR TITLE
Rendons les migrations réversibles

### DIFF
--- a/gsl_projet/migrations/0018_dotationprojet.py
+++ b/gsl_projet/migrations/0018_dotationprojet.py
@@ -10,6 +10,10 @@ def create_dotation_projet(apps, schema_editor):
     create_or_update_dotation_projets_from_all_projets()
 
 
+def nothing(apps, schema_editor):
+    pass
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("gsl_projet", "0017_projet_is_budget_vert"),
@@ -78,5 +82,5 @@ class Migration(migrations.Migration):
                 "unique_together": {("projet", "dotation")},
             },
         ),
-        migrations.RunPython(create_dotation_projet),
+        migrations.RunPython(create_dotation_projet, reverse_code=nothing),
     ]

--- a/gsl_simulation/migrations/0013_initialize_dotation_projet_for_simulation_projets.py
+++ b/gsl_simulation/migrations/0013_initialize_dotation_projet_for_simulation_projets.py
@@ -3,6 +3,10 @@
 from django.db import migrations
 
 
+def nothing(apps, schema_editor):
+    pass
+
+
 def set_dotation_projet_for_simulation_projets(apps, schema_editor):
     SimulationProjet = apps.get_model("gsl_simulation", "SimulationProjet")
     DotationProjet = apps.get_model("gsl_projet", "DotationProjet")
@@ -33,4 +37,8 @@ class Migration(migrations.Migration):
         ),
     ]
 
-    operations = [migrations.RunPython(set_dotation_projet_for_simulation_projets)]
+    operations = [
+        migrations.RunPython(
+            set_dotation_projet_for_simulation_projets, reverse_code=nothing
+        )
+    ]


### PR DESCRIPTION
## 🌮 Objectif

Faciliter le développement en parallèle (là je n'ai pas pu faire le `migrate gsl_projet 0017` pour refaire un `migrate` qui m'aurait permis de récupérer ton initialisation).

## 🔍 Liste des modifications

- Ajout des `reverse_code` là où c'est utile
