### PR TITLE
Utilisation des settings plutôt que des fichiers d'env

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -30,7 +30,7 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG")
-ENV = os.getenv("ENV", "dev")
+ENV = os.getenv("ENV")
 if ENV not in ("dev", "staging", "prod"):
     raise ValueError(
         f"ENV must be one of 'dev', 'staging' or 'prod'. Got {ENV} instead."

--- a/gsl/utils/context_processors.py
+++ b/gsl/utils/context_processors.py
@@ -1,7 +1,7 @@
-import os
+from gsl import settings
 
 
 def export_vars(request):
     data = {}
-    data["ENV"] = os.environ["ENV"]
+    data["ENV"] = settings.ENV
     return data


### PR DESCRIPTION
## ⚠️ Informations supplémentaires

Dans cette PR je propose d'empêcher le serveur de se lancer si la variable d'env n'a pas été définie. Un fallback peut être source d'erreur !