### PR TITLE
Désactivation des boutons pour éviter le double clic lors d'un changement de statut ou de dotation

### DIFF
--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -106,7 +106,7 @@
   color: var(--background-alt-blue-france)
 }
 
-.accept-button:hover{
+.accept-button:hover:not(:disabled){
   background-color: var(--background-action-high-success-hover) !important;
 }
 
@@ -115,7 +115,7 @@
   color: var(--background-alt-blue-france)
 }
 
-.refuse-button:hover{
+.refuse-button:hover:not(:disabled){
   background-color: var(--background-action-high-error-hover) !important;
 }
 
@@ -124,7 +124,7 @@
   color: var(--background-alt-blue-france)
 }
 
-.dismiss-button:hover{
+.dismiss-button:hover:not(:disabled){
   background-color: var(--background-action-high-warning-hover) !important;
 }
 

--- a/gsl_simulation/static/js/handleInteractionInSimulationProjet.js
+++ b/gsl_simulation/static/js/handleInteractionInSimulationProjet.js
@@ -1,4 +1,5 @@
 import { handleDotationChange } from "./modules/handleDotationUpdate.js";
+import { disableAllModalButtons } from "./modules/utils.js";
 
 document.querySelectorAll(".status-radio-button").forEach((elt) => {
     elt.addEventListener("change", (ev) => {
@@ -35,8 +36,11 @@ document.querySelector("#submit-dotation").addEventListener("click", (ev) => {
 });
 
 
-document.querySelector("#confirm-dotation-update").addEventListener("click", (ev) => {
-  let form = document.querySelector("form#projet_form").closest("form")
-  form.submit()
-  closeModal()
+document.querySelectorAll("#confirm-dotation-update").forEach(elt => {
+  elt.addEventListener("click", async (ev) => {
+    disableAllModalButtons(elt.closest(".confirmation-modal"));
+    let form = document.querySelector("form#projet_form").closest("form")
+    form.submit()
+    closeModal()
+  })
 })

--- a/gsl_simulation/static/js/handleInteractionsInSimulation.js
+++ b/gsl_simulation/static/js/handleInteractionsInSimulation.js
@@ -1,4 +1,5 @@
 import { handleDotationChange } from "./modules/handleDotationUpdate.js"
+import { disableAllModalButtons } from "./modules/utils.js"
 
 'use strict'
 
@@ -61,7 +62,10 @@ document.querySelectorAll('.dotation-dropdown button').forEach(button => {
 });
   
 
-document.querySelector("#confirm-dotation-update").addEventListener("click", (ev) => {
+document.querySelectorAll("#confirm-dotation-update").forEach(elt => {
+  elt.addEventListener("click", (ev) => {
+    disableAllModalButtons(elt.closest(".confirmation-modal"));
     selectedForm.submit();
     closeModal();
   })
+})

--- a/gsl_simulation/static/js/modules/utils.js
+++ b/gsl_simulation/static/js/modules/utils.js
@@ -1,0 +1,6 @@
+export function disableAllModalButtons(modal) {
+    const buttons = modal.querySelectorAll("button")
+    buttons.forEach((button) => {
+        button.disabled = true
+    })
+}

--- a/gsl_simulation/static/js/simulationProjetStatusConfirmation.js
+++ b/gsl_simulation/static/js/simulationProjetStatusConfirmation.js
@@ -35,11 +35,6 @@ function mustOpenConfirmationModal(newValue, originalValue) {
     return false;
 }
 
-function replaceInitialStatusModalContentText(originalValue, modalContentId) {
-    const confirmationModalContent = document.getElementById(modalContentId)
-    confirmationModalContent.querySelector(".initial-status").innerHTML= STATUS_TO_FRENCH_WORD[originalValue]
-}
-
 function handleStatusChangeWithHtmx(select, originalValue) {
     if (mustOpenConfirmationModal(select.value, originalValue)) {
         showConfirmationModal(select, originalValue);
@@ -72,6 +67,7 @@ function showConfirmationModal(select, originalValue) {
     }
 
     const modal = document.getElementById(modalId)
+    _ensureButtonsAreEnabled(modal)
     dsfr(modal).modal.disclose()
 }
 
@@ -90,6 +86,20 @@ function _removeFromProgrammationText(modalContentId) {
     catch (e) {
         console.log("No element to remove")
     }
+}
+
+function _ensureButtonsAreEnabled(modal) {
+    const buttons = modal.querySelectorAll("button")
+    buttons.forEach((button) => {
+        button.disabled = false
+    })
+}
+
+function _disableAllModalButtons(modal) {
+    const buttons = modal.querySelectorAll("button")
+    buttons.forEach((button) => {
+        button.disabled = true
+    })
 }
 
 function closeModal() {
@@ -120,6 +130,7 @@ document.querySelectorAll(".close-modal").forEach((el) => {
 
 document.querySelectorAll('#confirmChange').forEach((e) => {
     e.addEventListener('click', function () {
+        _disableAllModalButtons(this.closest(".confirmation-modal"));
         if (selectedElement) {
             selectedElement.form.submit();
         }


### PR DESCRIPTION
## 🌮 Objectif

Rendre indisponible les boutons une fois qu'ils ont été cliqué.

## ⚠️ Informations supplémentaires

Bon, le js commence à devenir du spaghetti, soyons vigilants !

=> A merge après la MEP, au cas où !
