### PR TITLE
Empêcher l'apparition de l'onglet "notifications" lorsque le projet n'a pas été accepté

### DIFF
--- a/gsl_programmation/templates/gsl_programmation/tab_programmation_projet/tabs.html
+++ b/gsl_programmation/templates/gsl_programmation/tab_programmation_projet/tabs.html
@@ -18,11 +18,13 @@
                {% if current_tab == "historique" %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-archive-line fr-tabs__tab--icon-left">Historique du demandeur</a>
         </li>
-        <li>
-            {% url 'gsl_notification:documents' programmation_projet.id as notifications_url %}
-            <a href="{{ notifications_url }}"
-               {% if "/notification/" in request.path %}aria-selected="true"{% endif %}
-               class="fr-tabs__tab fr-icon-mail-fill fr-tabs__tab--icon-left">Notifications du demandeur</a>
-        </li>
+        {% if programmation_projet.status == "accepted" %}
+            <li>
+                {% url 'gsl_notification:documents' programmation_projet.id as notifications_url %}
+                <a href="{{ notifications_url }}"
+                   {% if "/notification/" in request.path %}aria-selected="true"{% endif %}
+                   class="fr-tabs__tab fr-icon-mail-fill fr-tabs__tab--icon-left">Notifications du demandeur</a>
+            </li>
+        {% endif %}
     </ul>
 </nav>

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tabs.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tabs.html
@@ -21,7 +21,7 @@
             demandeur</a>
 
         </li>
-        {% if dotation_projet.programmation_projet %}
+        {% if dotation_projet.programmation_projet and dotation_projet.programmation_projet.status == "accepted" %}
             <li>
                 {% url 'gsl_notification:documents' dotation_projet.programmation_projet.id as notifications_url %}
                 <a href="{{ notifications_url }}"


### PR DESCRIPTION
## 🌮 Objectif

Pour l'instant on ne gère pas les notifications des projets non acceptés => donc on cache l'onglet "notifications"
