### PR TITLE
Ajoute le port dans les ALLOWED_HOSTS du .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 DEBUG=True  # False for prod
 
 HOST=localhost
-ALLOWED_HOSTS=localhost,127.0.0.1,localhost:8000
+ALLOWED_HOSTS=localhost,127.0.0.1,localhost:8000,127.0.0.1:8000
 
 SECRET_KEY="change-this-secret-value-in-production-please"
 


### PR DESCRIPTION
## 🌮 Objectif

Ce paramètre était mal configuré chez moi, ce qui posait quelques bugs à la marge. Rien de grave, mais vu ce que ça coûte d'éviter ça aux futur·es collègues, corrigeons !
