### PR TITLE
Export CSV d'une liste de projets depuis une simulation

### DIFF
--- a/gsl_demarches_simplifiees/models.py
+++ b/gsl_demarches_simplifiees/models.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 
 from gsl_core.models import Adresse, Perimetre
 from gsl_core.models import Arrondissement as CoreArrondissement
+from gsl_projet.constants import MIN_DEMANDE_MONTANT_FOR_AVIS_DETR
 
 
 class DsModel(models.Model):
@@ -464,6 +465,14 @@ class Dossier(DsModel):
         if self.finance_cout_total and self.demande_montant:
             return round(self.demande_montant / self.finance_cout_total * 100, 2)
         return None
+
+    @property
+    def porteur_fullname(self):
+        return f"{self.porteur_de_projet_nom} {self.porteur_de_projet_prenom}"
+
+    @property
+    def demande_montant_is_greater_thant_min_montant_for_detr_commission(self):
+        return self.demande_montant >= MIN_DEMANDE_MONTANT_FOR_AVIS_DETR
 
 
 class DsChoiceLibelle(DsModel):

--- a/gsl_simulation/models.py
+++ b/gsl_simulation/models.py
@@ -2,22 +2,19 @@ from django.db import models
 from django.db.models import Count
 from django.forms import ValidationError
 
-from gsl_core.models import Collegue
+from gsl_core.models import BaseModel, Collegue
 from gsl_programmation.models import Enveloppe
 from gsl_projet.models import DotationProjet
 from gsl_projet.utils.utils import compute_taux
 
 
-class Simulation(models.Model):
+class Simulation(BaseModel):
     title = models.CharField(verbose_name="Titre")
     created_by = models.ForeignKey(Collegue, on_delete=models.SET_NULL, null=True)
     enveloppe = models.ForeignKey(
         Enveloppe, on_delete=models.PROTECT, verbose_name="Dotation associée"
     )
     slug = models.SlugField(verbose_name="Clé d’URL", unique=True, max_length=120)
-
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
         verbose_name = "Simulation"
@@ -38,7 +35,7 @@ class Simulation(models.Model):
             SimulationProjet.STATUS_REFUSED: 0,
             SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED: 0,
             SimulationProjet.STATUS_PROVISIONALLY_REFUSED: 0,
-            "notified": 0,  # TODO : add notified count
+            "notified": 0,
         }
         status_count = (
             SimulationProjet.objects.filter(simulation=self)
@@ -51,7 +48,7 @@ class Simulation(models.Model):
         return {**default_status_summary, **summary}
 
 
-class SimulationProjet(models.Model):
+class SimulationProjet(BaseModel):
     STATUS_PROCESSING = "draft"
     STATUS_ACCEPTED = "valid"
     STATUS_REFUSED = "cancelled"
@@ -79,9 +76,6 @@ class SimulationProjet(models.Model):
     status = models.CharField(
         verbose_name="État", choices=STATUS_CHOICES, default=STATUS_PROCESSING
     )
-
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
         verbose_name = "Projet de simulation"

--- a/gsl_simulation/models.py
+++ b/gsl_simulation/models.py
@@ -23,6 +23,10 @@ class Simulation(BaseModel):
     def __str__(self):
         return self.title
 
+    @property
+    def dotation(self):
+        return self.enveloppe.dotation
+
     def get_absolute_url(self):
         from django.urls import reverse
 

--- a/gsl_simulation/resources.py
+++ b/gsl_simulation/resources.py
@@ -1,0 +1,45 @@
+from import_export.resources import Field, ModelResource
+from import_export.widgets import ForeignKeyWidget
+
+from gsl_simulation.models import SimulationProjet
+
+
+class SimulationProjetResource(ModelResource):
+    dossier_number = Field(
+        attribute="dossier_ds",
+        column_name="Numéro de dossier DS",
+        widget=ForeignKeyWidget("dossier_ds", field="ds_number"),
+    )
+    has_double_dotations = Field(
+        attribute="projet",
+        column_name="Projet en double dotation",
+        widget=ForeignKeyWidget("projet", field="has_double_dotations"),
+    )
+
+    montant = Field(
+        attribute="montant",
+        column_name="Montant retenu",
+    )
+    taux = Field(
+        attribute="taux",
+        column_name="Taux",
+    )
+
+    class Meta:
+        model = SimulationProjet
+        fields = (
+            "dossier_number",
+            "dossier_ds.projet_intitule",
+            "has_double_dotations",
+            "montant",
+            "taux",
+            "status",
+        )
+        # export_order = (
+        #     "id",
+        #     "enveloppe",
+        #     "montant",
+        #     "annee",
+        #     "perimetre",
+        #     "dotation",
+        # )

--- a/gsl_simulation/resources.py
+++ b/gsl_simulation/resources.py
@@ -36,7 +36,7 @@ class DsilSimulationProjetResource(ModelResource):
     )
     porteur_name = Field(
         attribute="projet__dossier_ds__porteur_fullname",
-        column_name="Nom et prénomn du demandeur",  # TODO: demandeur ?? ou porteur ?
+        column_name="Nom et prénom du demandeur",
     )
     demandeur_code_insee = Field(
         attribute="projet__demandeur__address__commune__insee_code",

--- a/gsl_simulation/resources.py
+++ b/gsl_simulation/resources.py
@@ -1,45 +1,162 @@
 from import_export.resources import Field, ModelResource
-from import_export.widgets import ForeignKeyWidget
+from import_export.widgets import (
+    BooleanWidget,
+    DateTimeWidget,
+    DateWidget,
+    ForeignKeyWidget,
+)
 
 from gsl_simulation.models import SimulationProjet
 
 
-class SimulationProjetResource(ModelResource):
+class OuiNonWidget(BooleanWidget):
+    def render(self, value, obj=None, **kwargs):
+        if value is None:
+            return "Inconnu"
+        return "Oui" if value else "Non"
+
+
+class DsilSimulationProjetResource(ModelResource):
+    date_depot = Field(
+        attribute="projet__dossier_ds__ds_date_depot",
+        column_name="Date de dépôt du dossier",
+        widget=DateTimeWidget(format="%d/%m/%Y"),
+    )
     dossier_number = Field(
-        attribute="dossier_ds",
+        attribute="projet__dossier_ds__ds_number",
         column_name="Numéro de dossier DS",
-        widget=ForeignKeyWidget("dossier_ds", field="ds_number"),
+    )
+    projet_intitule = Field(
+        attribute="projet__dossier_ds__projet_intitule",
+        column_name="Intitulé du projet",
+    )
+    demandeur_name = Field(
+        attribute="projet__demandeur__name",
+        column_name="Demandeur",
+    )
+    porteur_name = Field(
+        attribute="projet__dossier_ds__porteur_fullname",
+        column_name="Nom et prénomn du demandeur",  # TODO: demandeur ?? ou porteur ?
+    )
+    demandeur_code_insee = Field(
+        attribute="projet__demandeur__address__commune__insee_code",
+        column_name="Code INSEE commune du demandeur",
+    )
+    arrondissement = Field(
+        attribute="projet__demandeur__address__commune__arrondissement__name",
+        column_name="Code INSEE commune du demandeur",
     )
     has_double_dotations = Field(
         attribute="projet",
         column_name="Projet en double dotation",
         widget=ForeignKeyWidget("projet", field="has_double_dotations"),
     )
-
+    cout_total = Field(
+        attribute="projet__dossier_ds__finance_cout_total",
+        column_name="Coût total du projet",
+    )
+    assiette = Field(
+        attribute="dotation_projet__assiette",
+        column_name="Assiette subventionnable",
+    )
+    demande_montant = Field(
+        attribute="projet__dossier_ds__demande_montant",
+        column_name="Montant demandé",
+    )
+    demande_taux = Field(
+        attribute="projet__dossier_ds__taux_demande",
+        column_name="Taux demandé par rapport au coût total",
+    )
+    status = Field(
+        attribute="get_status_display",
+        column_name="Statut de la simulation",
+    )
     montant = Field(
         attribute="montant",
-        column_name="Montant retenu",
+        column_name="Montant prévsionnel accordé",
     )
     taux = Field(
         attribute="taux",
-        column_name="Taux",
+        column_name="Taux prévsionnel accordé",
+    )
+    date_debut = Field(
+        attribute="projet__dossier_ds__date_debut",
+        column_name="Date de début des travaux",
+        widget=DateWidget(format="%d/%m/%Y"),
+    )
+    date_achevement = Field(
+        attribute="projet__dossier_ds__date_achevement",
+        column_name="Date de fin des travaux",
+        widget=DateWidget(format="%d/%m/%Y"),
+    )
+    is_in_qpv = Field(
+        attribute="projet__is_in_qpv",
+        column_name="Projet situé dans un QPV",
+        widget=OuiNonWidget(),
+    )
+    is_attached_to_a_crte = Field(
+        attribute="projet__is_attached_to_a_crte",
+        column_name="Projet rattaché à un CRTE",
+        widget=OuiNonWidget(),
+    )
+    is_budget_vert = Field(
+        attribute="projet__is_budget_vert",
+        column_name="Projet concourant à la transition écologique",
+        widget=OuiNonWidget(),
+    )
+    priorite = Field(
+        attribute="projet__dossier_ds__demande_priorite_dsil_detr",
+        column_name="Priorité du projet",
+    )
+    annotations = Field(
+        attribute="projet__dossier_ds__annotations_champ_libre",
+        column_name="Annotation de l’instructeur",
     )
 
     class Meta:
         model = SimulationProjet
         fields = (
+            "date_depot",
             "dossier_number",
-            "dossier_ds.projet_intitule",
+            "projet_intitule",
+            "demandeur_name",
+            "porteur_name",
+            "demandeur_code_insee",
+            "arrondissement",
             "has_double_dotations",
+            "cout_total",
+            "assiette",
+            "demande_montant",
+            "demande_taux",
             "montant",
             "taux",
             "status",
+            "date_debut",
+            "date_achevement",
+            "is_in_qpv",
+            "is_attached_to_a_crte",
+            "is_budget_vert",
+            "demande_priorite_dsil_detr",
+            "priorite",
+            "annotations",
         )
-        # export_order = (
-        #     "id",
-        #     "enveloppe",
-        #     "montant",
-        #     "annee",
-        #     "perimetre",
-        #     "dotation",
-        # )
+
+
+class DetrSimulationProjetResource(DsilSimulationProjetResource):
+    can_have_a_commission_detr_avis = Field(
+        attribute="projet__dossier_ds__demande_montant_is_greater_thant_min_montant_for_detr_commission",
+        column_name="Montant demandé supérieur à 100 000€ ?",
+        widget=OuiNonWidget(),
+    )
+    detr_avis_commission = Field(
+        attribute="dotation_projet__detr_avis_commission",
+        column_name="Avis de la commission",
+        widget=OuiNonWidget(),
+    )
+
+    class Meta:
+        model = SimulationProjet
+        fields = DsilSimulationProjetResource.Meta.fields + (
+            "can_have_a_commission_detr_avis",
+            "detr_avis_commission",
+        )

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -10,7 +10,7 @@
         {{ title }}
     </h1>
     {% include "includes/_status_summary.html" %}
-    <a class="fr-btn fr-btn--secondary"
+    <a class="fr-btn fr-btn--secondary fr-mt-2w"
        href="{% url 'gsl_simulation:simulation-projets-export' slug=simulation.slug %}?{{ filter_params }}">
         Exporter le tableau en csv
     </a>

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -10,6 +10,10 @@
         {{ title }}
     </h1>
     {% include "includes/_status_summary.html" %}
+    <a class="fr-btn fr-btn--secondary"
+       href="{% url 'gsl_simulation:simulation-projets-export' slug=simulation.slug %}?{{ filter_params }}">
+        Exporter le tableau en csv
+    </a>
     {% include "includes/_enveloppe_summary.html" %}
     {% include "includes/_projet_list_filters.html" %}
 

--- a/gsl_simulation/tests/test_resources.py
+++ b/gsl_simulation/tests/test_resources.py
@@ -1,0 +1,180 @@
+from datetime import date, datetime
+
+import pytest
+
+from gsl_demarches_simplifiees.tests.factories import DossierFactory
+from gsl_programmation.tests.factories import DetrEnveloppeFactory, DsilEnveloppeFactory
+from gsl_projet.tests.factories import (
+    DemandeurFactory,
+    DetrProjetFactory,
+    DsilProjetFactory,
+    ProjetFactory,
+)
+from gsl_simulation.models import SimulationProjet
+from gsl_simulation.resources import (
+    DetrSimulationProjetResource,
+    DsilSimulationProjetResource,
+)
+from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
+
+
+def test_dsil_meta_fields():
+    assert DsilSimulationProjetResource.Meta.fields == (
+        "date_depot",
+        "dossier_number",
+        "projet_intitule",
+        "demandeur_name",
+        "porteur_name",
+        "demandeur_code_insee",
+        "arrondissement",
+        "has_double_dotations",
+        "cout_total",
+        "assiette",
+        "demande_montant",
+        "demande_taux",
+        "montant",
+        "taux",
+        "status",
+        "date_debut",
+        "date_achevement",
+        "is_in_qpv",
+        "is_attached_to_a_crte",
+        "is_budget_vert",
+        "demande_priorite_dsil_detr",
+        "priorite",
+        "annotations",
+    )
+
+
+def test_detr_meta_fields():
+    assert DetrSimulationProjetResource.Meta.fields == (
+        "date_depot",
+        "dossier_number",
+        "projet_intitule",
+        "demandeur_name",
+        "porteur_name",
+        "demandeur_code_insee",
+        "arrondissement",
+        "has_double_dotations",
+        "cout_total",
+        "assiette",
+        "demande_montant",
+        "demande_taux",
+        "montant",
+        "taux",
+        "status",
+        "date_debut",
+        "date_achevement",
+        "is_in_qpv",
+        "is_attached_to_a_crte",
+        "is_budget_vert",
+        "demande_priorite_dsil_detr",
+        "priorite",
+        "annotations",
+        "can_have_a_commission_detr_avis",
+        "detr_avis_commission",
+    )
+
+
+@pytest.fixture
+def projet():
+    dossier_ds = DossierFactory(
+        ds_date_depot=datetime(2024, 12, 1),
+        ds_number=12345678,
+        projet_intitule="Intitulé",
+        porteur_de_projet_nom="Jean-Marc",
+        porteur_de_projet_prenom="Jancovici",
+        finance_cout_total=120_000,
+        demande_montant=30_000,
+        date_debut=date(2025, 1, 1),
+        date_achevement=date(2025, 5, 1),
+        demande_priorite_dsil_detr=2,
+        annotations_champ_libre="Ceci est une annotation",
+    )
+    demandeur = DemandeurFactory(
+        name="Commune de Baume-les-Messieurs",
+        address__commune__insee_code=39210,
+        address__commune__arrondissement__name="Lons-le-Saunier",
+    )
+    return ProjetFactory(
+        dossier_ds=dossier_ds,
+        demandeur=demandeur,
+        is_in_qpv=True,
+        is_attached_to_a_crte=False,
+        is_budget_vert=None,
+    )
+
+
+@pytest.fixture
+def detr_simulation():
+    return SimulationFactory(enveloppe=DetrEnveloppeFactory())
+
+
+@pytest.fixture
+def detr_simulation_projet(projet, detr_simulation):
+    detr_projet = DetrProjetFactory(
+        projet=projet,
+        assiette=100_000,
+        detr_avis_commission=True,
+    )
+
+    return SimulationProjetFactory(
+        simulation=detr_simulation,
+        dotation_projet=detr_projet,
+        montant=25_000,
+        status=SimulationProjet.STATUS_PROCESSING,
+    )
+
+
+@pytest.mark.django_db
+def test_detr_simulation_projet(detr_simulation_projet):
+    qs = SimulationProjet.objects.all()
+    resource = DetrSimulationProjetResource()
+    dataset = resource.export(qs)
+    export_data = dataset.csv
+    splited_data = export_data.split("\n")
+    assert (
+        splited_data[0]
+        == "Date de dépôt du dossier,Numéro de dossier DS,Intitulé du projet,Demandeur,Nom et prénom du demandeur,Code INSEE commune du demandeur,Code INSEE commune du demandeur,Projet en double dotation,Coût total du projet,Assiette subventionnable,Montant demandé,Taux demandé par rapport au coût total,Montant prévsionnel accordé,Taux prévsionnel accordé,Statut de la simulation,Date de début des travaux,Date de fin des travaux,Projet situé dans un QPV,Projet rattaché à un CRTE,Projet concourant à la transition écologique,Priorité du projet,Annotation de l’instructeur,Montant demandé supérieur à 100 000€ ?,Avis de la commission\r"
+    )
+    assert (
+        splited_data[1]
+        == "01/12/2024,12345678,Intitulé,Commune de Baume-les-Messieurs,Jean-Marc Jancovici,39210,Lons-le-Saunier,False,120000.00,100000.00,30000.00,25.00,25000.00,25.00,🔄 En traitement,01/01/2025,01/05/2025,Oui,Non,Inconnu,2,Ceci est une annotation,Non,Oui\r"
+    )
+
+
+@pytest.fixture
+def dsil_simulation():
+    return SimulationFactory(enveloppe=DsilEnveloppeFactory())
+
+
+@pytest.fixture
+def dsil_simulation_projet(projet, dsil_simulation):
+    detr_projet = DsilProjetFactory(
+        projet=projet,
+        assiette=90_000,
+    )
+
+    return SimulationProjetFactory(
+        simulation=dsil_simulation,
+        dotation_projet=detr_projet,
+        montant=30_000,
+        status=SimulationProjet.STATUS_ACCEPTED,
+    )
+
+
+@pytest.mark.django_db
+def test_dsil_simulation_projet(dsil_simulation_projet):
+    qs = SimulationProjet.objects.all()
+    resource = DsilSimulationProjetResource()
+    dataset = resource.export(qs)
+    export_data = dataset.csv
+    splited_data = export_data.split("\n")
+    assert (
+        splited_data[0]
+        == "Date de dépôt du dossier,Numéro de dossier DS,Intitulé du projet,Demandeur,Nom et prénom du demandeur,Code INSEE commune du demandeur,Code INSEE commune du demandeur,Projet en double dotation,Coût total du projet,Assiette subventionnable,Montant demandé,Taux demandé par rapport au coût total,Montant prévsionnel accordé,Taux prévsionnel accordé,Statut de la simulation,Date de début des travaux,Date de fin des travaux,Projet situé dans un QPV,Projet rattaché à un CRTE,Projet concourant à la transition écologique,Priorité du projet,Annotation de l’instructeur\r"
+    )
+    assert (
+        splited_data[1]
+        == "01/12/2024,12345678,Intitulé,Commune de Baume-les-Messieurs,Jean-Marc Jancovici,39210,Lons-le-Saunier,False,120000.00,90000.00,30000.00,25.00,30000.00,33.33,✅ Accepté,01/01/2025,01/05/2025,Oui,Non,Inconnu,2,Ceci est une annotation\r"
+    )

--- a/gsl_simulation/tests/test_resources.py
+++ b/gsl_simulation/tests/test_resources.py
@@ -139,7 +139,7 @@ def test_detr_simulation_projet(detr_simulation_projet):
     )
     assert (
         splited_data[1]
-        == "01/12/2024,12345678,Intitulé,Commune de Baume-les-Messieurs,Jean-Marc Jancovici,39210,Lons-le-Saunier,False,120000.00,100000.00,30000.00,25.00,25000.00,25.00,🔄 En traitement,01/01/2025,01/05/2025,Oui,Non,Inconnu,2,Ceci est une annotation,Non,Oui\r"
+        == "01/12/2024,12345678,Intitulé,Commune de Baume-les-Messieurs,Jean-Marc Jancovici,39210,Lons-le-Saunier,False,120000.00,100000.00,30000.00,25.00,25000.00,25.000,🔄 En traitement,01/01/2025,01/05/2025,Oui,Non,Inconnu,2,Ceci est une annotation,Non,Oui\r"
     )
 
 
@@ -176,5 +176,5 @@ def test_dsil_simulation_projet(dsil_simulation_projet):
     )
     assert (
         splited_data[1]
-        == "01/12/2024,12345678,Intitulé,Commune de Baume-les-Messieurs,Jean-Marc Jancovici,39210,Lons-le-Saunier,False,120000.00,90000.00,30000.00,25.00,30000.00,33.33,✅ Accepté,01/01/2025,01/05/2025,Oui,Non,Inconnu,2,Ceci est une annotation\r"
+        == "01/12/2024,12345678,Intitulé,Commune de Baume-les-Messieurs,Jean-Marc Jancovici,39210,Lons-le-Saunier,False,120000.00,90000.00,30000.00,25.00,30000.00,33.333,✅ Accepté,01/01/2025,01/05/2025,Oui,Non,Inconnu,2,Ceci est une annotation\r"
     )

--- a/gsl_simulation/tests/test_urls.py
+++ b/gsl_simulation/tests/test_urls.py
@@ -42,24 +42,38 @@ def client_with_same_departement_perimetre(enveloppe_departemental):
     return ClientWithLoggedUserFactory(collegue)
 
 
+@pytest.mark.parametrize(
+    "route",
+    (
+        "simulation:simulation-detail",
+        "simulation:simulation-projets-export",
+    ),
+)
 @pytest.mark.django_db
 def test_simulation_detail_url_with_not_authorized_user(
-    client_with_user_logged, enveloppe_departemental
+    client_with_user_logged, enveloppe_departemental, route
 ):
     SimulationFactory(slug="test-slug", enveloppe=enveloppe_departemental)
 
-    url = reverse("simulation:simulation-detail", kwargs={"slug": "test-slug"})
+    url = reverse(route, kwargs={"slug": "test-slug"})
     response = client_with_user_logged.get(url)
     assert response.status_code == 404
 
 
+@pytest.mark.parametrize(
+    "route",
+    (
+        "simulation:simulation-detail",
+        "simulation:simulation-projets-export",
+    ),
+)
 @pytest.mark.django_db
 def test_simulation_detail_url_for_user_with_correct_perimetre(
-    client_with_same_departement_perimetre, enveloppe_departemental
+    client_with_same_departement_perimetre, enveloppe_departemental, route
 ):
     SimulationFactory(slug="test-slug", enveloppe=enveloppe_departemental)
 
-    url = reverse("simulation:simulation-detail", kwargs={"slug": "test-slug"})
+    url = reverse(route, kwargs={"slug": "test-slug"})
     response = client_with_same_departement_perimetre.get(url)
     assert response.status_code == 200
 

--- a/gsl_simulation/tests/views/test_simulation_detail_view.py
+++ b/gsl_simulation/tests/views/test_simulation_detail_view.py
@@ -3,6 +3,7 @@ import io
 
 import pytest
 from django.urls import resolve, reverse
+from freezegun import freeze_time
 
 from gsl_core.tests.factories import (
     RequestFactory,
@@ -90,10 +91,13 @@ def test_get_other_dotations_simulation_projet_without_other_simulation_projet(
     }
 
 
+@freeze_time("2025-05-26")
 @pytest.mark.django_db
 def test_get_filter_projets_csv_export_view():
     ### Arrange
-    simulation = SimulationFactory(enveloppe__dotation=DOTATION_DSIL)
+    simulation = SimulationFactory(
+        title="Ma Simulation", enveloppe__dotation=DOTATION_DSIL
+    )
     SimulationProjetFactory.create_batch(
         2,
         dotation_projet__dotation=DOTATION_DSIL,
@@ -124,7 +128,7 @@ def test_get_filter_projets_csv_export_view():
     ### Assert
     assert response.status_code == 200
     assert response["Content-Disposition"] == (
-        f'attachment; filename="projets_{simulation.slug}.csv"'
+        'attachment; filename="2025-05-26 simulation Ma Simulation.csv"'
     )
     assert response["Content-Type"] == "text/csv"
 

--- a/gsl_simulation/tests/views/test_simulation_detail_view.py
+++ b/gsl_simulation/tests/views/test_simulation_detail_view.py
@@ -1,11 +1,24 @@
-import pytest
+import csv
+import io
 
+import pytest
+from django.urls import resolve, reverse
+
+from gsl_core.tests.factories import (
+    RequestFactory,
+)
 from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL
 from gsl_projet.models import DotationProjet, Projet
-from gsl_projet.tests.factories import DotationProjetFactory, ProjetFactory
+from gsl_projet.tests.factories import (
+    DotationProjetFactory,
+    ProjetFactory,
+)
 from gsl_simulation.models import SimulationProjet
-from gsl_simulation.tests.factories import SimulationProjetFactory
-from gsl_simulation.views.simulation_views import SimulationDetailView
+from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
+from gsl_simulation.views.simulation_views import (
+    FilteredProjetsCSVExportView,
+    SimulationDetailView,
+)
 
 
 @pytest.fixture
@@ -75,3 +88,46 @@ def test_get_other_dotations_simulation_projet_without_other_simulation_projet(
     assert result == {
         double_dotation_projet.id: None,
     }
+
+
+@pytest.mark.django_db
+def test_get_filter_projets_csv_export_view():
+    ### Arrange
+    simulation = SimulationFactory(enveloppe__dotation=DOTATION_DSIL)
+    SimulationProjetFactory.create_batch(
+        2,
+        dotation_projet__dotation=DOTATION_DSIL,
+        simulation=simulation,
+        status=SimulationProjet.STATUS_ACCEPTED,
+    )
+    SimulationProjetFactory.create_batch(
+        3,
+        dotation_projet__dotation=DOTATION_DSIL,
+        simulation=simulation,
+        status=SimulationProjet.STATUS_REFUSED,
+    )
+    projets = Projet.objects.all()
+    assert projets.count() == 5
+
+    ### Act
+    req = RequestFactory()
+    view = FilteredProjetsCSVExportView()
+    url = reverse(
+        "simulation:simulation-projets-export", kwargs={"slug": simulation.slug}
+    )
+    request = req.get(url, data={"status": [SimulationProjet.STATUS_ACCEPTED]})
+    request.resolver_match = resolve(url)
+    view.request = request
+    view.kwargs = {"slug": simulation.slug}
+    response = view.get(request)
+
+    ### Assert
+    assert response.status_code == 200
+    assert response["Content-Disposition"] == (
+        f'attachment; filename="projets_{simulation.slug}.csv"'
+    )
+    assert response["Content-Type"] == "text/csv"
+
+    csv_content = response.content.decode("utf-8")
+    csv_lines = list(csv.reader(io.StringIO(csv_content)))
+    assert len(csv_lines) == 3  # 1 header + 2 projets acceptés

--- a/gsl_simulation/urls.py
+++ b/gsl_simulation/urls.py
@@ -28,6 +28,13 @@ urlpatterns = [
         name="simulation-detail",
     ),
     path(
+        "voir/<slug:slug>/csv",
+        simulation_must_be_visible_by_user(
+            simulation_views.FilteredProjetsCSVExportView.as_view()
+        ),
+        name="simulation-projets-export",
+    ),
+    path(
         "projet-detail/<int:pk>/",
         simulation_projet_must_be_visible_by_user(SimulationProjetDetailView.as_view()),
         name="simulation-projet-detail",

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from django.core.paginator import Paginator
 from django.db.models import Count, Prefetch, QuerySet, Sum
 from django.forms import NumberInput
@@ -383,6 +385,6 @@ class FilteredProjetsCSVExportView(SimulationDetailView):
 
         response = HttpResponse(export_data, content_type="text/csv")
         response["Content-Disposition"] = (
-            f'attachment; filename="projets_{self.simulation.slug}.csv"'
+            f'attachment; filename="{date.today().strftime("%Y-%m-%d")} simulation {self.simulation.title}.csv"'
         )
         return response

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -174,35 +174,37 @@ class SimulationDetailView(FilterView, DetailView, FilterUtils):
         paginator = Paginator(qs, 25)
         page = self.kwargs.get("page") or self.request.GET.get("page") or 1
         current_page = paginator.page(page)
-        context["simulations_paginator"] = current_page
-        context["simulation_projets_list"] = current_page.object_list
-        context["title"] = (
-            f"{simulation.enveloppe.dotation} {simulation.enveloppe.annee} – {simulation.title}"
-        )
-        context["status_summary"] = simulation.get_projet_status_summary()
-        context["total_cost"] = ProjetService.get_total_cost(qs)
-        context["total_amount_asked"] = ProjetService.get_total_amount_asked(qs)
-        context["total_amount_granted"] = SimulationService.get_total_amount_granted(
-            qs, simulation
-        )
-        context["available_states"] = SimulationProjet.STATUS_CHOICES
-        context["filter_params"] = self.request.GET.urlencode()
-        context["enveloppe"] = self._get_enveloppe_data(simulation)
-        context["dotations"] = DOTATIONS
-        context["other_dotations_simu"] = self._get_other_dotations_simulation_projet(
-            current_page.object_list, simulation.enveloppe.dotation
+        context.update(
+            {
+                "simulation": simulation,
+                "simulations_paginator": current_page,
+                "simulation_projets_list": current_page.object_list,
+                "title": f"{simulation.enveloppe.dotation} {simulation.enveloppe.annee} – {simulation.title}",
+                "status_summary": simulation.get_projet_status_summary(),
+                "total_cost": ProjetService.get_total_cost(qs),
+                "total_amount_asked": ProjetService.get_total_amount_asked(qs),
+                "total_amount_granted": SimulationService.get_total_amount_granted(
+                    qs, simulation
+                ),
+                "available_states": SimulationProjet.STATUS_CHOICES,
+                "filter_params": self.request.GET.urlencode(),
+                "enveloppe": self._get_enveloppe_data(simulation),
+                "dotations": DOTATIONS,
+                "other_dotations_simu": self._get_other_dotations_simulation_projet(
+                    current_page.object_list, simulation.enveloppe.dotation
+                ),
+                "breadcrumb_dict": {
+                    "links": [
+                        {
+                            "url": reverse("simulation:simulation-list"),
+                            "title": "Mes simulations de programmation",
+                        }
+                    ],
+                    "current": simulation.title,
+                },
+            }
         )
         self.enrich_context_with_filter_utils(context, self.STATE_MAPPINGS)
-
-        context["breadcrumb_dict"] = {
-            "links": [
-                {
-                    "url": reverse("simulation:simulation-list"),
-                    "title": "Mes simulations de programmation",
-                }
-            ],
-            "current": simulation.title,
-        }
 
         return context
 


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir exporter en CSV une liste de projets depuis une simulation en prenant en compte les filtres.

## 🔍 Liste des modifications

- On se base sur le module `import_export` pour exporter en CSV

## 🖼️ Images

![image](https://github.com/user-attachments/assets/0f3abb7a-0bc8-4fdd-b13d-cc9433d28579)

## TODO

- [x] tester la route (pas accessible si on est pas dans le périmètre)
- [x] tester la vue avec le filtre ?
