### PR TITLE
Rendre configurable la taille des fichiers envoyés par les agents

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -284,3 +284,5 @@ AWS_S3_REGION_NAME = os.getenv("SCALEWAY_S3_REGION", "fr-par")
 AWS_S3_ENDPOINT_URL = os.getenv(
     "AWS_S3_ENDPOINT_URL", f"https://s3.{AWS_S3_REGION_NAME}.scw.cloud"
 )
+
+MAX_POST_FILE_SIZE_IN_MO = os.getenv("MAX_POST_FILE_SIZE_IN_MO", 20)

--- a/gsl_notification/forms.py
+++ b/gsl_notification/forms.py
@@ -4,6 +4,7 @@ from django import forms
 from django.db.models.fields import files
 from dsfr.forms import DsfrBaseForm
 
+from gsl.settings import MAX_POST_FILE_SIZE_IN_MO
 from gsl_notification.models import (
     Arrete,
     ArreteSigne,
@@ -43,8 +44,8 @@ class ArreteSigneForm(forms.ModelForm, DsfrBaseForm):
                 "Seuls les fichiers PDF, PNG ou JPEG sont acceptés."
             )
 
-        max_size_in_mo = 20
-        max_size = max_size_in_mo * 1024 * 1024  # 20 Mo
+        max_size_in_mo = MAX_POST_FILE_SIZE_IN_MO
+        max_size = max_size_in_mo * 1024 * 1024
         if file.size > max_size:
             raise forms.ValidationError(
                 f"La taille du fichier ne doit pas dépasser {max_size_in_mo} Mo."
@@ -91,8 +92,8 @@ class ModeleDocumentStepTwoForm(forms.ModelForm, DsfrBaseForm):
                     "Seuls les fichiers PNG ou JPEG sont acceptés."
                 )
 
-        max_size_in_mo = 20
-        max_size = max_size_in_mo * 1024 * 1024  # 20 Mo
+        max_size_in_mo = MAX_POST_FILE_SIZE_IN_MO
+        max_size = max_size_in_mo * 1024 * 1024
         if file.size > max_size:
             raise forms.ValidationError(
                 f"La taille du fichier ne doit pas dépasser {max_size_in_mo} Mo."


### PR DESCRIPTION
## 🌮 Objectif

Ne pas devoir refaire une mise en prod si on se rend compte en cours de route que la taille max acceptée par Scalingo est plus petite que 20 Mo.

## 🔍 Liste des modifications

- Création et utilisation d'un paramètre puisant sa valeur dans une variable d'environnement facultative.

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
