### PR TITLE
Sur la liste des projets programmés, je vois la liste des documents de chaque projet

### DIFF
--- a/gsl_programmation/models.py
+++ b/gsl_programmation/models.py
@@ -279,3 +279,13 @@ class ProgrammationProjet(models.Model):
         if self.status == self.STATUS_REFUSED:
             if self.montant != 0:
                 errors["montant"] = {"Un projet refusé doit avoir un montant nul."}
+
+    @cached_property
+    def documents_summary(self):
+        summary = list()
+        if hasattr(self, "arrete_signe"):
+            summary.append("1 arrêté signé")
+        elif hasattr(self, "arrete"):
+            summary.append("1 arrêté généré")
+
+        return summary

--- a/gsl_programmation/templates/gsl_programmation/programmation_projet_list.html
+++ b/gsl_programmation/templates/gsl_programmation/programmation_projet_list.html
@@ -147,10 +147,19 @@
                                         </td>
                                         <td>
                                             {{ programmation_projet.get_status_display }}
-
                                         </td>
                                         <td>
-                                            Pas de documents ajoutés
+                                            {% if programmation_projet.documents_summary %}
+                                                <ul>
+                                                    {% for document in programmation_projet.documents_summary %}
+                                                        <li>
+                                                            {{ document }}
+                                                        </li>
+                                                    {% endfor %}
+                                                </ul>
+                                            {% else %}
+                                                Pas de documents ajoutés
+                                            {% endif %}
                                         </td>
                                         <td>
                                             {% if programmation_projet.to_notify %}

--- a/gsl_programmation/tests/models/test_programmation_projet.py
+++ b/gsl_programmation/tests/models/test_programmation_projet.py
@@ -11,6 +11,7 @@ from gsl_core.tests.factories import (
     PerimetreDepartementalFactory,
     PerimetreRegionalFactory,
 )
+from gsl_notification.tests.factories import ArreteFactory, ArreteSigneFactory
 from gsl_programmation.models import Enveloppe, ProgrammationProjet
 from gsl_programmation.tests.factories import (
     DetrEnveloppeFactory,
@@ -358,3 +359,28 @@ class TestProgrammationProjetQuerySet:
         assert programmation_projet_departement in result
         assert programmation_projet_arrondissement in result
         assert result.count() == 2
+
+
+@pytest.mark.django_db
+def test_documents_summary_no_document():
+    programmation_projet = ProgrammationProjetFactory()
+    assert programmation_projet.documents_summary == []
+
+
+@pytest.mark.django_db
+def test_documents_summary_arrete_genere():
+    programmation_projet = ProgrammationProjetFactory()
+    ArreteFactory(programmation_projet=programmation_projet)
+
+    summary = programmation_projet.documents_summary
+    assert summary == ["1 arrêté généré"]
+
+
+@pytest.mark.django_db
+def test_documents_summary_arrete_signe_hides_arrete_genere():
+    programmation_projet = ProgrammationProjetFactory()
+    ArreteSigneFactory(programmation_projet=programmation_projet)
+    ArreteFactory(programmation_projet=programmation_projet)
+
+    summary = programmation_projet.documents_summary
+    assert summary == ["1 arrêté signé"]


### PR DESCRIPTION
## 🌮 Objectif

Afficher la liste des documents directement depuis la liste des projets programmés.

Très exactement les spécifications étaient : 

> Dans mon tableau, je vois sur un projet s'il y a des documents d’ajoutés ou non.
> 
>     S'il y a un arrêté généré, on écrit : “1 Arrêté généré”
> 
>     S'il y a un arrêté signé : on écrit : “1 arrêté signé” que l’on remplace par le généré
> 
>     (Ça sera pareil pour la lettre de notification)
> 
>     S'il y a une annexe d’ajouté : on écrit “1 annexe”

Il faudra repasser sur la fonction `documents_summary` pour s'adapter à la nouvelle modélisation quand on aura les lettres de notification.

## 🔍 Liste des modifications

- _Liste des modifications_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
