### PR TITLE
Ajout de l'en-tête du modèle dans l'arrêté

### DIFF
--- a/gsl_notification/templates/gsl_notification/pdf/arrete.html
+++ b/gsl_notification/templates/gsl_notification/pdf/arrete.html
@@ -11,10 +11,10 @@
     <body id="weasy">
         <header class="header">
             <div class="head-left">
-                <img class="logo" src={{ logo.url }} alt={{ alt_logo }} width="120">
+                <img class="logo" src="{{ logo.url }}" alt="{{ alt_logo }}" width="120">
             </div>
             <div class="head-right">
-                {{ top_right_text }}
+                {{ top_right_text|linebreaksbr }}
             </div>
         </header>
         <main>

--- a/gsl_notification/templates/gsl_notification/pdf/arrete.html
+++ b/gsl_notification/templates/gsl_notification/pdf/arrete.html
@@ -11,16 +11,10 @@
     <body id="weasy">
         <header class="header">
             <div class="head-left">
-                <img class="logo"
-                     src="{% static 'img/logo-exemple.png' %}"
-                     alt="À compléter"
-                     width="120">
-
+                <img class="logo" src={{ logo.url }} alt={{ alt_logo }} width="120">
             </div>
             <div class="head-right">
-                Ligne 1
-                <br>
-                Ligne 2
+                {{ top_right_text }}
             </div>
         </header>
         <main>

--- a/gsl_notification/views/views.py
+++ b/gsl_notification/views/views.py
@@ -327,7 +327,15 @@ class PrintArreteView(WeasyTemplateResponseMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["content"] = mark_safe(self.get_object().content)
+        arrete = self.get_object()
+        context.update(
+            {
+                "logo": arrete.modele.logo,
+                "alt_logo": arrete.modele.logo_alt_text,
+                "top_right_text": arrete.modele.top_right_text,
+                "content": mark_safe(arrete.content),
+            }
+        )
         return context
 
 

--- a/gsl_notification/views/views.py
+++ b/gsl_notification/views/views.py
@@ -332,7 +332,7 @@ class PrintArreteView(WeasyTemplateResponseMixin, DetailView):
             {
                 "logo": arrete.modele.logo,
                 "alt_logo": arrete.modele.logo_alt_text,
-                "top_right_text": arrete.modele.top_right_text,
+                "top_right_text": arrete.modele.top_right_text.strip(),
                 "content": mark_safe(arrete.content),
             }
         )


### PR DESCRIPTION
## 🌮 Objectif

Avoir le logo et le texte à droite définis dans le modèle qui s'affichent dans l'arrêté.