### PR TITLE
Suppression des avertissements dans les tests

### DIFF
--- a/gsl_projet/tests/models/test_projet.py
+++ b/gsl_projet/tests/models/test_projet.py
@@ -82,9 +82,13 @@ def test_dotation_dsil():
     "status, notified_at, expected",
     (
         (ProgrammationProjet.STATUS_ACCEPTED, None, True),
-        (ProgrammationProjet.STATUS_ACCEPTED, "2023-01-01", False),
+        (
+            ProgrammationProjet.STATUS_ACCEPTED,
+            "2023-07-23 13:05:03.837825+00:00",
+            False,
+        ),
         (ProgrammationProjet.STATUS_REFUSED, None, False),
-        (ProgrammationProjet.STATUS_REFUSED, "2023-01-01", False),
+        (ProgrammationProjet.STATUS_REFUSED, "2023-07-23 13:05:03.837825+00:00", False),
     ),
 )
 @pytest.mark.django_db

--- a/gsl_simulation/tests/test_resources.py
+++ b/gsl_simulation/tests/test_resources.py
@@ -1,6 +1,7 @@
-from datetime import date, datetime
+from datetime import UTC, date
 
 import pytest
+from django.utils import timezone
 
 from gsl_demarches_simplifiees.tests.factories import DossierFactory
 from gsl_programmation.tests.factories import DetrEnveloppeFactory, DsilEnveloppeFactory
@@ -79,7 +80,7 @@ def test_detr_meta_fields():
 @pytest.fixture
 def projet():
     dossier_ds = DossierFactory(
-        ds_date_depot=datetime(2024, 12, 1),
+        ds_date_depot=timezone.datetime(2024, 12, 1, 17, 45, tzinfo=UTC),
         ds_number=12345678,
         projet_intitule="Intitulé",
         porteur_de_projet_nom="Jean-Marc",


### PR DESCRIPTION
## 🌮 Objectif

Je veux que ce soit vert, pas jaune.

## 🔍 Liste des modifications

- Préciser la timezone dans les dates sous format "chaîne de caractères"
- Utilisation de `django.utils.timezone.datetime` à la place de `datetime.datetime`

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
