### PR TITLE
Mise à jour de djlint pour être iso version avec VSCode

### DIFF
--- a/.djlintrc
+++ b/.djlintrc
@@ -1,8 +1,0 @@
-{
-  "max_line_length": 120,
-  "preserve_blank_lines": true,
-  "line_break_after_multiline_tag": true,
-  "ignore": "H006,H008,H021,H026,H029",
-  "profile": "django",
-  "indent": 4
-}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -50,6 +50,9 @@ jobs:
       run: |
         ruff check
         ruff format --check
+    - name: Check templates format
+      run: |
+        djlint . --check
     - name: Check migrations
       run: python manage.py makemigrations --check --dry-run
     - name: Run Tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/djlint/djLint
-  rev: v1.36.3
+  rev: v1.36.4
   hooks:
     - id: djlint-reformat-django
     - id: djlint-django

--- a/gsl_core/templates/blocks/footer.html
+++ b/gsl_core/templates/blocks/footer.html
@@ -44,7 +44,9 @@
         <a class="fr-footer__brand-link"
            href="{{ home_url }}"
            title="{{ back_to_home_label }} - {{ SITE_CONFIG.operator_logo_alt }} - {{ SITE_CONFIG.footer_brand|default:'république française' }}">
-            <img class="fr-responsive-img dgcl-logo-footer" src="{% static "img/logo-collectivites-locales.png" %}" alt="Direction Générale des Collectivités Locales" />
+            <img class="fr-responsive-img dgcl-logo-footer"
+                 src="{% static "img/logo-collectivites-locales.png" %}"
+                 alt="Direction Générale des Collectivités Locales" />
         </a>
     </div>
 

--- a/gsl_core/templates/blocks/header.html
+++ b/gsl_core/templates/blocks/header.html
@@ -35,7 +35,9 @@
 
 {% block operator_logo %}
     <div class="fr-header__operator">
-        <img class="fr-responsive-img" src="{% static "img/logo-collectivites-locales.png" %}" alt="Direction Générale des Collectivités Locales" />
+        <img class="fr-responsive-img"
+             src="{% static "img/logo-collectivites-locales.png" %}"
+             alt="Direction Générale des Collectivités Locales" />
     </div>
 {% endblock operator_logo %}
 

--- a/gsl_notification/templates/gsl_notification/modele/list.html
+++ b/gsl_notification/templates/gsl_notification/modele/list.html
@@ -3,7 +3,8 @@
 
 {% block extra_css %}
     <link rel="stylesheet" href="{% static "css/gsl.css" %}">
-    <link rel="stylesheet" href="{% static "css/programmation_projet_list.css" %}">
+    <link rel="stylesheet"
+          href="{% static "css/programmation_projet_list.css" %}">
     <link rel="stylesheet" href="{% static "css/notification.css" %}">
 {% endblock extra_css %}
 

--- a/gsl_notification/templates/gsl_notification/modele/modele_form_base.html
+++ b/gsl_notification/templates/gsl_notification/modele/modele_form_base.html
@@ -3,7 +3,8 @@
 
 {% block extra_css %}
     <link rel="stylesheet" href="{% static "css/gsl.css" %}">
-    <link rel="stylesheet" href="{% static "css/programmation_projet_list.css" %}">
+    <link rel="stylesheet"
+          href="{% static "css/programmation_projet_list.css" %}">
     <link rel="stylesheet" href="{% static "css/notification.css" %}">
     <link rel="stylesheet" href="{% static 'ui/components/tiptap.css' %}">
 {% endblock extra_css %}

--- a/gsl_notification/templates/gsl_notification/modele/modele_form_step_1.html
+++ b/gsl_notification/templates/gsl_notification/modele/modele_form_step_1.html
@@ -3,6 +3,7 @@
 
 {% block next_to_form %}
     <div class="arrete-step-1-more-info">
-        <img src="{% static "img/mise-en-page-exemple.png" %}" alt="L'en-tête est composé d'un logo sur la gauche et d'un texte aligné à droite" />
+        <img src="{% static "img/mise-en-page-exemple.png" %}"
+             alt="L'en-tête est composé d'un logo sur la gauche et d'un texte aligné à droite" />
     </div>
 {% endblock next_to_form %}

--- a/gsl_notification/templates/includes/_modele_card.html
+++ b/gsl_notification/templates/includes/_modele_card.html
@@ -36,7 +36,9 @@
 
     <div class="fr-card__header">
         <div class="fr-card__img">
-            <img class="fr-responsive-img " src="{% static "img/placeholder.1x1.svg" %}" alt="placeholder">
+            <img class="fr-responsive-img "
+                 src="{% static "img/placeholder.1x1.svg" %}"
+                 alt="placeholder">
             <span class="fr-tag modele-card-badge">{{ modele.type_label }}</span>
         </div>
     </div>

--- a/gsl_pages/templates/gsl_pages/coming_features.html
+++ b/gsl_pages/templates/gsl_pages/coming_features.html
@@ -756,7 +756,9 @@
                      class="column">
                     <figure id="19d765c7-b6a4-805d-b504-daad01b778d6" class="image">
                         <a href="{% static "img/coming_features/Capture_decran_2025-02-17_a_17.02.20.png" %}">
-                            <img style="width:2368px" src="{% static "img/coming_features/Capture_decran_2025-02-17_a_17.02.20.png" %}" alt="Page actuelle" />
+                            <img style="width:2368px"
+                                 src="{% static "img/coming_features/Capture_decran_2025-02-17_a_17.02.20.png" %}"
+                                 alt="Page actuelle" />
                         </a>
                         <figcaption>
                             Page actuelle
@@ -768,7 +770,9 @@
                      class="column">
                     <figure id="19d765c7-b6a4-8049-9ab1-ef8146f5d0ce" class="image">
                         <a href="{% static "img/coming_features/Connexion.png" %}">
-                            <img style="width:288px" src="{% static "img/coming_features/Connexion.png" %}" alt="Page à venir" />
+                            <img style="width:288px"
+                                 src="{% static "img/coming_features/Connexion.png" %}"
+                                 alt="Page à venir" />
                         </a>
                         <figcaption>
                             Page à venir
@@ -791,7 +795,9 @@
                      class="column">
                     <figure id="19d765c7-b6a4-8007-8913-dd67026973d2" class="image">
                         <a href="{% static "img/coming_features/Capture_decran_2025-02-17_a_17.27.15.png" %}">
-                            <img style="width:240px" src="{% static "img/coming_features/Capture_decran_2025-02-17_a_17.27.15.png" %}" alt="Page actuelle" />
+                            <img style="width:240px"
+                                 src="{% static "img/coming_features/Capture_decran_2025-02-17_a_17.27.15.png" %}"
+                                 alt="Page actuelle" />
                         </a>
                         <figcaption>
                             Page actuelle
@@ -803,7 +809,9 @@
                      class="column">
                     <figure id="19d765c7-b6a4-80d7-bbb6-f9d3656cdda6" class="image">
                         <a href="{% static "img/coming_features/Projets_2025_--.png" %}">
-                            <img style="width:240px" src="{% static "img/coming_features/Projets_2025_--.png" %}" alt="Page à venir" />
+                            <img style="width:240px"
+                                 src="{% static "img/coming_features/Projets_2025_--.png" %}"
+                                 alt="Page à venir" />
                         </a>
                         <figcaption>
                             Page à venir
@@ -853,7 +861,10 @@
                      class="column">
                     <figure id="19d765c7-b6a4-80c5-a8b2-e5ae2d3a8acb" class="image">
                         <a href="{% static "img/coming_features/Capture_decran_2025-02-17_a_16.54.51.png" %}">
-                            <img style="width:331.9921875px" src="{% static "img/coming_features/Capture_decran_2025-02-17_a_16.54.51.png" %}" alt="Page de connexion actuelle" alt="Capture d’écran de la page actuelle" />
+                            <img style="width:331.9921875px"
+                                 src="{% static "img/coming_features/Capture_decran_2025-02-17_a_16.54.51.png" %}"
+                                 alt="Page de connexion actuelle"
+                                 alt="Capture d’écran de la page actuelle" />
                         </a>
                         <figcaption>
                             Capture d’écran de la page actuelle
@@ -865,7 +876,10 @@
                      class="column">
                     <figure id="19d765c7-b6a4-802a-81a9-fb8c98cb586e" class="image">
                         <a href="{% static "img/coming_features/Simulation_de_programmation_DETR_-_Departement_-_-.png" %}">
-                            <img style="width:336px" src="{% static "img/coming_features/Simulation_de_programmation_DETR_-_Departement_-_-.png" %}" alt="Page de connexion à venir" alt="Image de projection de l’évolution de la page" />
+                            <img style="width:336px"
+                                 src="{% static "img/coming_features/Simulation_de_programmation_DETR_-_Departement_-_-.png" %}"
+                                 alt="Page de connexion à venir"
+                                 alt="Image de projection de l’évolution de la page" />
                         </a>
                         <figcaption>
                             Image de projection de l’évolution de la page
@@ -910,7 +924,9 @@
                      class="column">
                     <figure id="19d765c7-b6a4-8001-b7cb-f7cfabfc2abe" class="image">
                         <a href="{% static "img/coming_features/Capture_decran_2025-02-17_a_16.57.57.png" %}">
-                            <img style="width:288px" src="{% static "img/coming_features/Capture_decran_2025-02-17_a_16.57.57.png" %}" alt="Capture d’écran de la page actuellement en ligne " />
+                            <img style="width:288px"
+                                 src="{% static "img/coming_features/Capture_decran_2025-02-17_a_16.57.57.png" %}"
+                                 alt="Capture d’écran de la page actuellement en ligne " />
                         </a>
                         <figcaption>
                             Capture d’écran de la page actuellement en ligne
@@ -922,7 +938,9 @@
                      class="column">
                     <figure id="19d765c7-b6a4-8060-9c53-cb2d34aa009c" class="image">
                         <a href="{% static "img/coming_features/Projet_Detaille_modifiable_-_Projet.png" %}">
-                            <img style="width:144px" src="{% static "img/coming_features/Projet_Detaille_modifiable_-_Projet.png" %}" alt="Projection de la page à venir" />
+                            <img style="width:144px"
+                                 src="{% static "img/coming_features/Projet_Detaille_modifiable_-_Projet.png" %}"
+                                 alt="Projection de la page à venir" />
                         </a>
                         <figcaption>
                             Projection de la page à venir
@@ -1048,7 +1066,9 @@
                     class="image"
                     style="text-align:left">
                 <a href="{% static "img/coming_features/Capture_decran_2025-02-03_a_8.51.54_PM.png" %}">
-                    <img style="width:132px" src="{% static "img/coming_features/Capture_decran_2025-02-03_a_8.51.54_PM.png" %}" alt="Image de projection (cliquer pour agrandir)" />
+                    <img style="width:132px"
+                         src="{% static "img/coming_features/Capture_decran_2025-02-03_a_8.51.54_PM.png" %}"
+                         alt="Image de projection (cliquer pour agrandir)" />
                 </a>
                 <figcaption>
                     Image de projection (cliquer pour agrandir)
@@ -1097,7 +1117,9 @@
                      class="column">
                     <figure id="18f765c7-b6a4-80db-bdbe-fba4defa067b" class="image">
                         <a href="{% static "img/coming_features/Programmations_-_En_cours.png" %}">
-                            <img style="width:709.9921875px" src="{% static "img/coming_features/Programmations_-_En_cours.png" %}" alt="Programmations en cours" />
+                            <img style="width:709.9921875px"
+                                 src="{% static "img/coming_features/Programmations_-_En_cours.png" %}"
+                                 alt="Programmations en cours" />
                         </a>
                     </figure>
                 </div>
@@ -1106,7 +1128,9 @@
                      class="column">
                     <figure id="18f765c7-b6a4-80c0-a3ad-e4e1a6fa71c4" class="image">
                         <a href="{% static "img/coming_features/Programmations_-_A_venir.png" %}">
-                            <img style="width:709.9921875px" src="{% static "img/coming_features/Programmations_-_A_venir.png" %}" alt="Programmation à venir" />
+                            <img style="width:709.9921875px"
+                                 src="{% static "img/coming_features/Programmations_-_A_venir.png" %}"
+                                 alt="Programmation à venir" />
                         </a>
                     </figure>
                 </div>
@@ -1121,7 +1145,9 @@
                      class="column">
                     <figure id="18f765c7-b6a4-80ec-8c3d-c1e7027aa71d" class="image">
                         <a href="{% static "img/coming_features/Programmations_-_Passees_-_Vue_1.png" %}">
-                            <img style="width:709.9921875px" src="{% static "img/coming_features/Programmations_-_Passees_-_Vue_1.png" %}" alt="Programmations passées" />
+                            <img style="width:709.9921875px"
+                                 src="{% static "img/coming_features/Programmations_-_Passees_-_Vue_1.png" %}"
+                                 alt="Programmations passées" />
                         </a>
                     </figure>
                 </div>
@@ -1130,7 +1156,9 @@
                      class="column">
                     <figure id="18f765c7-b6a4-80cb-be35-deca8dcb8a0b" class="image">
                         <a href="{% static "img/coming_features/Programmations_-_Passees_-_Vue_2-.png" %}">
-                            <img style="width:332px" src="{% static "img/coming_features/Programmations_-_Passees_-_Vue_2-.png" %}" alt="Programmations passées 2" />
+                            <img style="width:332px"
+                                 src="{% static "img/coming_features/Programmations_-_Passees_-_Vue_2-.png" %}"
+                                 alt="Programmations passées 2" />
                         </a>
                     </figure>
                 </div>

--- a/gsl_programmation/templates/gsl_programmation/programmation_projet_detail.html
+++ b/gsl_programmation/templates/gsl_programmation/programmation_projet_detail.html
@@ -2,7 +2,8 @@
 {% load static gsl_filters dsfr_tags %}
 {% block extra_css %}
     <link rel="stylesheet" href="{% static "css/projet_detail.css" %}">
-    <link rel="stylesheet" href="{% static "css/programmation_projet_detail.css" %}">
+    <link rel="stylesheet"
+          href="{% static "css/programmation_projet_detail.css" %}">
     <link rel="stylesheet" href="{% static 'css/annotations.css' %}">
 {% endblock extra_css %}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,11 @@ addopts = "--reuse-db"
 exclude = ["**/migrations/*.py"]
 ignore = ["E501"]
 select = ["I", "F", "E", "DJ", "C90"]
+
+[tool.djlint]
+profile = "django"
+ignore = "H006,H008,H021,H026,H029"
+preserve_blank_lines = true
+line_break_after_multiline_tag = true
+indent = 4
+max_line_length = 120


### PR DESCRIPTION
## 🌮 Objectif

Le formateur de mon éditeur de code était un patch au-dessus et créait des formatages que le hook de pre-commit retirait.

## 🔍 Liste des modifications

- Par la même occaz, on retire le `.djlintrc` et on centralise dans le `pyprojet.yaml`
