### PR TITLE
Afficher et filtrer par catégorie DETR

### DIFF
--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -57,6 +57,7 @@ class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     inlines = [
         DotationProjetInline,
     ]
+    search_fields = ("dossier_ds__ds_number",)
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -175,8 +175,8 @@ class Projet(models.Model):
 
     @property
     def categorie_doperation(self):
-        if DOTATION_DETR in self.dossier_ds.demande_dispositif_sollicite:
-            yield from self.dossier_ds.demande_eligibilite_detr.all()
+        if self.dotation_detr:
+            yield from self.dotation_detr.detr_categories.all()
         if DOTATION_DSIL in self.dossier_ds.demande_dispositif_sollicite:
             yield from self.dossier_ds.demande_eligibilite_dsil.all()
 

--- a/gsl_projet/tasks.py
+++ b/gsl_projet/tasks.py
@@ -16,7 +16,8 @@ from .services.projet_services import ProjetService
 @shared_task
 def update_projet_from_dossier(ds_dossier_number):
     ds_dossier = Dossier.objects.get(ds_number=ds_dossier_number)
-    ProjetService.create_or_update_from_ds_dossier(ds_dossier)
+    projet = ProjetService.create_or_update_from_ds_dossier(ds_dossier)
+    DotationProjetService.create_or_update_dotation_projet_from_projet(projet)
 
 
 @shared_task

--- a/gsl_projet/templates/includes/_filter_categorie_detr.html
+++ b/gsl_projet/templates/includes/_filter_categorie_detr.html
@@ -1,0 +1,34 @@
+{% if categorie_detr_choices|length != 0 and categorie_detr_choices|length != 1 %}
+    <div class="filter-field fr-col-12 fr-col-md-4 fr-col-lg-2">
+        <div class="filter-dropdown">
+            <label class="fr-label" id="filter_categorie_detr_label">
+                <span class="fr-sr-only">Filtrer par</span>
+                Catégorie DETR
+            </label>
+            <button type="button"
+                    class="fr-select {% if is_categorie_detr_active %}filter-dropdown-button-active{% endif %}">
+                {{ categorie_detr_placeholder }}
+            </button>
+            <div id="filter-categorie_detr"
+                 class="filter-content"
+                 role="group"
+                 aria-describedby="filter_categorie_detr_label">
+                {% for categorie in categorie_detr_choices %}
+                    <div class="fr-checkbox-group fr-checkbox-group--sm">
+                        <input type="checkbox"
+                               name="categorie_detr"
+                               value="{{ categorie.id }}"
+                               id="id_categorie_detr_{{ forloop.counter }}"
+                               {% if categorie.id in categorie_detr_selected %}checked{% endif %}>
+                        <label for="id_categorie_detr_{{ forloop.counter }}" class="fr-label">
+                            {{ categorie.libelle }}
+                        </label>
+                    </div>
+                {% endfor %}
+                <button type="submit" class="fr-btn fr-btn--sm">
+                    Filtrer
+                </button>
+            </div>
+        </div>
+    </div>
+{% endif %}

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -829,3 +829,31 @@ def test_view_has_correct_territoire_choices():
         perimetre_departement_A,
         perimetre_arrondissement_A,
     )
+
+
+def test_view_has_correct_detr_category_choices():
+    perimetre_arrondissement_A = PerimetreArrondissementFactory()
+    perimetre_arrondissement_B = PerimetreArrondissementFactory()
+
+    perimetre_departement_A = PerimetreDepartementalFactory(
+        departement=perimetre_arrondissement_A.departement,
+    )
+    _perimetre_departement_B = PerimetreDepartementalFactory(
+        departement=perimetre_arrondissement_B.departement,
+    )
+    perimetre_region_A = PerimetreRegionalFactory(
+        region=perimetre_departement_A.region,
+    )
+
+    user = CollegueFactory(perimetre=perimetre_region_A)
+    client = ClientWithLoggedUserFactory(user)
+    url = reverse("projet:list")
+
+    response = client.get(url)
+    assert response.status_code == 200
+    assert len(response.context["territoire_choices"]) == 3
+    assert response.context["territoire_choices"] == (
+        perimetre_region_A,
+        perimetre_departement_A,
+        perimetre_arrondissement_A,
+    )

--- a/gsl_projet/utils/filter_utils.py
+++ b/gsl_projet/utils/filter_utils.py
@@ -13,6 +13,7 @@ class FilterUtils:
         "montant_retenu": "includes/_filter_montant_retenu.html",
         "montant_previsionnel": "includes/_filter_montant_previsionnel.html",
         "territoire": "includes/_filter_territoire.html",
+        "categorie_detr": "includes/_filter_categorie_detr.html",
     }
 
     DOTATION_MAPPING = dict(ProjetFilters.DOTATION_CHOICES)
@@ -42,6 +43,15 @@ class FilterUtils:
             self._get_selected_territoires()
         )
         context["territoire_choices"] = self._get_territoire_choices()
+        context["is_categorie_detr_active"] = self._get_is_one_field_active(
+            "categorie_detr"
+        )
+        context["categorie_detr_placeholder"], context["categorie_detr_selected"] = (
+            self._get_selected_categorie_detr()
+        )
+        context["categorie_detr_choices"] = self._get_categorie_detr_choices()
+        # context["categorie_dsil_choices"] = self._get_territoire_choices()
+
         context["filter_templates"] = self._get_filter_templates()
 
         return context
@@ -94,10 +104,26 @@ class FilterUtils:
         )
         return ", ".join(p.entity_name for p in perimetres), territoire_ids
 
+    def _get_selected_categorie_detr(self):
+        if self.request.GET.get("categorie_detr") in (None, "", []):
+            return "Toutes", set()
+
+        categorie_detr_ids = set(
+            int(categorie_detr)
+            for categorie_detr in self.request.GET.getlist("categorie_detr")
+        )
+        categories_detr = self._get_categorie_detr_choices().filter(
+            id__in=categorie_detr_ids
+        )
+        return ", ".join(c.libelle for c in categories_detr), categorie_detr_ids
+
     def _get_perimetre(self) -> Perimetre:
         raise NotImplementedError
 
     def _get_territoire_choices(self):
+        raise NotImplementedError
+
+    def _get_categorie_detr_choices(self):
         raise NotImplementedError
 
     def _get_is_one_field_active(self, *field_names):

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -187,6 +187,13 @@ class ProjetFilters(FilterSet):
                 perimetres.add(child)
         return queryset.filter(perimetre__in=perimetres)
 
+    categorie_detr = MultipleChoiceFilter(
+        field_name="dotation_projet__categorie_detr",
+        lookup_expr="in",
+        choices=[],
+        widget=CustomCheckboxSelectMultiple(),
+    )
+
     class Meta:
         model = Projet
         fields = (
@@ -200,6 +207,7 @@ class ProjetFilters(FilterSet):
             "montant_retenu_max",
             "status",
             "territoire",
+            "categorie_detr",
         )
 
     @property

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -12,7 +12,7 @@ from gsl_projet.utils.filter_utils import FilterUtils
 from gsl_projet.utils.projet_filters import ProjetFilters
 from gsl_projet.utils.projet_page import PROJET_MENU
 
-from .models import Projet
+from .models import CategorieDetr, Projet
 
 
 def visible_by_user(func):
@@ -84,6 +84,7 @@ class ProjetListViewFilters(ProjetFilters):
         "cout_total",
         "montant_demande",
         "montant_retenu",
+        "categorie_detr",
     )
 
     @property
@@ -131,7 +132,7 @@ class ProjetListView(FilterView, ListView, FilterUtils):
         qs_global = (
             self.filterset.qs
         )  # utile pour ne pas avoir la pagination de context["object_list"]
-        context["title"] = "Projets 2025"
+        context["title"] = "Projets 2025"  # todo année hardcodée
         context["breadcrumb_dict"] = {}
         context["total_cost"] = ProjetService.get_total_cost(qs_global)
         context["total_amount_asked"] = ProjetService.get_total_amount_asked(qs_global)
@@ -152,3 +153,16 @@ class ProjetListView(FilterView, ListView, FilterUtils):
             return ()
 
         return (perimetre, *perimetre.children())
+
+    def _get_categorie_detr_choices(self):
+        perimetre = self._get_perimetre()
+        if not perimetre:
+            return ()
+
+        if not perimetre.departement:
+            return ()
+
+        # todo année hardcodée :
+        return CategorieDetr.objects.filter(
+            annee=2025, departement=perimetre.departement
+        ).order_by("tri")


### PR DESCRIPTION
## 🌮 Objectif

- Afficher la "vraie" catégorie DETR (celle portée par la DotationProjet) dans la liste des projets et dans les simulations DETR
- Pouvoir filtrer sur ces catégories

## 🔍 Liste des modifications

Dans la liste des projets :

- [ ] Afficher la catégorie dans le tableau
- [ ] Afficher le filtre
- [ ] Faire fonctionner le filtre

Dans une simulation DETR :

- [ ] Afficher la catégorie dans le tableau
- [ ] Afficher le filtre
- [ ] Faire fonctionner le filtre

À part ça : 

- [ ] Dans une simulation DSIL, ne pas afficher le filtre
- [ ] Pour un utilisateur à périmètre régional, ne pas afficher le filtre dans la liste des projets
- [ ] Vérifier (PR à part ?) qu'un utilisateur à périmètre régional ne peut pas afficher les projets DETR


## ⚠️ Informations supplémentaires

Deux PR à venir : 

- [ ] Permettre à l'instructeur de modifier la catégorie d'opération (à re-challenger selon les usages et les demandes instructeur, peut-être ?)
- [ ] Affichage et filtre des catégories DSIL

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
