### PR TITLE
Ajout d'informations sur les projets à double dotation dans une simulation

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -134,6 +134,14 @@ ul.no-list-style li {
     text-overflow: ellipsis;
 }
 
+.max_160_width {
+    max-width: 160px;
+    width: 160px;
+    min-width: 140px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .max_80_width {
     max-width: 100px;
     width: 80px;

--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -33,6 +33,11 @@ def remove_first_word(value):
     return parts[1] if len(parts) > 1 else ""
 
 
+@register.filter
+def get(dictionary, key):
+    return dictionary.get(key)
+
+
 STATUS_TO_ALERT_TITLE = {
     SimulationProjet.STATUS_ACCEPTED: "Projet accepté",
     SimulationProjet.STATUS_REFUSED: "Projet refusé",

--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -35,6 +35,8 @@ def remove_first_word(value):
 
 @register.filter
 def get(dictionary, key):
+    if not isinstance(dictionary, dict):
+        return dictionary
     return dictionary.get(key)
 
 

--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -55,6 +55,8 @@
 /* other dotation */
 .other-simulation-row {
   background-color: var(--background-default-grey-hover);
+  min-height: 40px;
+  height: 40px;
 }
 
 .gsl-projet-table table tbody tr.row-with-double-dotations td{ /* cette longue liste est utile pour être plus spécifique que .gsl-projet-table table tbody tr td */
@@ -70,7 +72,9 @@
   text-align: end;
 }
 
-
+.other-simulation-status > b {
+  margin-right: 20px;
+}
 
 /* colors */
 

--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -52,6 +52,25 @@
   font-size: small;
 }
 
+/* other dotation */
+.other-simulation-row {
+  background-color: var(--background-default-grey-hover);
+}
+
+.gsl-projet-table table tbody tr.row-with-double-dotations td{ /* cette longue liste est utile pour être plus spécifique que .gsl-projet-table table tbody tr td */
+  border-bottom: 1px solid var(--border-disabled-grey);
+}
+
+.information-other-dotation {
+  text-align: end;
+  font-style: italic;
+}
+
+.other-simulation-status {
+  text-align: end;
+}
+
+
 
 /* colors */
 

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -51,10 +51,10 @@
                     <th class="max_80_width">
                         Taux de subvention
                     </th>
-                    <th>
+                    <th class="max_160_width">
                         Choix de la catégorie d’opération
                     </th>
-                    <th class="max_180_width">
+                    <th class="max_160_width">
                         Statut
                     </th>
                     <th>

--- a/gsl_simulation/templates/includes/_simulation_detail_row.html
+++ b/gsl_simulation/templates/includes/_simulation_detail_row.html
@@ -61,12 +61,12 @@
             </td>
             <td class="gsl-money">
                 <div class="gsl-money">
-                    <b>{{ other_simu.montant }}</b>
+                    <b>{{ other_simu.montant|euro:2 }}</b>
                 </div>
             </td>
             <td class="gsl-money">
                 <div class="gsl-money">
-                    <b>{{ other_simu.taux }}</b>
+                    <b>{{ other_simu.taux|percent }}</b>
                 </div>
             </td>
             <td>

--- a/gsl_simulation/templates/includes/_simulation_detail_row.html
+++ b/gsl_simulation/templates/includes/_simulation_detail_row.html
@@ -1,52 +1,84 @@
 {% load gsl_filters %}
 
-<tr id="simulation-{{ simu.pk }}" hx-swap-oob="true">
-    <td>
-        <input type="checkbox"
-               name="simu[{{ simu.pk }}]"
-               aria-label="Sélectionner le projet {{ projet.dossier_ds.projet_intitule }}">
-    </td>
-    <td>
-        {{ projet.dossier_ds.ds_date_depot|date:"d/m/Y" }}
-    </td>
-    <td>
-        {{ projet.dossier_ds.projet_intitule }}
-    </td>
-    <td>
-        {{ projet.demandeur.name | format_demandeur_nom }}
-    </td>
-    <td>
-        {% include "includes/table_forms/_dotation_form.html" with simu=simu %}
-    </td>
-    <td class="gsl-money">
-        {{ projet.dossier_ds.finance_cout_total|euro:2 }}
-    </td>
-    <td class="gsl-money">
-        {{ projet.dossier_ds.demande_montant|euro:2 }}
-        <br>
-        {{ dotation_projet.taux_de_subvention_sollicite|percent }}
-    </td>
-    <td class="gsl-money">
-        {% include "includes/table_forms/_montant_form.html" with simu=simu %}
-    </td>
-    <td class="gsl-money">
-        {% include "includes/table_forms/_taux_form.html" with simu=simu %}
-    </td>
-    <td>
-        <select class="fr-select gsl-projet-table__select" name="" id="">
-            <option value="">
-                {{ projet.categorie_doperation.first }}
-            </option>
-        </select>
-    </td>
-    <td>
-        {% include "includes/table_forms/_status_form.html" with simu=simu %}
-    </td>
-    <td class="fr-cell--right gsl-nowrap">
-        <a class="fr-btn--tertiary-no-outline gsl-no-underline"
-           href="{{ simu.get_absolute_url }}">
-            <span class="fr-sr-only">Voir le projet {{ projet.dossier_ds.ds_number }}</span>
-            <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
-        </a>
-    </td>
-</tr>
+{% with other_simu=other_dotations_simu|get:projet.id %}
+    <tr id="simulation-{{ simu.pk }}"
+        hx-swap-oob="true"
+        {% if other_simu %}class="row-with-double-dotations"{% endif %}>
+        <td>
+            <input type="checkbox"
+                   name="simu[{{ simu.pk }}]"
+                   aria-label="Sélectionner le projet {{ projet.dossier_ds.projet_intitule }}">
+        </td>
+        <td>
+            {{ projet.dossier_ds.ds_date_depot|date:"d/m/Y" }}
+        </td>
+        <td>
+            {{ projet.dossier_ds.projet_intitule }}
+        </td>
+        <td>
+            {{ projet.demandeur.name | format_demandeur_nom }}
+        </td>
+        <td>
+            {% include "includes/table_forms/_dotation_form.html" with simu=simu %}
+        </td>
+        <td class="gsl-money">
+            {{ projet.dossier_ds.finance_cout_total|euro:2 }}
+        </td>
+        <td class="gsl-money">
+            {{ projet.dossier_ds.demande_montant|euro:2 }}
+            <br>
+            {{ dotation_projet.taux_de_subvention_sollicite|percent }}
+        </td>
+        <td class="gsl-money">
+            {% include "includes/table_forms/_montant_form.html" %}
+        </td>
+        <td class="gsl-money">
+            {% include "includes/table_forms/_taux_form.html" %}
+        </td>
+        <td>
+            <select class="fr-select gsl-projet-table__select" name="" id="">
+                <option value="">
+                    {{ projet.categorie_doperation.first }}
+                </option>
+            </select>
+        </td>
+        <td>
+            {% include "includes/table_forms/_status_form.html" %}
+        </td>
+        <td class="fr-cell--right gsl-nowrap">
+            <a class="fr-btn--tertiary-no-outline gsl-no-underline"
+               href="{{ simu.get_absolute_url }}">
+                <span class="fr-sr-only">Voir le projet {{ projet.dossier_ds.ds_number }}</span>
+                <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
+            </a>
+        </td>
+    </tr>
+
+    {% if other_simu %}
+        <tr id="other-simulation-{{ simu.pk }}" class="other-simulation-row">
+            <td colspan=7 class="information-other-dotation">
+                Informations pour la dotation {{ other_simu.dotation_projet.dotation }}
+            </td>
+            <td class="gsl-money">
+                <div class="gsl-money">
+                    <b>{{ other_simu.montant }}</b>
+                </div>
+            </td>
+            <td class="gsl-money">
+                <div class="gsl-money">
+                    <b>{{ other_simu.taux }}</b>
+                </div>
+            </td>
+            <td>
+                <div class="gsl-money">
+                    Catégorie d'opération {{ other_simu.dotation_projet.dotation }}
+                </div>
+            </td>
+            <td class="other-simulation-status">
+                <b>{{ other_simu.get_status_display }}</b>
+            </td>
+            <td class="fr-cell--right gsl-nowrap">
+            </td>
+        </tr>
+    {% endif %}
+{% endwith %}

--- a/gsl_simulation/tests/views/test_simulation_detail_view.py
+++ b/gsl_simulation/tests/views/test_simulation_detail_view.py
@@ -1,0 +1,77 @@
+import pytest
+
+from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL
+from gsl_projet.models import DotationProjet, Projet
+from gsl_projet.tests.factories import DotationProjetFactory, ProjetFactory
+from gsl_simulation.models import SimulationProjet
+from gsl_simulation.tests.factories import SimulationProjetFactory
+from gsl_simulation.views.simulation_views import SimulationDetailView
+
+
+@pytest.fixture
+def one_dotation_projets():
+    DotationProjetFactory.create_batch(2, dotation=DOTATION_DSIL)
+
+
+@pytest.mark.django_db
+def test_get_other_dotations_simulation_projet_no_double_dotation(one_dotation_projets):
+    projets = Projet.objects.all()
+    assert projets.count() == 2
+
+    view = SimulationDetailView()
+
+    result = view._get_other_dotations_simulation_projet(projets, DOTATION_DSIL)
+
+    assert result == {}
+
+
+@pytest.fixture
+def double_dotation_projet():
+    projet = ProjetFactory()
+    DotationProjetFactory(projet=projet, dotation=DOTATION_DETR)
+    DotationProjetFactory(projet=projet, dotation=DOTATION_DSIL)
+    return projet
+
+
+@pytest.mark.django_db
+def test_get_other_dotations_simulation_projet(
+    double_dotation_projet, one_dotation_projets
+):
+    projets = Projet.objects.all()
+    assert projets.count() == 3
+    assert DotationProjet.objects.filter(dotation=DOTATION_DSIL).count() == 3
+    assert DotationProjet.objects.filter(dotation=DOTATION_DETR).count() == 1
+
+    for dp in DotationProjet.objects.all():
+        SimulationProjetFactory(dotation_projet=dp)
+
+    view = SimulationDetailView()
+
+    result = view._get_other_dotations_simulation_projet(projets, DOTATION_DSIL)
+
+    detr_simulation_projet = SimulationProjet.objects.filter(
+        dotation_projet__projet=double_dotation_projet,
+        dotation_projet__dotation=DOTATION_DETR,
+    )
+    assert detr_simulation_projet.count() == 1
+    assert result == {
+        double_dotation_projet.id: detr_simulation_projet.first(),
+    }
+
+
+@pytest.mark.django_db
+def test_get_other_dotations_simulation_projet_without_other_simulation_projet(
+    double_dotation_projet, one_dotation_projets
+):
+    projets = Projet.objects.all()
+    assert projets.count() == 3
+    assert DotationProjet.objects.filter(dotation=DOTATION_DSIL).count() == 3
+    assert DotationProjet.objects.filter(dotation=DOTATION_DETR).count() == 1
+
+    view = SimulationDetailView()
+
+    result = view._get_other_dotations_simulation_projet(projets, DOTATION_DSIL)
+
+    assert result == {
+        double_dotation_projet.id: None,
+    }


### PR DESCRIPTION
## 🌮 Objectif

Permettre de rappeler les informations de la 2ème dotation d'un projet en double dotations dans une simulation.

## 🔍 Liste des modifications

- Création de la fonction `_get_other_dotations_simulation_projet` dans la vue `SimulationDetailView`

## 🖼️ Images

<img width="1220" alt="image" src="https://github.com/user-attachments/assets/07ee2065-bc86-4456-9001-4fb69264669f" />

## A faire

- [x] Tester la fonction