### PR TITLE
Évitons un test "flaky"

### DIFF
--- a/gsl_projet/tests/factories.py
+++ b/gsl_projet/tests/factories.py
@@ -89,7 +89,7 @@ class CategorieDetrFactory(factory.django.DjangoModelFactory):
 
     departement = factory.SubFactory(DepartementFactory)
     annee = factory.Faker("random_int", min=2024, max=2027)
-    rang = factory.Faker("random_int", min=1, max=20)
+    rang = factory.Sequence(lambda n: n)
     libelle = factory.Faker("sentence", locale="fr_FR")
 
 


### PR DESCRIPTION
## 🌮 Objectif

De temps en temps, le test `test_get_current_categories_for_departement` échoue car on a 5 catégories DETR au lieu de 6.

C'est parce que la `DetrCategoryFactory` a une clause `django_get_or_create = ("departement", "annee", "rang")` où `annee` ne peut avoir que 4 valeurs possibles et `rang` 20 valeurs possibles. Donc la possibilité qu'on se retrouve avec plusieurs fois le même triplet n'est pas négligeable, et le test échoue dans ce cas-là.

Je contourne le problème en supprimant l'aléatoire sur le champ `rang` et en en faisant un entier strictement croissant.

## 🔍 Liste des modifications

- _Liste des modifications_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
