### PR TITLE
Ajout du tacker Matomo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DEBUG=True  # False for prod
+ENV=dev  # dev, staging, prod
 
 HOST=localhost
 ALLOWED_HOSTS=localhost,127.0.0.1,localhost:8000,127.0.0.1:8000

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -30,6 +30,7 @@ jobs:
     env:
       DATABASE_URL: "postgres://${{ vars.DATABASE_USER }}:${{ vars.DATABASE_PASSWORD }}@${{ vars.DATABASE_HOST }}:${{ vars.DATABASE_PORT }}/${{ vars.DATABASE_NAME }}"
       SECRET_KEY: ${{ vars.SECRET_KEY }}
+      ENV: dev
 
     steps:
     - uses: actions/checkout@v4

--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -30,6 +30,7 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG")
+ENV = os.getenv("ENV", "dev")
 
 # We support a comma-separated list of allowed hosts.
 ENV_SEPARATOR = ","
@@ -125,6 +126,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "dsfr.context_processors.site_config",
+                "gsl.utils.context_processors.export_vars",
             ],
         },
     },
@@ -242,9 +244,13 @@ CELERY_RESULT_EXTENDED = True
 CONTENT_SECURITY_POLICY = {
     "DIRECTIVES": {
         "default-src": [SELF],
-        "img-src": [SELF, "data:"],
+        "img-src": [SELF, "data:", "stats.beta.gouv.fr"],
         "style-src": [SELF, NONCE],
-        "script-src": [SELF, NONCE],
+        "script-src": [SELF, NONCE, "stats.beta.gouv.fr"],
+        "connect-src": [
+            SELF,
+            "https://stats.beta.gouv.fr",
+        ],
     },
 }
 

--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -31,6 +31,10 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG")
 ENV = os.getenv("ENV", "dev")
+if ENV not in ("dev", "staging", "prod"):
+    raise ValueError(
+        f"ENV must be one of 'dev', 'staging' or 'prod'. Got {ENV} instead."
+    )
 
 # We support a comma-separated list of allowed hosts.
 ENV_SEPARATOR = ","

--- a/gsl/utils/context_processors.py
+++ b/gsl/utils/context_processors.py
@@ -1,0 +1,11 @@
+import os
+
+
+def export_vars(request):
+    data = {}
+    print("export_vars")
+    print("export_vars")
+    print(os.environ)
+    print(os.environ["ENV"])
+    data["ENV"] = os.environ["ENV"]
+    return data

--- a/gsl/utils/context_processors.py
+++ b/gsl/utils/context_processors.py
@@ -3,9 +3,5 @@ import os
 
 def export_vars(request):
     data = {}
-    print("export_vars")
-    print("export_vars")
-    print(os.environ)
-    print(os.environ["ENV"])
     data["ENV"] = os.environ["ENV"]
     return data

--- a/gsl_core/static/js/matomo.js
+++ b/gsl_core/static/js/matomo.js
@@ -1,0 +1,12 @@
+
+var _paq = window._paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="https://stats.beta.gouv.fr/";
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '214']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();

--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -94,6 +94,9 @@
         {% endblock modal %}
 
         <script src="{% static "js/gsl.js" %}" defer></script>
+        {% if ENV == "prod" %}
+            <script src="{% static "js/matomo.js" %}" nonce="{{request.csp_nonce}}" defer></script>
+        {% endif %}
         {% block extra_js %}
         {% endblock extra_js %}
     </body>


### PR DESCRIPTION
## 🌮 Objectif

Nous voulons suivre les utilisations de notre site

## 🔍 Liste des modifications

- Je propose de rajouter la variable d'environnement "ENV" qui peut prendre la valeur `dev`, `staging`ou `prod`
- On ne tracke que sur la prod
- Il faut dire à notre police interne que le script de matomo est autorisé

# A faire
- [x] rajouter la variable d'env sur staging (scalingo)
- [x] rajouter la variable d'env sur prod (scalingo)
