### PR TITLE
Afficher l'avis commission DETR seulement si le montant est supérieur à 50 000€

### DIFF
--- a/gsl_projet/constants.py
+++ b/gsl_projet/constants.py
@@ -18,3 +18,6 @@ PROJET_STATUS_CHOICES = (
     (PROJET_STATUS_PROCESSING, "🔄 En traitement"),
     (PROJET_STATUS_DISMISSED, "⛔️ Classé sans suite"),
 )
+
+
+MIN_DEMANDE_MONTANT_FOR_AVIS_DETR = 50_000

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -166,6 +166,24 @@ class Projet(models.Model):
             if dotation.dotation in [DOTATION_DETR, DOTATION_DSIL]
         ]
 
+    @property
+    def has_double_dotations(self):
+        return self.dotationprojet_set.count() > 1
+
+    @property
+    def dotation_detr(self):
+        try:
+            return self.dotationprojet_set.get(dotation=DOTATION_DETR)
+        except DotationProjet.DoesNotExist:
+            return None
+
+    @property
+    def dotation_dsil(self):
+        try:
+            return self.dotationprojet_set.get(dotation=DOTATION_DSIL)
+        except DotationProjet.DoesNotExist:
+            return None
+
 
 class DotationProjet(models.Model):
     projet = models.ForeignKey(Projet, on_delete=models.CASCADE)

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -147,7 +147,7 @@ class Projet(models.Model):
     def can_have_a_commission_detr_avis(self) -> bool:
         return (
             self.dotationprojet_set.filter(dotation=DOTATION_DETR).exists()
-            and self.dossier_ds.demande_montant
+            and self.dossier_ds.demande_montant is not None
             and self.dossier_ds.demande_montant >= 50_000
         )
 

--- a/gsl_projet/templates/gsl_projet/projet/tab_projet.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_projet.html
@@ -51,7 +51,7 @@
 {% endblock form_for_simulation_projet %}
 
 {% block detr_avis_commission %}
-    {% if projet.is_asking_for_detr %}
+    {% if projet.can_have_a_commission_detr_avis %}
         <div class="fr-callout fr-background-alt--blue-france callout-without-left-border block-avis-commission-detr fr-p-2w">
             <h2 class="fr-callout__title fr-text--lg">
                 <span class="fr-icon fr-icon-team-fill blue-color fr-mr-3v"

--- a/gsl_projet/templates/gsl_projet/projet/tab_projet.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_projet.html
@@ -58,9 +58,9 @@
                       aria-hidden="true"></span>Avis de la commission DETR
             </h2>
             <p class="fr-callout__text">
-                {% if projet.detr_avis_commission %}
+                {% if projet.dotation_detr.detr_avis_commission %}
                     <span class="fr-icon-chat-check-fill green-color" aria-hidden="true"></span> Oui
-                {% elif projet.detr_avis_commission is False %}
+                {% elif projet.dotation_detr.detr_avis_commission is False %}
                     <span class="fr-icon-chat-delete-fill red-color" aria-hidden="true"></span> Non
                 {% else %}
                     <span class="fr-icon-message-2-fill grey-color" aria-hidden="true"></span> En cours

--- a/gsl_projet/tests/models/test_projet.py
+++ b/gsl_projet/tests/models/test_projet.py
@@ -7,20 +7,37 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 
 @pytest.mark.parametrize(
-    ("create_a_detr_projet", "create_a_dsil_projet", "expected_is_asking_for_detr"),
     (
-        (True, False, True),
-        (True, True, True),
-        (False, True, False),
+        "create_a_detr_projet",
+        "create_a_dsil_projet",
+        "demande_montant",
+        "expected_can_have_a_commission_detr_avis",
+    ),
+    (
+        (True, False, 50_000, True),
+        (True, False, 49_999, False),
+        (True, False, None, False),
+        (True, True, 50_000, True),
+        (True, True, 49_999, False),
+        (True, True, None, False),
+        (False, True, 50_000, False),
+        (False, True, 49_999, False),
+        (False, True, None, False),
     ),
 )
-def test_is_asking_for_detr(
-    create_a_detr_projet, create_a_dsil_projet, expected_is_asking_for_detr
+def test_can_have_a_commission_detr_avis(
+    create_a_detr_projet,
+    create_a_dsil_projet,
+    demande_montant,
+    expected_can_have_a_commission_detr_avis,
 ):
-    projet = ProjetFactory()
+    projet = ProjetFactory(dossier_ds__demande_montant=demande_montant)
     if create_a_detr_projet:
         DotationProjetFactory(projet=projet, dotation=DOTATION_DETR)
     if create_a_dsil_projet:
         DotationProjetFactory(projet=projet, dotation=DOTATION_DSIL)
 
-    assert projet.is_asking_for_detr is expected_is_asking_for_detr
+    assert (
+        projet.can_have_a_commission_detr_avis
+        is expected_can_have_a_commission_detr_avis
+    )

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_projet.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_projet.html
@@ -15,7 +15,7 @@
 {% endblock form_for_simulation_projet %}
 
 {% block detr_avis_commission %}
-    {% if enveloppe.dotation == 'DETR' %}
+    {% if enveloppe.dotation == 'DETR' and projet.can_have_a_commission_detr_avis %}
         {% include "includes/forms/_detr_avis_commission_form.html" %}
     {% endif %}
 {% endblock detr_avis_commission %}


### PR DESCRIPTION
## 🌮 Objectif

Afficher l'avis commission DETR seulement si le montant est supérieur à 50 000€ sur une page projet modifiable d'une simulation DETR.
Sur la page projet non modifiable, on l'affiche si le projet est associé à une dotation DETR et que le montant demandé est supérieur à 50 000€.