### PR TITLE
Correction de bugs et de détails de style

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -52,8 +52,8 @@ ul.no-list-style li {
     color: var(--status-color-blue);
 }
 
-.color-orange {
-    color: var(--artwork-minor-pink-tuile)
+.color-brown {
+    color: var(--status-color-brown);
 }
 
 /* Page un projet */

--- a/gsl_projet/static/css/projet_list_filters.css
+++ b/gsl_projet/static/css/projet_list_filters.css
@@ -33,7 +33,7 @@
   gap: 1rem;
   --status-color-green: var(--text-default-success);
   --status-color-blue: var(--text-default-info);
-  --status-color-orange: var(--text-default-warning);
+  --status-color-brown: var(--text-action-high-orange-terre-battue);
   --status-color-red: var(--text-default-error);
 }
 

--- a/gsl_projet/utils/django_filters_custom_widget.py
+++ b/gsl_projet/utils/django_filters_custom_widget.py
@@ -15,7 +15,7 @@ class CustomCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
         return {
             SimulationProjet.STATUS_PROCESSING: "",
             SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED: "blue",
-            SimulationProjet.STATUS_PROVISIONALLY_REFUSED: "orange",
+            SimulationProjet.STATUS_PROVISIONALLY_REFUSED: "brown",
             SimulationProjet.STATUS_REFUSED: "red",
             SimulationProjet.STATUS_ACCEPTED: "green",
             PROJET_STATUS_ACCEPTED: "green",

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -140,14 +140,13 @@ class SimulationProjetService:
         ):
             return cls._set_back_to_processing(simulation_projet)
 
-        if (
-            new_status == SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED
-            and simulation_projet.status
-            in (
-                SimulationProjet.STATUS_ACCEPTED,
-                SimulationProjet.STATUS_REFUSED,
-                SimulationProjet.STATUS_DISMISSED,
-            )
+        if new_status in (
+            SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED,
+            SimulationProjet.STATUS_PROVISIONALLY_REFUSED,
+        ) and simulation_projet.status in (
+            SimulationProjet.STATUS_ACCEPTED,
+            SimulationProjet.STATUS_REFUSED,
+            SimulationProjet.STATUS_DISMISSED,
         ):
             cls._set_back_to_processing(simulation_projet)
 

--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -68,12 +68,9 @@
   font-style: italic;
 }
 
-.other-simulation-status {
+.gsl-projet-table table tbody td.other-simulation-status {
   text-align: end;
-}
-
-.other-simulation-status > b {
-  margin-right: 20px;
+  padding-right: 26px;
 }
 
 /* colors */

--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -147,7 +147,7 @@
 }
 
 .status-select:has(> option[value="provisionally_refused"]:checked){
-  color: var(--artwork-minor-pink-tuile)
+  color: var(--text-action-high-orange-terre-battue)
 }
 
 /* inputs */
@@ -160,6 +160,11 @@
 .input-status-color-provisionally_accepted{
   background-color: var(--text-inverted-blue-ecume);
   box-shadow: inset 0 -2px 0 0 var(--border-action-high-info)
+}
+
+.input-status-color-provisionally_refused{
+  background-color: var(--background-contrast-brown-opera);
+  box-shadow: inset 0 -2px 0 0 var(--text-action-high-orange-terre-battue)
 }
 
 .form-disabled-before-value-change > .fr-callout {

--- a/gsl_simulation/tests/services/test_simulation_projet_services.py
+++ b/gsl_simulation/tests/services/test_simulation_projet_services.py
@@ -292,8 +292,15 @@ SIMULATION_PROJET_STATUS_TO_DOTATION_PROJET_STATUS = {
         SimulationProjet.STATUS_DISMISSED,
     ),
 )
+@pytest.mark.parametrize(
+    "new_status",
+    (
+        SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED,
+        SimulationProjet.STATUS_PROVISIONALLY_REFUSED,
+    ),
+)
 def test_update_status_with_provisionally_accepted_from_refused_or_accepted_or_dismissed(
-    initial_status,
+    initial_status, new_status
 ):
     dotation_projet = DotationProjetFactory(
         status=SIMULATION_PROJET_STATUS_TO_DOTATION_PROJET_STATUS[initial_status]
@@ -312,12 +319,10 @@ def test_update_status_with_provisionally_accepted_from_refused_or_accepted_or_d
         status=initial_status,
     )
 
-    SimulationProjetService.update_status(
-        simulation_projet, SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED
-    )
+    SimulationProjetService.update_status(simulation_projet, new_status)
 
     simulation_projet.refresh_from_db()
-    assert simulation_projet.status == SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED
+    assert simulation_projet.status == new_status
     assert simulation_projet.dotation_projet.status == PROJET_STATUS_PROCESSING
 
     other_simulation_projets = SimulationProjet.objects.exclude(pk=simulation_projet.pk)


### PR DESCRIPTION
## 🌮 Objectif

1. Résoudre le bug lié au retour au statut `Refusé Provisoirement` (le résumé de l'enveloppe ne se mettait pas à jour)
2. Résoudre le problème de marge de `Accepté provisoirement`
3. Mettre les bonnes couleurs pour `Refusé provisoirement`

## 🖼️ Images
#### Avant
![image](https://github.com/user-attachments/assets/259dca24-8588-4aa4-86d0-61ce6f0e0cab)
#### Après
![image](https://github.com/user-attachments/assets/87125cb5-2427-4064-a8cc-bca2123089d4)
![image](https://github.com/user-attachments/assets/2af5f9ac-911b-4e78-aa8a-ed5699ff685d)
