### PR TITLE
Ajustement du style d'une "carte" fichier

### DIFF
--- a/gsl_notification/static/css/notification.css
+++ b/gsl_notification/static/css/notification.css
@@ -54,6 +54,9 @@
 .arrete-card:hover .show-on-hover {
   display: flex;
 }
+.arrete-card .fr-enlarge-link{
+  max-width: 100%;
+}
 .arrete-card .fr-enlarge-link a {
   display: block;
 }

--- a/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications.html
+++ b/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications.html
@@ -20,10 +20,23 @@
                 Documents de notification
             </h2>
             <div class="notification-btns">
-                <a href="{% url 'gsl_notification:modifier-arrete' programmation_projet.id %}"
-                   class="fr-btn fr-btn--icon-left fr-btn--secondary fr-icon-file-text-line">
-                    Générer un document
-                </a>
+                {% if programmation_projet.arrete %}
+                    <button class="fr-btn fr-btn--icon-left fr-btn--secondary fr-icon-file-text-line"
+                            disabled
+                            aria-describedby="tooltip-import-arrete">
+                        Générer un document
+                    </button>
+                    <span class="fr-tooltip fr-placement"
+                          id="tooltip-import-arrete"
+                          role="tooltip">
+                        Un arrêté a déjà été généré pour ce projet.
+                    </span>
+                {% else %}
+                    <a href="{% url 'gsl_notification:select-modele' programmation_projet.id %}"
+                       class="fr-btn fr-btn--icon-left fr-btn--secondary fr-icon-file-text-line">
+                        Générer un document
+                    </a>
+                {% endif %}
                 {% if programmation_projet.arrete_signe %}
                     <button class="fr-btn fr-btn--icon-left fr-btn--tertiary fr-icon-upload-line"
                             disabled

--- a/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications.html
+++ b/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications.html
@@ -32,7 +32,7 @@
                         Un arrêté a déjà été généré pour ce projet.
                     </span>
                 {% else %}
-                    <a href="{% url 'gsl_notification:select-modele' programmation_projet.id %}"
+                    <a href="{% url 'gsl_notification:modifier-arrete' programmation_projet.id %}"
                        class="fr-btn fr-btn--icon-left fr-btn--secondary fr-icon-file-text-line">
                         Générer un document
                     </a>


### PR DESCRIPTION
## 🌮 Objectif

- On donne une largeur maximale à une carte.
- On désactive le lien "Générer un arrêté" s'il y en a déjà un.

## 🖼️ Images

<img width="648" height="367" alt="Capture d’écran 2025-07-22 à 16 14 02" src="https://github.com/user-attachments/assets/c5ab9231-089c-4c7a-8524-cf294006da70" />

