### PR TITLE
Réparation de la barre de navigation pour qu'elle soit active sur les bonnes pages

### DIFF
--- a/gsl_core/templates/blocks/main_menu.html
+++ b/gsl_core/templates/blocks/main_menu.html
@@ -21,14 +21,14 @@
                     <a class="fr-nav__link"
                        href="{{ projets_url }}"
                        target="_self"
-                       {% if request.path == projet_url %}aria-current="true"{% endif %}>Projets 2025</a>
+                       {% if "/projets/" in request.path %}aria-current="true"{% endif %}>Projets 2025</a>
                 </li>
                 <li class="fr-nav__item">
                     {% url 'simulation:simulation-list' as simulations_url %}
                     <a class="fr-nav__link"
                        href="{{ simulations_url }}"
                        target="_self"
-                       {% if request.path == simulations_url %}aria-current="true"{% endif %}>Simulations</a>
+                       {% if "/simulation/" in request.path %}aria-current="true"{% endif %}>Simulations</a>
                 </li>
                 <li class="fr-nav__item">
                     {% url 'coming-features' as coming_features_url %}
@@ -42,7 +42,7 @@
                         <button class="fr-nav__btn"
                                 aria-expanded="false"
                                 aria-controls="menu-resources"
-                                {% if '/ds' in request.path %}aria-current="true"{% endif %}>
+                                {% if '/ds/' in request.path %}aria-current="true"{% endif %}>
                             ⚙️ Administration DS ⚙️
                         </button>
                         <div class="fr-collapse fr-menu" id="menu-resources">

--- a/gsl_pages/templates/gsl_pages/coming_features.html
+++ b/gsl_pages/templates/gsl_pages/coming_features.html
@@ -120,11 +120,11 @@
             margin-top: 4rem;
         }
 
-        nav {
+        .table_of_contents {
             margin: 1em 0;
         }
 
-        nav > div {
+        .table_of_contents > div {
             margin-bottom: 1em;
         }
     


### PR DESCRIPTION
## 🌮 Objectif

Il y avait des soucis. Par exemple, lorsque j'étais dans une démarche dont le slug commençait par "**ds**il", alors "Administration DS" était sélectionné.
De plus, pour Simulations et Projet 2025, seul la page racine était sélectionnée, et non les descendants.