### PR TITLE
Possibilité de changer la dotation après avoir changé le montant d'un projet dans une simulation

### DIFF
--- a/gsl_simulation/templates/htmx/projet_update.html
+++ b/gsl_simulation/templates/htmx/projet_update.html
@@ -2,6 +2,6 @@
 
 {% include "includes/_status_summary.html" with hx_swap_oob="true" %}
 <span hx-swap-oob="innerHTML" id="total-amount-granted">{{ total_amount_granted | euro }}</span>
-<table>
-    {% include "includes/_simulation_detail_row.html" %}
-</table>
+{% include "includes/table_forms/_montant_form.html" %}
+{% include "includes/table_forms/_taux_form.html" %}
+{% include "includes/table_forms/_status_form.html" %}

--- a/gsl_simulation/templates/includes/table_forms/_montant_form.html
+++ b/gsl_simulation/templates/includes/table_forms/_montant_form.html
@@ -1,5 +1,7 @@
 <form action="{% url 'simulation:patch-simulation-projet-montant' simu.id %}"
-      method="POST">
+      method="POST"
+      id="id-montant-{{ simu.id }}"
+      hx-swap-oob="true">
     {% csrf_token %}
     <div class="gsl-projet-table__input-wrap">
         <input name="montant"

--- a/gsl_simulation/templates/includes/table_forms/_status_form.html
+++ b/gsl_simulation/templates/includes/table_forms/_status_form.html
@@ -1,9 +1,11 @@
 {% load gsl_filters %}
 <form action="{% url 'simulation:patch-simulation-projet-status' simu.id %}"
       method="POST"
+      id="id-status-{{ simu.id }}"
       hx-post="{% url 'simulation:patch-simulation-projet-status' simu.id %}"
       hx-trigger="status-confirmed"
-      hx-disabled-elt="find .input-simulation-projet-{{ simu.pk }}">
+      hx-disabled-elt="find .input-simulation-projet-{{ simu.pk }}"
+      hx-swap-oob="true">
     {% csrf_token %}
     <select class="fr-select gsl-projet-table__select input-simulation-projet-{{ simu.pk }} input-status-select-{{ simu.status }} status-select"
             name="status"

--- a/gsl_simulation/templates/includes/table_forms/_taux_form.html
+++ b/gsl_simulation/templates/includes/table_forms/_taux_form.html
@@ -1,5 +1,7 @@
 <form action="{% url 'simulation:patch-simulation-projet-taux' simu.id %}"
-      method="POST">
+      method="POST"
+      id="id-taux-{{ simu.id }}"
+      hx-swap-oob="true">
     {% csrf_token %}
     <div class="gsl-projet-table__input-wrap gsl-projet-table__rate">
         <input name="taux"

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -284,7 +284,11 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
             return {}
 
         other_simulation_projets = (
-            SimulationProjet.objects.select_related("dotation_projet")
+            SimulationProjet.objects.select_related(
+                "dotation_projet",
+                "dotation_projet__projet",
+                "dotation_projet__projet__dossier_ds",
+            )
             .filter(dotation_projet__projet__id__in=ids_of_double_dotation_projet)
             .exclude(simulation__enveloppe__dotation=current_dotation)
             .order_by("-updated_at")


### PR DESCRIPTION
## 🌮 Objectif

Fix d'un bug qui empêchait le changement de dotation après avoir changé le montant ou le taux d'un projet.

## 🔍 Liste des modifications

Source du bug : après un changement de montant (ou taux ou statut) nous renvoyions une nouvelle ligne (row) dans le tableau. C'est donc un nouvel élément HTML. Or, nous avions installé un listener à la fin du chargement de la page. Il n'y a donc plus d'écoute des changements sur cette nouvelle ligne.

Pour éviter ce problème, autant renvoyer que les cellules potentiellement modifiées, à savoir les cellules montant, taux et statut.
Merci HTMX !