### PR TITLE
Petits ajustements liés à des bugs relevés

### DIFF
--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -176,6 +176,10 @@ class Projet(models.Model):
             and len(self.accepted_programmation_projets) > 0
         ):
             return self.accepted_programmation_projets[0]
+        else:
+            for dp in self.dotationprojet_set.all():
+                if dp.status == PROJET_STATUS_ACCEPTED:
+                    return dp.programmation_projet
 
     # TODO pr_dotation move it to DotationProjet => ticket double ligne projet
     @property

--- a/gsl_projet/templates/gsl_projet/projet.html
+++ b/gsl_projet/templates/gsl_projet/projet.html
@@ -12,7 +12,7 @@
     {% endblock go_back_button %}
     <h1>
         {% block status_badge %}
-            <span class="fr-badge fr-text--xl gsl-pull-right fr-mt-2v fr-ml-5w badge-projet-status__{{ projet.status }}">{{ projet.status|remove_first_word }}</span>
+            <span class="fr-badge fr-text--xl gsl-pull-right fr-mt-2v fr-ml-5w badge-projet-status__{{ projet.status }}">{{ projet.get_status_display|remove_first_word }}</span>
         {% endblock status_badge %}
         {{ dossier.projet_intitule|lower|capfirst }}
     </h1>

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -39,7 +39,7 @@ class ProjetFilters(FilterSet):
         method="filter_dotation",
     )
 
-    # TODO dotation_pr use dotation_projet
+    # TODO pr_dotation use dotation_projet
     def filter_dotation(self, queryset, _name, values):
         if not values:
             return queryset

--- a/gsl_simulation/models.py
+++ b/gsl_simulation/models.py
@@ -129,7 +129,7 @@ class SimulationProjet(models.Model):
         if self.dotation_projet.assiette is not None:
             if self.montant and self.montant > self.dotation_projet.assiette:
                 errors["montant"] = {
-                    "Le montant de la simulation ne peut pas être supérieur à l'assiette du projet."
+                    f"Le montant de la simulation ne peut pas être supérieur à l'assiette du projet ({self.projet.pk})."
                 }
         else:
             if (
@@ -138,7 +138,7 @@ class SimulationProjet(models.Model):
                 and self.montant > self.projet.dossier_ds.finance_cout_total
             ):
                 errors["montant"] = {
-                    "Le montant de la simulation ne peut pas être supérieur au coût total du projet."
+                    f"Le montant de la simulation ne peut pas être supérieur au coût total du projet ({self.projet.pk})."
                 }
 
     def _validate_dotation(self, errors):

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -58,6 +58,7 @@ class SimulationProjetService:
             SimulationProjet.STATUS_REFUSED,
         ):
             return Decimal(0)
+
         try:
             return dotation_projet.programmation_projet.montant
         except ProgrammationProjet.DoesNotExist:

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -66,9 +66,14 @@ class SimulationProjetService:
         projet = dotation_projet.projet
 
         if projet.dossier_ds.annotations_montant_accorde:
-            return projet.dossier_ds.annotations_montant_accorde
+            return min(
+                projet.dossier_ds.annotations_montant_accorde,
+                projet.dossier_ds.finance_cout_total,
+            )
         if projet.dossier_ds.demande_montant:
-            return projet.dossier_ds.demande_montant
+            return min(
+                projet.dossier_ds.demande_montant, projet.dossier_ds.finance_cout_total
+            )
         return Decimal(0)
 
     @classmethod

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -65,7 +65,7 @@
             <tbody>
                 {% for projet in simulations_list %}
                     {% with projet.dotation_projet.0.simu.0 as simu %}
-                        {% include "includes/_simulation_detail_row.html" with simu=simu projet=projet %}
+                        {% include "includes/_simulation_detail_row.html" with simu=simu projet=projet dotation_projet=projet.dotation_projet.0 %}
                     {% endwith %}
                 {% empty %}
                     <tr>

--- a/gsl_simulation/tests/test_models.py
+++ b/gsl_simulation/tests/test_models.py
@@ -63,7 +63,7 @@ def test_simulation_projet_cant_have_a_montant_higher_than_projet_assiette():
         assert sp.montant == 101
         sp.save()
     assert (
-        "Le montant de la simulation ne peut pas être supérieur à l'assiette du projet."
+        "Le montant de la simulation ne peut pas être supérieur à l'assiette du projet"
         in exc_info.value.message_dict.get("montant")[0]
     )
 
@@ -82,7 +82,7 @@ def test_simulation_projet_cant_have_a_montant_higher_than_projet_cout_total():
         )
         sp.save()
     assert (
-        "Le montant de la simulation ne peut pas être supérieur au coût total du projet."
+        "Le montant de la simulation ne peut pas être supérieur au coût total du projet"
         in exc_info.value.message_dict.get("montant")[0]
     )
 

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -295,8 +295,8 @@ def simulation_form(request):
             "breadcrumb_dict": {
                 "links": [
                     {
-                        "url": reverse("gsl_projet:list"),
-                        "title": "Liste des projets",
+                        "url": reverse("gsl_simulation:simulation-list"),
+                        "title": "Mes simulations de programmation",
                     },
                 ],
                 "current": "Création d'une simulation de programmation",


### PR DESCRIPTION
## 🌮 Objectif

- le montant affiché sur la liste de projets (temporaire en attendant les doubles lignes)
- le statut affiché sur la page projet non modifiable
- on s'assure que la création d'une simulation ne crash pas, même si on a un montant total du projet < au montant demandé
