### PR TITLE
Ajout du formulaire des montants dans une page de projet modifiable (assiette, montant et taux)

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -182,6 +182,9 @@ USE_I18N = True
 
 USE_TZ = True
 
+USE_THOUSAND_SEPARATOR = True
+THOUSAND_SEPARATOR = " "
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
 

--- a/gsl_programmation/admin.py
+++ b/gsl_programmation/admin.py
@@ -66,7 +66,7 @@ class ProgrammationProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
         "notified_at",
     )
     autocomplete_fields = ("enveloppe",)
-    raw_id_fields = ("dotation_projet",)  # TODO pr_dotation, ok here ?
+    raw_id_fields = ("dotation_projet",)
     readonly_fields = ("created_at", "updated_at")
 
     def formatted_amount(self, obj):

--- a/gsl_programmation/tests/services/test_programmation_projet_service.py
+++ b/gsl_programmation/tests/services/test_programmation_projet_service.py
@@ -70,7 +70,7 @@ def test_create_or_update_from_dotation_projet_with_no_existing_one_and_complete
     )
     assert programmation_projet.dotation_projet == accepted_dotation_projet
     assert programmation_projet.montant == 1_000
-    assert programmation_projet.taux == Decimal("33.33")
+    assert programmation_projet.taux == Decimal("33.333")
     assert programmation_projet.status == ProgrammationProjet.STATUS_ACCEPTED
     assert programmation_projet.enveloppe == detr_enveloppe
     assert ProgrammationProjet.objects.count() == 11
@@ -99,7 +99,7 @@ def test_create_or_update_from_dotation_projet_with_an_existing_one_and_complete
     )
     assert programmation_projet.dotation_projet == accepted_dotation_projet
     assert programmation_projet.montant == 1_000
-    assert programmation_projet.taux == Decimal("33.33")
+    assert programmation_projet.taux == Decimal("33.333")
     assert programmation_projet.status == ProgrammationProjet.STATUS_ACCEPTED
     assert programmation_projet.enveloppe == detr_enveloppe
 

--- a/gsl_projet/forms.py
+++ b/gsl_projet/forms.py
@@ -80,15 +80,9 @@ class DotationProjetForm(ModelForm, DsfrBaseForm):
         required=False,
         widget=forms.Select(attrs={"form": "dotation_projet_form"}),
     )
-    assiette = forms.DecimalField(
-        label="Montant des dépenses éligibles retenues (€)",
-        required=False,
-        widget=forms.NumberInput(attrs={"form": "dotation_projet_form"}),
-    )
 
     class Meta:
         model = DotationProjet
         fields = [
             "detr_avis_commission",
-            "assiette",
         ]

--- a/gsl_projet/forms.py
+++ b/gsl_projet/forms.py
@@ -80,9 +80,15 @@ class DotationProjetForm(ModelForm, DsfrBaseForm):
         required=False,
         widget=forms.Select(attrs={"form": "dotation_projet_form"}),
     )
+    assiette = forms.DecimalField(
+        label="Montant des dépenses éligibles retenues (€)",
+        required=False,
+        widget=forms.NumberInput(attrs={"form": "dotation_projet_form"}),
+    )
 
     class Meta:
         model = DotationProjet
         fields = [
             "detr_avis_commission",
+            "assiette",
         ]

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -231,7 +231,7 @@ class DotationProjet(models.Model):
         if (
             self.dossier_ds.finance_cout_total
             and self.assiette
-            and self.dossier_ds.finance_cout_total
+            and self.dossier_ds.finance_cout_total < self.assiette  # TODO test
         ):
             errors["assiette"] = (
                 "L'assiette ne doit pas être supérieure au coût total du projet."

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -231,7 +231,7 @@ class DotationProjet(models.Model):
         if (
             self.dossier_ds.finance_cout_total
             and self.assiette
-            and self.dossier_ds.finance_cout_total < self.assiette  # TODO test
+            and self.dossier_ds.finance_cout_total < self.assiette
         ):
             errors["assiette"] = (
                 "L'assiette ne doit pas être supérieure au coût total du projet."

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -228,6 +228,15 @@ class DotationProjet(models.Model):
                     f"L'avis de la commission DETR ne doit être renseigné que pour les projets DETR dont le montant demandé est supérieur ou égal à {MIN_DEMANDE_MONTANT_FOR_AVIS_DETR}."
                 )
 
+        if (
+            self.dossier_ds.finance_cout_total
+            and self.assiette
+            and self.dossier_ds.finance_cout_total
+        ):
+            errors["assiette"] = (
+                "L'assiette ne doit pas être supérieure au coût total du projet."
+            )
+
         if errors:
             raise ValidationError(errors)
 

--- a/gsl_projet/services/dotation_projet_services.py
+++ b/gsl_projet/services/dotation_projet_services.py
@@ -117,6 +117,23 @@ class DotationProjetService:
         except InvalidOperation:
             return Decimal(0)
 
+    # TODO test
+    @classmethod
+    def compute_montant_from_taux(
+        cls, dotation_projet: DotationProjet, new_taux: float | Decimal
+    ) -> float | Decimal:
+        try:
+            assiette = dotation_projet.assiette_or_cout_total
+            new_montant = (assiette * Decimal(new_taux) / 100) if assiette else 0
+            new_montant = round(new_montant, 2)
+            return max(min(new_montant, dotation_projet.assiette_or_cout_total), 0)
+        except TypeError:
+            return 0
+        except ZeroDivisionError:
+            return 0
+        except InvalidOperation:
+            return 0
+
     @classmethod
     def validate_montant(
         cls, montant: float | Decimal, dotation_projet: DotationProjet

--- a/gsl_projet/services/dotation_projet_services.py
+++ b/gsl_projet/services/dotation_projet_services.py
@@ -98,26 +98,6 @@ class DotationProjetService:
 
         return None
 
-    # TODO, to remove ??
-    @classmethod
-    def compute_taux_from_montant(
-        cls, dotation_projet: DotationProjet, new_montant: float | Decimal
-    ) -> Decimal:
-        try:
-            new_taux = round(
-                (Decimal(new_montant) / Decimal(dotation_projet.assiette_or_cout_total))
-                * 100,
-                2,
-            )
-            return max(min(new_taux, Decimal(100)), Decimal(0))
-        except TypeError:
-            return Decimal(0)
-        except ZeroDivisionError:
-            return Decimal(0)
-        except InvalidOperation:
-            return Decimal(0)
-
-    # TODO test
     @classmethod
     def compute_montant_from_taux(
         cls, dotation_projet: DotationProjet, new_taux: float | Decimal
@@ -128,8 +108,6 @@ class DotationProjetService:
             new_montant = round(new_montant, 2)
             return max(min(new_montant, dotation_projet.assiette_or_cout_total), 0)
         except TypeError:
-            return 0
-        except ZeroDivisionError:
             return 0
         except InvalidOperation:
             return 0

--- a/gsl_projet/templates/gsl_projet/projet/tab_projet.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_projet.html
@@ -285,18 +285,7 @@
                                 {{ dotation_projet.dotation }}
                             </h6>
                         {% endif %}
-
-                        <div class="fr-highlight fr-highlight--beige-gris-galet fr-ml-0 fr-mb-4w">
-                            <p>
-                                <b>Montant des dépenses éligibles retenues :</b> {{ dotation_projet.assiette|euro:2 }}
-                            </p>
-                            <p>
-                                <b>Montant accordé :</b> {{ dotation_projet.montant_retenu|euro:2 }}
-                            </p>
-                            <p>
-                                <b>Taux de subvention :</b> {{ dotation_projet.taux_retenu|percent:2 }}
-                            </p>
-                        </div>
+                        {% include "includes/projet_detail/dotation_montant_info.html" with assiette=dotation_projet.assiette montant=dotation_projet.montant_retenu taux=dotation_projet.taux_retenu %}
                     {% endfor %}
                 {% endblock montants_form %}
             </section>

--- a/gsl_projet/templates/gsl_projet/projet/tab_projet.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_projet.html
@@ -278,25 +278,27 @@
                         <b>Montant de la subvention demandée : </b>{{ dossier.demande_montant|euro:2 }} ({{ dossier.taux_demande|percent:2 }} du coût total)
                     </p>
                 </div>
-                {% for dotation_projet in projet.dotationprojet_set.all %}
-                    {% if projet.dotationprojet_set.all|length > 1 %}
-                        <h6>
-                            {{ dotation_projet.dotation }}
-                        </h6>
-                    {% endif %}
+                {% block montants_form %}
+                    {% for dotation_projet in projet.dotationprojet_set.all %}
+                        {% if projet.dotationprojet_set.all|length > 1 %}
+                            <h6>
+                                {{ dotation_projet.dotation }}
+                            </h6>
+                        {% endif %}
 
-                    <div class="fr-highlight fr-highlight--beige-gris-galet fr-ml-0 fr-mb-4w">
-                        <p>
-                            <b>Montant des dépenses éligibles retenues :</b> {{ dotation_projet.assiette|euro:2 }}
-                        </p>
-                        <p>
-                            <b>Montant accordé :</b> {{ dotation_projet.montant_retenu|euro:2 }}
-                        </p>
-                        <p>
-                            <b>Taux de subvention :</b> {{ dotation_projet.taux_retenu|percent:2 }}
-                        </p>
-                    </div>
-                {% endfor %}
+                        <div class="fr-highlight fr-highlight--beige-gris-galet fr-ml-0 fr-mb-4w">
+                            <p>
+                                <b>Montant des dépenses éligibles retenues :</b> {{ dotation_projet.assiette|euro:2 }}
+                            </p>
+                            <p>
+                                <b>Montant accordé :</b> {{ dotation_projet.montant_retenu|euro:2 }}
+                            </p>
+                            <p>
+                                <b>Taux de subvention :</b> {{ dotation_projet.taux_retenu|percent:2 }}
+                            </p>
+                        </div>
+                    {% endfor %}
+                {% endblock montants_form %}
             </section>
         </div>
     </div>

--- a/gsl_projet/templates/includes/projet_detail/dotation_montant_info.html
+++ b/gsl_projet/templates/includes/projet_detail/dotation_montant_info.html
@@ -1,0 +1,13 @@
+{% load gsl_filters %}
+
+<div class="fr-highlight fr-highlight--beige-gris-galet fr-ml-0 fr-mb-4w">
+    <p>
+        <b>Montant des dépenses éligibles retenues :</b> {{ assiette|euro:2 }}
+    </p>
+    <p>
+        <b>Montant accordé :</b> {{ montant|euro:2 }}
+    </p>
+    <p>
+        <b>Taux de subvention :</b> {{ taux|percent:2 }}
+    </p>
+</div>

--- a/gsl_projet/tests/models/test_dotation_projet.py
+++ b/gsl_projet/tests/models/test_dotation_projet.py
@@ -130,6 +130,36 @@ def test_error_raised_if_detr_avis_commission_is_set_on_dsil_projet(
         assert dotation_projet.detr_avis_commission == avis_commission
 
 
+@pytest.mark.parametrize(
+    ("cout_total, assiette, must_raise_error"),
+    (
+        (None, 1_000, False),
+        (1_000, 1_000, False),
+        (1_000, 1_001, True),
+        (1_000, None, False),
+    ),
+)
+def test_error_raised_if_assiette_is_greater_than_cout_total(
+    cout_total, assiette, must_raise_error
+):
+    dotation_projet = DotationProjetFactory(
+        dotation=DOTATION_DETR,
+        assiette=assiette,
+        projet__dossier_ds__finance_cout_total=cout_total,
+    )
+
+    if must_raise_error:
+        with pytest.raises(ValidationError) as exc_info:
+            dotation_projet.clean()
+        assert (
+            str(exc_info.value.messages[0])
+            == "L'assiette ne doit pas être supérieure au coût total du projet."
+        )
+    else:
+        dotation_projet.clean()
+        assert dotation_projet.assiette == assiette
+
+
 # Accept
 
 

--- a/gsl_projet/tests/models/test_dotation_projet.py
+++ b/gsl_projet/tests/models/test_dotation_projet.py
@@ -259,7 +259,7 @@ def test_accept_dotation_projet_update_programmation_projet():
     assert programmation_projets.count() == 1
     programmation_projet = programmation_projets.first()
     assert programmation_projet.montant == 5_000
-    assert programmation_projet.taux == Decimal("55.56")
+    assert programmation_projet.taux == Decimal("55.556")
     assert programmation_projet.status == ProgrammationProjet.STATUS_ACCEPTED
 
 

--- a/gsl_projet/tests/models/test_projet.py
+++ b/gsl_projet/tests/models/test_projet.py
@@ -41,3 +41,37 @@ def test_can_have_a_commission_detr_avis(
         projet.can_have_a_commission_detr_avis
         is expected_can_have_a_commission_detr_avis
     )
+    assert projet.is_asking_for_detr is expected_can_have_a_commission_detr_avis
+
+
+def test_has_double_dotations():
+    projet = ProjetFactory()
+    assert projet.has_double_dotations is False
+
+    DotationProjetFactory(projet=projet, dotation=DOTATION_DETR)
+    assert projet.has_double_dotations is False
+
+    DotationProjetFactory(projet=projet, dotation=DOTATION_DSIL)
+    assert projet.has_double_dotations is True
+
+
+def test_dotation_detr():
+    projet = ProjetFactory()
+    assert projet.dotation_detr is None
+
+    dotation = DotationProjetFactory(projet=projet, dotation=DOTATION_DSIL)
+    assert projet.dotation_detr is None
+
+    dotation = DotationProjetFactory(projet=projet, dotation=DOTATION_DETR)
+    assert projet.dotation_detr == dotation
+
+
+def test_dotation_dsil():
+    projet = ProjetFactory()
+    assert projet.dotation_dsil is None
+
+    dotation = DotationProjetFactory(projet=projet, dotation=DOTATION_DETR)
+    assert projet.dotation_dsil is None
+
+    dotation = DotationProjetFactory(projet=projet, dotation=DOTATION_DSIL)
+    assert projet.dotation_dsil == dotation

--- a/gsl_projet/tests/models/test_projet.py
+++ b/gsl_projet/tests/models/test_projet.py
@@ -41,7 +41,6 @@ def test_can_have_a_commission_detr_avis(
         projet.can_have_a_commission_detr_avis
         is expected_can_have_a_commission_detr_avis
     )
-    assert projet.is_asking_for_detr is expected_can_have_a_commission_detr_avis
 
 
 def test_has_double_dotations():

--- a/gsl_projet/tests/services/test_dotation_projet_services.py
+++ b/gsl_projet/tests/services/test_dotation_projet_services.py
@@ -78,11 +78,11 @@ def test_create_or_update_dotation_projet_from_projet_do_not_remove_dotation_pro
     projet_dotation_projets = DotationProjet.objects.filter(projet_id=projet.id)
     assert projet_dotation_projets.count() == 2
 
-    dotation_projet = projet_dotation_projets[0]
-    assert dotation_projet.dotation == DOTATION_DSIL
+    dsil_dotation_projets = projet_dotation_projets.filter(dotation=DOTATION_DSIL)
+    assert dsil_dotation_projets.count() == 1
 
-    dotation_projet = projet_dotation_projets[1]
-    assert dotation_projet.dotation == DOTATION_DETR
+    detr_dotation_projet = projet_dotation_projets.filter(dotation=DOTATION_DETR)
+    assert detr_dotation_projet.count() == 1
 
 
 @pytest.mark.django_db

--- a/gsl_projet/tests/services/test_dotation_projet_services.py
+++ b/gsl_projet/tests/services/test_dotation_projet_services.py
@@ -259,25 +259,6 @@ def test_create_simulation_projets_from_dotation_projet_with_a_dsil_and_departem
     assert last_year_simulation_projets.count() == 0
 
 
-@pytest.mark.django_db
-def test_compute_taux_from_montant():
-    dotation_projet = DotationProjetFactory(
-        projet__dossier_ds__finance_cout_total=100_000,
-    )
-    taux = DotationProjetService.compute_taux_from_montant(dotation_projet, 10_000)
-    assert taux == 10
-
-    dotation_projet = DotationProjetFactory(
-        assiette=50_000,
-    )
-    taux = DotationProjetService.compute_taux_from_montant(dotation_projet, 10_000)
-    assert taux == 20
-
-    dotation_projet = DotationProjetFactory()
-    taux = DotationProjetService.compute_taux_from_montant(dotation_projet, 10_000)
-    assert taux == 0
-
-
 def test_get_dotation_projet_status_from_dossier():
     accepted = Dossier(ds_state=Dossier.STATE_ACCEPTE)
     en_construction = Dossier(ds_state=Dossier.STATE_EN_CONSTRUCTION)
@@ -375,41 +356,62 @@ def test_validate_montant(
         DotationProjetService.validate_montant(montant, dotation_projet)
 
 
+@pytest.mark.django_db
+def test_compute_montant_from_taux():
+    dotation_projet = DotationProjetFactory(
+        projet__dossier_ds__finance_cout_total=100_000,
+    )
+    taux = DotationProjetService.compute_montant_from_taux(dotation_projet, 25)
+    assert taux == 25_000
+
+    dotation_projet = DotationProjetFactory(
+        assiette=50_000,
+    )
+    taux = DotationProjetService.compute_montant_from_taux(dotation_projet, 25)
+    assert taux == 12_500
+
+    dotation_projet = DotationProjetFactory()
+    taux = DotationProjetService.compute_montant_from_taux(dotation_projet, 25)
+    assert taux == 0
+
+
 test_data = (
-    (10_000, 30_000, 33.33),
-    (10_000, 0, 0),
-    (10_000, 10_000, 100),
-    (100_000, 10_000, 100),
-    (10_000, -3_000, 0),
+    (30_000, 33.333, 9_999.90),
+    (10_000, 100, 10_000),
+    (10_000, 1000, 10_000),
+    (-3_000, 10, 0),
+    (0, 100, 0),
     (0, 0, 0),
-    (Decimal(0), Decimal(0), 0),
-    (0, None, 0),
+    (Decimal(0), 0, 0),
+    (1_000, Decimal(10), 100),
     (None, 0, 0),
-    (1_000, None, 0),
-    (None, 4_000, 0),
+    (None, 10, 0),
+    (0, None, 0),
+    (10, None, 0),
+    (4_000, 0, 0),
 )
 
 
-@pytest.mark.parametrize("montant, assiette, expected_taux", test_data)
+@pytest.mark.parametrize("assiette, taux, expected_montant", test_data)
 @pytest.mark.django_db
-def test_compute_taux_from_montant_with_various_assiettes(
-    assiette, montant, expected_taux
+def test_compute_montant_from_taux_with_various_assiettes(
+    assiette, taux, expected_montant
 ):
     dotation_projet = DotationProjetFactory(assiette=assiette)
-    taux = DotationProjetService.compute_taux_from_montant(dotation_projet, montant)
-    assert taux == round(Decimal(expected_taux), 2)
+    montant = DotationProjetService.compute_montant_from_taux(dotation_projet, taux)
+    assert montant == round(Decimal(expected_montant), 2)
 
 
-@pytest.mark.parametrize("montant, cout_total, expected_taux", test_data)
+@pytest.mark.parametrize("cout_total, taux, expected_montant", test_data)
 @pytest.mark.django_db
-def test_compute_taux_from_montant_with_various_cout_total(
-    cout_total, montant, expected_taux
+def test_compute_montant_from_taux_with_various_cout_total(
+    taux, cout_total, expected_montant
 ):
     dotation_projet = DotationProjetFactory(
         projet__dossier_ds__finance_cout_total=cout_total
     )
-    taux = DotationProjetService.compute_taux_from_montant(dotation_projet, montant)
-    assert taux == round(Decimal(expected_taux), 2)
+    montant = DotationProjetService.compute_montant_from_taux(dotation_projet, taux)
+    assert montant == round(Decimal(expected_montant), 2)
 
 
 @pytest.mark.parametrize(

--- a/gsl_projet/tests/utils/test_utils.py
+++ b/gsl_projet/tests/utils/test_utils.py
@@ -45,7 +45,7 @@ def test_order_couples_tuple_by_first_value_empty_choices():
 @pytest.mark.parametrize(
     "numerator, denominator, expected_taux",
     (
-        (10_000, 30_000, 33.33),
+        (10_000, 30_000, 33.333),
         (10_000, 0, 0),
         (10_000, 10_000, 100),
         (100_000, 10_000, 1000),  # we accept more than 100%
@@ -60,4 +60,4 @@ def test_order_couples_tuple_by_first_value_empty_choices():
 )
 def test_compute_taux(numerator, denominator, expected_taux):
     taux = compute_taux(numerator, denominator)
-    assert taux == round(Decimal(expected_taux), 2)
+    assert taux == round(Decimal(expected_taux), 3)

--- a/gsl_projet/utils/utils.py
+++ b/gsl_projet/utils/utils.py
@@ -17,7 +17,7 @@ def transform_choices_to_map(choices: tuple[tuple[str, str], ...]) -> dict[str, 
 
 def compute_taux(numerator: float | Decimal, denominator: float | Decimal) -> Decimal:
     try:
-        new_taux = round((Decimal(numerator) / Decimal(denominator)) * 100, 2)
+        new_taux = round((Decimal(numerator) / Decimal(denominator)) * 100, 3)
         return max(new_taux, Decimal(0))
     except TypeError:
         return Decimal(0)

--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -66,8 +66,8 @@ class SimulationProjetForm(ModelForm, DsfrBaseForm):
 
     taux = forms.DecimalField(
         label="Taux de subvention (%)",
-        max_digits=5,
-        decimal_places=2,
+        max_digits=6,
+        decimal_places=3,
         min_value=0,
         max_value=100,
         required=False,
@@ -100,7 +100,6 @@ class SimulationProjetForm(ModelForm, DsfrBaseForm):
         cleaned_data = super().clean()
         simulation_projet = self.instance
         dotation_projet = self.instance.dotation_projet
-        dotation_projet.clean()
 
         new_montant = cleaned_data.get("montant")
         has_montant_changed = simulation_projet.montant != new_montant
@@ -125,6 +124,8 @@ class SimulationProjetForm(ModelForm, DsfrBaseForm):
                 )
                 cleaned_data["montant"] = computed_montant
 
+        dotation_projet.assiette = new_assiette
+        dotation_projet.clean()
         return cleaned_data
 
     def save(self, commit=True):

--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -52,7 +52,8 @@ class SimulationProjetForm(ModelForm, DsfrBaseForm):
         decimal_places=2,
         min_value=0,
         required=False,
-        widget=forms.NumberInput(attrs={"form": "simulation_projet_form", "min": 0}),
+        localize=True,
+        widget=forms.TextInput(attrs={"form": "simulation_projet_form", "min": 0}),
     )
 
     montant = forms.DecimalField(
@@ -61,7 +62,8 @@ class SimulationProjetForm(ModelForm, DsfrBaseForm):
         decimal_places=2,
         min_value=0,
         required=False,
-        widget=forms.NumberInput(attrs={"form": "simulation_projet_form", "min": 0}),
+        localize=True,
+        widget=forms.TextInput(attrs={"form": "simulation_projet_form", "min": 0}),
     )
 
     taux = forms.DecimalField(
@@ -71,7 +73,8 @@ class SimulationProjetForm(ModelForm, DsfrBaseForm):
         min_value=0,
         max_value=100,
         required=False,
-        widget=forms.NumberInput(
+        localize=True,
+        widget=forms.TextInput(
             attrs={"form": "simulation_projet_form", "min": 0, "max": 100}
         ),
     )

--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -1,9 +1,12 @@
 from django import forms
 from django.core.exceptions import ValidationError
+from django.forms import ModelForm
 from dsfr.forms import DsfrBaseForm
 
 from gsl_core.models import Perimetre
 from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL
+from gsl_projet.services.dotation_projet_services import DotationProjetService
+from gsl_simulation.models import SimulationProjet
 
 
 class SimulationForm(DsfrBaseForm):
@@ -37,5 +40,68 @@ class SimulationForm(DsfrBaseForm):
                 raise ValidationError(
                     f"Votre compte est associé à un périmètre régional ({self.user.perimetre}), vous ne pouvez pas créer une simulation de programmation pour un fonds de dotation DETR."
                 )
+
+        return cleaned_data
+
+
+class SimulationProjetForm(ModelForm, DsfrBaseForm):
+    montant = forms.DecimalField(
+        label="Montant prévisionnel accordé (€)",
+        max_digits=14,
+        decimal_places=2,
+        min_value=0,
+        required=False,
+        widget=forms.NumberInput(attrs={"form": "simulation_projet_form", "min": 0}),
+    )
+
+    taux = forms.DecimalField(
+        label="Taux de subvention (%)",
+        max_digits=5,
+        decimal_places=2,
+        min_value=0,
+        max_value=100,
+        required=False,
+        widget=forms.NumberInput(
+            attrs={"form": "simulation_projet_form", "min": 0, "max": 100}
+        ),
+    )
+
+    class Meta:
+        model = SimulationProjet
+        fields = ["montant", "taux"]
+
+    def clean(self):
+        cleaned_data = super().clean()
+        simulation_projet = self.instance
+        new_montant = cleaned_data.get("montant")
+        new_taux = cleaned_data.get("taux")
+        has_montant_changed = simulation_projet.montant != new_montant
+        has_taux_changed = simulation_projet.taux != new_taux
+
+        if has_montant_changed:
+            computed_taux = DotationProjetService.compute_taux_from_montant(
+                simulation_projet.dotation_projet, new_montant
+            )
+
+            if has_taux_changed:
+                if computed_taux != new_taux:
+                    self.add_error(
+                        "montant", "Le montant doit être cohérent avec le taux."
+                    )
+                    self.add_error(
+                        "taux", "Le taux doit être cohérent avec le montant."
+                    )
+                    raise ValidationError(
+                        "Le montant et le taux ne sont pas cohérents. Veuillez vérifier vos données."
+                    )
+
+            else:
+                cleaned_data["taux"] = computed_taux
+
+        elif has_taux_changed:
+            computed_montant = DotationProjetService.compute_montant_from_taux(
+                simulation_projet.dotation_projet, new_taux
+            )
+            cleaned_data["montant"] = computed_montant
 
         return cleaned_data

--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -104,30 +104,21 @@ class SimulationProjetForm(ModelForm, DsfrBaseForm):
         simulation_projet = self.instance
         dotation_projet = self.instance.dotation_projet
 
-        new_montant = cleaned_data.get("montant")
-        has_montant_changed = simulation_projet.montant != new_montant
-
-        new_assiette = cleaned_data.get("assiette")
-        has_assiette_changed = (
-            simulation_projet.dotation_projet.assiette != new_assiette
-        )
-
-        if has_assiette_changed or has_montant_changed:
-            computed_taux = compute_taux(new_montant, new_assiette)
+        if "assiette" in self.changed_data or "montant" in self.changed_data:
+            computed_taux = compute_taux(
+                cleaned_data.get("montant"), cleaned_data.get("assiette")
+            )
             cleaned_data["taux"] = computed_taux
 
         else:
-            new_taux = cleaned_data.get("taux")
-            has_taux_changed = (
-                simulation_projet.taux != new_taux
-            )  # TODO Test si le taux a changé et de 0,01 ou moins
-            if has_taux_changed:
+            # TODO Test si le taux a changé et de 0,01 ou moins
+            if "taux" in self.changed_data:
                 computed_montant = DotationProjetService.compute_montant_from_taux(
-                    simulation_projet.dotation_projet, new_taux
+                    simulation_projet.dotation_projet, cleaned_data.get("taux")
                 )
                 cleaned_data["montant"] = computed_montant
 
-        dotation_projet.assiette = new_assiette
+        dotation_projet.assiette = cleaned_data.get("assiette")
         dotation_projet.clean()
         return cleaned_data
 

--- a/gsl_simulation/models.py
+++ b/gsl_simulation/models.py
@@ -120,17 +120,10 @@ class SimulationProjet(models.Model):
 
     def clean(self):
         errors = {}
-        self._validate_taux(errors)
         self._validate_montant(errors)
         self._validate_dotation(errors)
         if errors:
             raise ValidationError(errors)
-
-    def _validate_taux(self, errors):
-        if self.taux and self.taux > 100:
-            errors["taux"] = {
-                "Le taux de la simulation ne peut pas être supérieur à 100."
-            }
 
     def _validate_montant(self, errors):
         if self.dotation_projet.assiette is not None:

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -154,9 +154,9 @@ class SimulationProjetService:
 
     @classmethod
     def update_taux(cls, simulation_projet: SimulationProjet, new_taux: float):
-        assiette = simulation_projet.dotation_projet.assiette_or_cout_total
-        new_montant = (assiette * Decimal(new_taux) / 100) if assiette else 0
-        new_montant = round(new_montant, 2)
+        new_montant = DotationProjetService.compute_montant_from_taux(
+            simulation_projet.dotation_projet, new_taux
+        )
 
         simulation_projet.montant = new_montant
         simulation_projet.save()

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -104,19 +104,6 @@ class SimulationProjetService:
         )
 
     @classmethod
-    def get_initial_taux_from_dotation_projet(
-        cls, dotation_projet: DotationProjet, montant: Decimal
-    ) -> Decimal:
-        if montant > 0:
-            return (
-                dotation_projet.projet.dossier_ds.annotations_taux
-                or DotationProjetService.compute_taux_from_montant(
-                    dotation_projet, montant
-                )
-            )
-        return Decimal(0)
-
-    @classmethod
     def update_status(cls, simulation_projet: SimulationProjet, new_status: str):
         if new_status == SimulationProjet.STATUS_ACCEPTED:
             return cls._accept_a_simulation_projet(simulation_projet)

--- a/gsl_simulation/static/css/simulation_projet_detail.css
+++ b/gsl_simulation/static/css/simulation_projet_detail.css
@@ -57,8 +57,3 @@
 #id_is_budget_vert {
   width:180px
 }
-
-.hint-text {
-  font-size: calc(12rem / 16);
-  color: var(--text-mention-grey);
-}

--- a/gsl_simulation/static/js/handleInteractionInSimulationProjet.js
+++ b/gsl_simulation/static/js/handleInteractionInSimulationProjet.js
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const montant = parseValue(montantInput.value);
       if (!isNaN(assiette) && !isNaN(montant)) {
           const taux = (montant / assiette) * 100;
-          tauxInput.value = taux.toFixed(2).replace('.', ',');
+          tauxInput.value = taux.toFixed(3).replace('.', ',');
       }
   });
 
@@ -71,7 +71,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const montant = parseValue(montantInput.value);
       if (!isNaN(montant)) {
           const taux = (montant / TOTAL_ELIGIBLE) * 100;
-          tauxInput.value = taux.toFixed(2).replace('.', ',');
+          tauxInput.value = taux.toFixed(3).replace('.', ',');
       }
   });
 

--- a/gsl_simulation/static/js/handleInteractionInSimulationProjet.js
+++ b/gsl_simulation/static/js/handleInteractionInSimulationProjet.js
@@ -44,3 +44,43 @@ document.querySelectorAll("#confirm-dotation-update").forEach(elt => {
     closeModal()
   })
 })
+
+
+// Montant update
+document.addEventListener('DOMContentLoaded', function () {
+  const assietteInput = document.querySelector('#id_assiette'); 
+  const montantInput = document.querySelector('#id_montant'); 
+  const tauxInput = document.querySelector('#id_taux');
+
+  
+  const parseValue = (val) => parseFloat(val.replace(',', '.').replace(/\s/g, ''));
+  const TOTAL_ELIGIBLE = assietteInput.value ? parseValue(assietteInput.value) : 0;
+
+  // Lorsqu'on modifie l'assiette
+  assietteInput.addEventListener('input', function () {
+      const assiette = parseValue(assietteInput.value);
+      const montant = parseValue(montantInput.value);
+      if (!isNaN(assiette) && !isNaN(montant)) {
+          const taux = (montant / assiette) * 100;
+          tauxInput.value = taux.toFixed(2).replace('.', ',');
+      }
+  });
+
+  // Lorsqu'on modifie le montant
+  montantInput.addEventListener('input', function () {
+      const montant = parseValue(montantInput.value);
+      if (!isNaN(montant)) {
+          const taux = (montant / TOTAL_ELIGIBLE) * 100;
+          tauxInput.value = taux.toFixed(2).replace('.', ',');
+      }
+  });
+
+  // Lorsqu'on modifie le taux
+  tauxInput.addEventListener('input', function () {
+      const taux = parseValue(tauxInput.value);
+      if (!isNaN(taux)) {
+          const montant = (taux / 100) * TOTAL_ELIGIBLE;
+          montantInput.value = montant.toFixed(2).replace('.', ',');
+      }
+  });
+});

--- a/gsl_simulation/static/js/handleInteractionInSimulationProjet.js
+++ b/gsl_simulation/static/js/handleInteractionInSimulationProjet.js
@@ -48,13 +48,15 @@ document.querySelectorAll("#confirm-dotation-update").forEach(elt => {
 
 // Montant update
 document.addEventListener('DOMContentLoaded', function () {
+  const form = document.querySelector('#simulation_projet_form');
   const assietteInput = document.querySelector('#id_assiette'); 
   const montantInput = document.querySelector('#id_montant'); 
   const tauxInput = document.querySelector('#id_taux');
-
   
+  const coutTotal = form.dataset.coutTotal;
+
   const parseValue = (val) => parseFloat(val.replace(',', '.').replace(/\s/g, ''));
-  const TOTAL_ELIGIBLE = assietteInput.value ? parseValue(assietteInput.value) : 0;
+  const TOTAL_ELIGIBLE = assietteInput.value ? parseValue(assietteInput.value) : parseValue(coutTotal);
 
   // Lorsqu'on modifie l'assiette
   assietteInput.addEventListener('input', function () {

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_projet.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_projet.html
@@ -47,5 +47,19 @@
 {% endblock dotations_form %}
 
 {% block montants_form %}
+    {% if other_dotation_simu %}
+        <h6>
+            {{ dotation_projet.dotation }}
+        </h6>
+    {% endif %}
+
     {% include "includes/forms/_montants_form.html" %}
+
+    {% if other_dotation_simu %}
+        <h6>
+            {{ other_dotation_simu.dotation_projet.dotation }}
+        </h6>
+        {% include "includes/projet_detail/dotation_montant_info.html" with assiette=other_dotation_simu.dotation_projet.assiette montant=other_dotation_simu.montant taux=other_dotation_simu.taux %}
+    {% endif %}
+
 {% endblock montants_form %}

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_projet.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_projet.html
@@ -45,3 +45,7 @@
 {% block dotations_form %}
     {% include "includes/forms/_dotations_form.html" %}
 {% endblock dotations_form %}
+
+{% block montants_form %}
+    {% include "includes/forms/_montants_form.html" %}
+{% endblock montants_form %}

--- a/gsl_simulation/templates/includes/forms/_dotations_form.html
+++ b/gsl_simulation/templates/includes/forms/_dotations_form.html
@@ -8,7 +8,7 @@
                 Imputation budgétaire - Choix de la dotation
             </b>
             <br />
-            <small class="hint-text">
+            <small class="fr-hint-text">
                 Préciser la ligne budgétaire vers laquelle le projet doit être orienté
             </small>
         </div>

--- a/gsl_simulation/templates/includes/forms/_montants_form.html
+++ b/gsl_simulation/templates/includes/forms/_montants_form.html
@@ -1,6 +1,7 @@
 <form id="simulation_projet_form"
       class="form-disabled-before-value-change fr-mb-2w"
-      method="post">
+      method="post"
+      data-cout-total="{{ dossier.finance_cout_total }}">
     {% csrf_token %}
     <div class="fr-callout fr-background-alt--blue-france fr-py-2w fr-pl-3w">
         {{ simulation_projet_form.non_field_errors }}

--- a/gsl_simulation/templates/includes/forms/_montants_form.html
+++ b/gsl_simulation/templates/includes/forms/_montants_form.html
@@ -6,6 +6,24 @@
         {{ simulation_projet_form.non_field_errors }}
 
         <div class="fr-mb-4w">
+            {{ simulation_projet_form.assiette.label_tag }}
+            <br>
+            <small class="fr-hint-text">Vous pouvez saisir jusqu’à 3 décimales après le point. Exemple: 3.141
+                <br>
+            Montant des dépenses éligibles retenues à faire figurer sur l'arrêté préfectoral notifiant la décision de financement</small>
+            {{ simulation_projet_form.assiette }}
+            {% if simulation_projet_form.errors.assiette %}
+                <div class="fr-messages-group">
+                    {% for err in simulation_projet_form.errors.assiette %}
+                        <p class="fr-message fr-message--error">
+                            {{ err }}
+                        </p>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        </div>
+
+        <div class="fr-mb-4w">
             {{ simulation_projet_form.montant.label_tag }}
             <br>
             <small class="fr-hint-text">Vous pouvez saisir jusqu’à 3 décimales après le point. Exemple: 3.141

--- a/gsl_simulation/templates/includes/forms/_montants_form.html
+++ b/gsl_simulation/templates/includes/forms/_montants_form.html
@@ -1,0 +1,47 @@
+<form id="simulation_projet_form"
+      class="form-disabled-before-value-change fr-mb-2w"
+      method="post">
+    {% csrf_token %}
+    <div class="fr-callout fr-background-alt--blue-france fr-py-2w fr-pl-3w">
+        {{ simulation_projet_form.non_field_errors }}
+
+        <div class="fr-mb-4w">
+            {{ simulation_projet_form.montant.label_tag }}
+            <br>
+            <small class="fr-hint-text">Vous pouvez saisir jusqu’à 3 décimales après le point. Exemple: 3.141
+                <br>
+            Montant des dépenses éligibles retenues à faire figurer sur l'arrêté préfectoral notifiant la décision de financement</small>
+            {{ simulation_projet_form.montant }}
+            {% if simulation_projet_form.errors.montant %}
+                <div class="fr-messages-group">
+                    {% for err in simulation_projet_form.errors.montant %}
+                        <p class="fr-message fr-message--error">
+                            {{ err }}
+                        </p>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        </div>
+
+        <div>
+            {{ simulation_projet_form.taux.label_tag }}
+            <br>
+            <small class="fr-hint-text">Vous pouvez saisir jusqu’à 3 décimales après le point. Exemple: 3.141
+                <br>
+            Montant des dépenses éligibles retenues à faire figurer sur l'arrêté préfectoral notifiant la décision de financement</small>
+            {{ simulation_projet_form.taux }}
+            {% if simulation_projet_form.errors.taux %}
+                <div class="fr-messages-group">
+                    {% for err in simulation_projet_form.errors.taux %}
+                        <p class="fr-message fr-message--error">
+                            {{ err }}
+                        </p>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        </div>
+    </div>
+    <button class="fr-btn" type="submit" form='simulation_projet_form' disabled>
+        Enregistrer
+    </button>
+</form>

--- a/gsl_simulation/templates/includes/forms/_montants_form.html
+++ b/gsl_simulation/templates/includes/forms/_montants_form.html
@@ -9,7 +9,7 @@
         <div class="fr-mb-4w">
             {{ simulation_projet_form.assiette.label_tag }}
             <br>
-            <small class="fr-hint-text">Vous pouvez saisir jusqu’à 3 décimales après le point. Exemple: 3.141
+            <small class="fr-hint-text">Vous pouvez saisir jusqu’à 2 décimales après la virgule. Exemple: 3,14
                 <br>
             Montant des dépenses éligibles retenues à faire figurer sur l'arrêté préfectoral notifiant la décision de financement</small>
             {{ simulation_projet_form.assiette }}
@@ -27,9 +27,9 @@
         <div class="fr-mb-4w">
             {{ simulation_projet_form.montant.label_tag }}
             <br>
-            <small class="fr-hint-text">Vous pouvez saisir jusqu’à 3 décimales après le point. Exemple: 3.141
+            <small class="fr-hint-text">Vous pouvez saisir jusqu’à 2 décimales après la virgule. Exemple: 3,14
                 <br>
-            Montant des dépenses éligibles retenues à faire figurer sur l'arrêté préfectoral notifiant la décision de financement</small>
+            Montant de la subvention à faire figurer sur l'arrêté préfectoral notifiant la décision de financement.</small>
             {{ simulation_projet_form.montant }}
             {% if simulation_projet_form.errors.montant %}
                 <div class="fr-messages-group">
@@ -45,9 +45,9 @@
         <div>
             {{ simulation_projet_form.taux.label_tag }}
             <br>
-            <small class="fr-hint-text">Vous pouvez saisir jusqu’à 3 décimales après le point. Exemple: 3.141
+            <small class="fr-hint-text">Vous pouvez saisir jusqu’à 3 décimales après la virgule. Exemple: 3,141
                 <br>
-            Montant des dépenses éligibles retenues à faire figurer sur l'arrêté préfectoral notifiant la décision de financement</small>
+            Le taux de subvention à faire figurer sur l'arrêté préfectoral notifiant la décision de financement.Sources juridiques : articles L. 1111-10 et R.2334-27 CGCT.</small>
             {{ simulation_projet_form.taux }}
             {% if simulation_projet_form.errors.taux %}
                 <div class="fr-messages-group">

--- a/gsl_simulation/tests/forms/test_simulation_projet_form.py
+++ b/gsl_simulation/tests/forms/test_simulation_projet_form.py
@@ -1,7 +1,7 @@
 import pytest
 from django import forms
 
-from gsl_projet.tests.factories import DotationProjetFactory
+from gsl_projet.tests.factories import DetrProjetFactory
 from gsl_simulation.forms import SimulationProjetForm
 from gsl_simulation.tests.factories import SimulationProjetFactory
 
@@ -10,10 +10,26 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def simulation_projet():
-    dotation_projet = DotationProjetFactory(assiette=1_000)
+    dotation_projet = DetrProjetFactory(assiette=1_000)
     return SimulationProjetFactory(
         dotation_projet=dotation_projet, montant=200, taux=20
     )
+
+
+def test_assiette_field(simulation_projet):
+    form = SimulationProjetForm(instance=simulation_projet)
+    assert "assiette" in form.fields
+    assert isinstance(form.fields["assiette"], forms.DecimalField)
+    assert (
+        form.fields["assiette"].label == "Montant des dépenses éligibles retenues (€)"
+    )
+    assert form.fields["assiette"].max_digits == 12
+    assert form.fields["assiette"].decimal_places == 2
+    assert form.fields["assiette"].required is False
+    assert form.fields["assiette"].widget.attrs["min"] == 0
+
+    form = SimulationProjetForm(instance=simulation_projet, data={"montant": -1})
+    assert not form.is_valid()
 
 
 def test_montant_field(simulation_projet):
@@ -21,7 +37,7 @@ def test_montant_field(simulation_projet):
     assert "montant" in form.fields
     assert isinstance(form.fields["montant"], forms.DecimalField)
     assert form.fields["montant"].label == "Montant prévisionnel accordé (€)"
-    assert form.fields["montant"].max_digits == 14
+    assert form.fields["montant"].max_digits == 12
     assert form.fields["montant"].decimal_places == 2
     assert form.fields["montant"].required is False
     assert form.fields["montant"].widget.attrs["min"] == 0
@@ -98,7 +114,38 @@ def test_incoherent_both_new_montant_and_new_taux(simulation_projet):
     form = SimulationProjetForm(instance=simulation_projet, data=data)
 
     assert not form.is_valid()
-    assert "montant" in form.errors
-    assert "taux" in form.errors
+    assert list(form.errors.keys()) == ["montant", "taux", "__all__"]
     assert form.errors["montant"] == ["Le montant doit être cohérent avec le taux."]
     assert form.errors["taux"] == ["Le taux doit être cohérent avec le montant."]
+    assert form.errors["__all__"] == [
+        "Le montant et le taux ne sont pas cohérents. Veuillez vérifier vos données."
+    ]
+
+
+def test_assiette_cant_be_higher_than_cout_total(simulation_projet):
+    simulation_projet.dotation_projet.projet.dossier_ds.finance_cout_total = 1_000
+    simulation_projet.dotation_projet.projet.dossier_ds.save()
+    data = {
+        "assiette": 2_000,
+        "montant": 200,
+        "taux": 13,
+    }
+    form = SimulationProjetForm(instance=simulation_projet, data=data)
+    assert not form.is_valid()
+    assert list(form.errors.keys()) == ["assiette"]
+    assert form.errors["assiette"] == [
+        "L'assiette ne doit pas être supérieure au coût total du projet."
+    ]
+
+
+def test_montant_cant_be_higher_than_assiette(simulation_projet):
+    data = {
+        "assiette": 1_000,
+        "montant": 2_000,
+    }
+    form = SimulationProjetForm(instance=simulation_projet, data=data)
+    assert not form.is_valid()
+    assert list(form.errors.keys()) == ["montant"]
+    assert form.errors["montant"] == [
+        "Le montant ne doit pas être supérieure à l'assiette."
+    ]

--- a/gsl_simulation/tests/forms/test_simulation_projet_form.py
+++ b/gsl_simulation/tests/forms/test_simulation_projet_form.py
@@ -1,0 +1,104 @@
+import pytest
+from django import forms
+
+from gsl_projet.tests.factories import DotationProjetFactory
+from gsl_simulation.forms import SimulationProjetForm
+from gsl_simulation.tests.factories import SimulationProjetFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def simulation_projet():
+    dotation_projet = DotationProjetFactory(assiette=1_000)
+    return SimulationProjetFactory(
+        dotation_projet=dotation_projet, montant=200, taux=20
+    )
+
+
+def test_montant_field(simulation_projet):
+    form = SimulationProjetForm(instance=simulation_projet)
+    assert "montant" in form.fields
+    assert isinstance(form.fields["montant"], forms.DecimalField)
+    assert form.fields["montant"].label == "Montant prévisionnel accordé (€)"
+    assert form.fields["montant"].max_digits == 14
+    assert form.fields["montant"].decimal_places == 2
+    assert form.fields["montant"].required is False
+    assert form.fields["montant"].widget.attrs["min"] == 0
+
+    form = SimulationProjetForm(instance=simulation_projet, data={"montant": -1})
+    assert not form.is_valid()
+
+
+def test_taux_field(simulation_projet):
+    form = SimulationProjetForm(instance=simulation_projet)
+    assert "taux" in form.fields
+    assert isinstance(form.fields["taux"], forms.DecimalField)
+    assert form.fields["taux"].label == "Taux de subvention (%)"
+    assert form.fields["taux"].max_digits == 5
+    assert form.fields["taux"].decimal_places == 2
+    assert form.fields["taux"].required is False
+    assert form.fields["taux"].widget.attrs["min"] == 0
+    assert form.fields["taux"].widget.attrs["max"] == 100
+
+    form = SimulationProjetForm(instance=simulation_projet, data={"taux": -1})
+    assert not form.is_valid()
+
+
+def test_new_montant(simulation_projet):
+    data = {
+        "montant": 300,
+        "taux": 20,
+    }
+    form = SimulationProjetForm(instance=simulation_projet, data=data)
+
+    assert form.is_valid()
+    assert form.cleaned_data["montant"] == 300
+    assert form.cleaned_data["taux"] == 30
+    form.save()
+    assert simulation_projet.montant == 300
+    assert simulation_projet.taux == 30
+
+
+def test_new_taux(simulation_projet):
+    data = {
+        "montant": 200,
+        "taux": 30,
+    }
+    form = SimulationProjetForm(instance=simulation_projet, data=data)
+
+    assert form.is_valid()
+    assert form.cleaned_data["montant"] == 300  # calculated from taux
+    assert form.cleaned_data["taux"] == 30
+    form.save()
+    assert simulation_projet.montant == 300
+    assert simulation_projet.taux == 30
+
+
+def test_coherent_both_new_montant_and_new_taux(simulation_projet):
+    data = {
+        "montant": 300,
+        "taux": 30,
+    }
+    form = SimulationProjetForm(instance=simulation_projet, data=data)
+
+    assert form.is_valid()
+    assert form.cleaned_data["montant"] == 300
+    assert form.cleaned_data["taux"] == 30
+    form.save()
+    assert simulation_projet.montant == 300
+    assert simulation_projet.taux == 30
+
+
+def test_incoherent_both_new_montant_and_new_taux(simulation_projet):
+    data = {
+        "montant": 400,
+        "taux": 30,
+    }
+    form = SimulationProjetForm(instance=simulation_projet, data=data)
+
+    assert not form.is_valid()
+    assert "montant" in form.errors
+    assert "taux" in form.errors
+    assert form.errors["montant"] == ["Le montant doit être cohérent avec le taux."]
+    assert form.errors["taux"] == ["Le taux doit être cohérent avec le montant."]

--- a/gsl_simulation/tests/forms/test_simulation_projet_form.py
+++ b/gsl_simulation/tests/forms/test_simulation_projet_form.py
@@ -139,10 +139,7 @@ def test_assiette_cant_be_higher_than_cout_total(simulation_projet):
 
 
 def test_montant_cant_be_higher_than_assiette(simulation_projet):
-    data = {
-        "assiette": 1_000,
-        "montant": 2_000,
-    }
+    data = {"assiette": 1_000, "montant": 2_000, "taux": 10}
     form = SimulationProjetForm(instance=simulation_projet, data=data)
     assert not form.is_valid()
     assert list(form.errors.keys()) == ["montant"]

--- a/gsl_simulation/tests/test_tasks.py
+++ b/gsl_simulation/tests/test_tasks.py
@@ -133,7 +133,7 @@ def test_add_enveloppe_projets_to_detr_simulation(
         simulation=detr_simulation,
     )
     assert simulation_projet.montant == 1_000
-    assert simulation_projet.taux == Decimal("33.33")
+    assert simulation_projet.taux == Decimal("33.333")
     assert simulation_projet.status == SimulationProjet.STATUS_PROCESSING
     assert simulation_projet.enveloppe.dotation == DOTATION_DETR
     assert (

--- a/gsl_simulation/tests/test_views.py
+++ b/gsl_simulation/tests/test_views.py
@@ -865,7 +865,7 @@ def test_patch_montant_simulation_projet(
 
     assert response.status_code == 200
     assert updated_simulation_projet.montant == Decimal("1267.32")
-    assert updated_simulation_projet.taux == Decimal("12.67")
+    assert updated_simulation_projet.taux == Decimal("12.673")
     assert (
         '<span hx-swap-oob="innerHTML" id="total-amount-granted">1\xa0267\xa0€</span>'
         in response.content.decode()

--- a/gsl_simulation/tests/views/test_simulation_projet_view.py
+++ b/gsl_simulation/tests/views/test_simulation_projet_view.py
@@ -1,41 +1,87 @@
 import pytest
 
+from gsl_projet.tests.factories import DotationProjetFactory, ProjetFactory
+from gsl_simulation.models import SimulationProjet
 from gsl_simulation.tests.factories import SimulationProjetFactory
 from gsl_simulation.views.simulation_projet_views import (
     _get_other_dotation_simulation_projet,
 )
 
+pytestmark = pytest.mark.django_db
 
-@pytest.mark.django_db
-def test_get_other_dotation_simulation_projet():
-    # Without any other simulation projet with an other dotation
-    original_simulation_projet = SimulationProjetFactory(
-        simulation__enveloppe__dotation="DSIL"
-    )
-    _other_simulation_projet_with_same_dotation = SimulationProjetFactory(
-        dotation_projet=original_simulation_projet.dotation_projet
-    )
-    assert _get_other_dotation_simulation_projet(original_simulation_projet) is None
 
-    # With two simulation projets with an other dotation. We should get the last updated
-    simulation_projet_with_other_dotation = SimulationProjetFactory(
-        dotation_projet__dotation="DETR",
-        dotation_projet__projet=original_simulation_projet.projet,
-    )
-    second_simulation_projet_with_other_dotation = SimulationProjetFactory(
-        dotation_projet__dotation="DETR",
-        dotation_projet__projet=original_simulation_projet.projet,
+@pytest.fixture
+def projet():
+    return ProjetFactory()
+
+
+@pytest.fixture
+def detr_projet(projet):
+    return DotationProjetFactory(projet=projet, dotation="DETR")
+
+
+@pytest.fixture
+def dsil_projet(projet):
+    return DotationProjetFactory(projet=projet, dotation="DSIL")
+
+
+@pytest.fixture
+def dsil_simulation_projets(dsil_projet):
+    return [
+        SimulationProjetFactory(
+            dotation_projet=dsil_projet,
+        )
+        for _ in range(3)
+    ]
+
+
+@pytest.fixture
+def detr_simulation_projets(detr_projet):
+    return [
+        SimulationProjetFactory(
+            dotation_projet=detr_projet,
+        )
+        for _ in range(3)
+    ]
+
+
+def test_get_other_dotation_simulation_projet_without_other_dotation_simulation_projets(
+    dsil_simulation_projets,
+):
+    simulation_projet = dsil_simulation_projets[0]
+
+    result = _get_other_dotation_simulation_projet(simulation_projet)
+
+    assert result is None
+
+
+def test_get_other_dotation_simulation_projet_with_other_dotation_simulation_projets(
+    dsil_simulation_projets, detr_simulation_projets
+):
+    simulation_projet = dsil_simulation_projets[0]
+
+    result = _get_other_dotation_simulation_projet(simulation_projet)
+
+    expected_simulation_projet = (
+        SimulationProjet.objects.filter(
+            dotation_projet__projet=simulation_projet.dotation_projet.projet,
+            dotation_projet__dotation="DETR",
+        )
+        .order_by("-updated_at")
+        .first()
     )
 
-    assert (
-        _get_other_dotation_simulation_projet(original_simulation_projet)
-        == second_simulation_projet_with_other_dotation
-    )
+    assert result == expected_simulation_projet
 
-    # We check that we get the last updated simulation projet with an other dotation
-    simulation_projet_with_other_dotation.montant = 1000
-    simulation_projet_with_other_dotation.save()
-    assert (
-        _get_other_dotation_simulation_projet(original_simulation_projet)
-        == simulation_projet_with_other_dotation
-    )
+
+def test_get_other_dotation_simulation_projet_give_the_last_updated(
+    dsil_simulation_projets, detr_simulation_projets
+):
+    detr_simu_to_update = detr_simulation_projets[1]
+    detr_simu_to_update.montant = 1000
+    detr_simu_to_update.save()
+    simulation_projet = dsil_simulation_projets[0]
+
+    result = _get_other_dotation_simulation_projet(simulation_projet)
+
+    assert result == detr_simu_to_update

--- a/gsl_simulation/tests/views/test_simulation_projet_view.py
+++ b/gsl_simulation/tests/views/test_simulation_projet_view.py
@@ -1,0 +1,41 @@
+import pytest
+
+from gsl_simulation.tests.factories import SimulationProjetFactory
+from gsl_simulation.views.simulation_projet_views import (
+    _get_other_dotation_simulation_projet,
+)
+
+
+@pytest.mark.django_db
+def test_get_other_dotation_simulation_projet():
+    # Without any other simulation projet with an other dotation
+    original_simulation_projet = SimulationProjetFactory(
+        simulation__enveloppe__dotation="DSIL"
+    )
+    _other_simulation_projet_with_same_dotation = SimulationProjetFactory(
+        dotation_projet=original_simulation_projet.dotation_projet
+    )
+    assert _get_other_dotation_simulation_projet(original_simulation_projet) is None
+
+    # With two simulation projets with an other dotation. We should get the last updated
+    simulation_projet_with_other_dotation = SimulationProjetFactory(
+        dotation_projet__dotation="DETR",
+        dotation_projet__projet=original_simulation_projet.projet,
+    )
+    second_simulation_projet_with_other_dotation = SimulationProjetFactory(
+        dotation_projet__dotation="DETR",
+        dotation_projet__projet=original_simulation_projet.projet,
+    )
+
+    assert (
+        _get_other_dotation_simulation_projet(original_simulation_projet)
+        == second_simulation_projet_with_other_dotation
+    )
+
+    # We check that we get the last updated simulation projet with an other dotation
+    simulation_projet_with_other_dotation.montant = 1000
+    simulation_projet_with_other_dotation.save()
+    assert (
+        _get_other_dotation_simulation_projet(original_simulation_projet)
+        == simulation_projet_with_other_dotation
+    )


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir renseigner l'assiette d'un projet (lié à une dotation), le montant d'un projet de simulation et/ou son taux.

## 🔍 Liste des modifications

- [x] Rajouter l'information de l'autre dotation en cas de double dotation

## ⚠️ Informations supplémentaires

Pour le moment le formatage n'est pas fait. ça demande de s'y pencher un peu pour que ça reset fonctionnelle

## 🖼️ Images

<img width="701" alt="image" src="https://github.com/user-attachments/assets/aa926245-b746-4f2a-bb56-d79eafe1f48c" />

