### PR TITLE
Amélioration du code : retrait du JS pour déplier un toggle

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -366,10 +366,31 @@ ul.no-list-style li {
     padding-bottom: 2em;
 }
 
+
 .gsl-dropdown > button {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+
+/* New gsl-dropdown without JS ! Migrate to this then, remove gsl-dropdown-content (or rename the new to the old)*/
+
+.new-gsl-dropdown-content {
+  display: grid;
+  position: absolute;
+  background-color: white;
+  min-width: 260px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  padding: 10px;
+  z-index: 1000;
+  gap: 1rem;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.new-gsl-dropdown-content:has(.stick-to-bottom) div:last-of-type {
+    padding-bottom: 2em;
 }
 
 .projet__to_notify {

--- a/gsl_notification/static/css/notification.css
+++ b/gsl_notification/static/css/notification.css
@@ -73,10 +73,14 @@
 .arrete-card__actions {
   width: 200px;
   padding: 0px;
+  gap: 0;
+  min-width: 0;
 }
 
 .arrete-card__actions-button {
   box-shadow: none;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .arrete-card__action {
@@ -84,7 +88,9 @@
   display: flex;
   justify-content: center;
   box-shadow: none;
+  padding: 0;
 }
+
 .arrete-card__action:focus-visible {
   outline-offset: -2px;
 }

--- a/gsl_notification/templates/includes/_document_card.html
+++ b/gsl_notification/templates/includes/_document_card.html
@@ -5,7 +5,7 @@
             {{ document.tag }}
         </span>
 
-        <details class="new-gsl-dropdown">
+        <details class="new-gsl-dropdown" name="document-actions">
             <summary class="fr-btn fr-btn--tertiary fr-btn--icon-only fr-icon-more-fill arrete-card__actions-button"
                      aria-label="Ouvrir les actions du document">
             </summary>

--- a/gsl_notification/templates/includes/_document_card.html
+++ b/gsl_notification/templates/includes/_document_card.html
@@ -5,39 +5,33 @@
             {{ document.tag }}
         </span>
 
-        <div class="gsl-dropdown">
-            <button class="fr-btn fr-btn--tertiary fr-btn--icon-only fr-icon-more-fill arrete-card__actions-button"
-                    data-fr-opened="false"
-                    aria-controls="document-menu-arrete-signe"
-                    aria-expanded="false"
-                    title="Actions du document">
-            </button>
-            <div class="gsl-dropdown-content arrete-card__actions"
-                 id="document-menu-arrete-signe">
-                <ul class="no-list-style fr-m-0">
-                    {% for action in document.actions %}
-                        <li>
-                            {% if action.name == "delete" %}
-                                <form method="post" id="{{ action.form_id }}" action="{{ action.action }}">
-                                    {% csrf_token %}
-                                    <button type="button"
-                                            class="fr-btn fr-btn--secondary arrete-card__action"
-                                            aria-controls="{{ action.aria_controls }}"
-                                            data-fr-opened="false">
-                                        {{ action.label }}
-                                    </button>
-                                </form>
-                            {% else %}
-                                <a href="{{ action.href }}"
-                                   class="fr-btn fr-btn--secondary arrete-card__action">
+        <details class="new-gsl-dropdown">
+            <summary class="fr-btn fr-btn--tertiary fr-btn--icon-only fr-icon-more-fill arrete-card__actions-button"
+                     aria-label="Ouvrir les actions du document">
+            </summary>
+            <ul class="new-gsl-dropdown-content arrete-card__actions no-list-style fr-m-0">
+                {% for action in document.actions %}
+                    <li>
+                        {% if action.name == "delete" %}
+                            <form method="post" id="{{ action.form_id }}" action="{{ action.action }}">
+                                {% csrf_token %}
+                                <button type="button"
+                                        class="fr-btn fr-btn--secondary arrete-card__action"
+                                        aria-controls="{{ action.aria_controls }}"
+                                        data-toggle="false">
                                     {{ action.label }}
-                                </a>
-                            {% endif %}
-                        </li>
-                    {% endfor %}
-                </ul>
-            </div>
-        </div>
+                                </button>
+                            </form>
+                        {% else %}
+                            <a href="{{ action.href }}"
+                               class="fr-btn fr-btn--secondary arrete-card__action">
+                                {{ action.label }}
+                            </a>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ul>
+        </details>
     </div>
     <div>
         <div class="fr-enlarge-link">


### PR DESCRIPTION
## 🌮 Objectif

Ne plus utiliser de JS pour ouvrir un toggle.

## 🔍 Liste des modifications

- Utilisation de [details/summary](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details)
- Ce n'est fait que dans la `document_card.html` pour le moment. => A migrer progressivement
