### PR TITLE
Amélioration du système de messages de succès/erreurs/info

### DIFF
--- a/gsl_core/static/css/messages.css
+++ b/gsl_core/static/css/messages.css
@@ -1,28 +1,24 @@
-.message--cancelled > .fr-notice,
-.message--projet_note_deletion > .fr-notice {
-  background-color: var(--background-alt-orange-terre-battue);
-  color: var(--text-default-error);
-}
-
-.message--success > .fr-notice,
-.message--valid > .fr-notice {
+.message--success > .fr-notice {
   background-color: var(--background-alt-green-emeraude);
   color: var(--text-default-success);
 }
 
+.message--error > .fr-notice {
+  background-color: var(--background-alt-orange-terre-battue);
+  color: var(--text-default-error);
+}
 
-.message--dismissed > .fr-notice {
+.message--orange > .fr-notice {
   background-color: var(--brown-caramel-975-75);
   color: var(--text-default-warning);
 }
 
-.message--delete-modele-arrete > .fr-notice,
-.message--draft > .fr-notice {
+.message--grey > .fr-notice {
   background-color: var(--background-alt-grey);
   color: var(--text-default-grey);
 }
 
-.message--provisionally_refused > .fr-notice {
+.message--brown > .fr-notice {
   background-color: var(--background-alt-orange-terre-battue);
   color: var(--text-action-high-orange-terre-battue);
 }

--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -88,11 +88,11 @@
             {% if messages %}
                 <div class="messages">
                     {% for message in messages %}
-                        <div class="message--{{ message.extra_tags }}">
-                            {% with message|create_alert_data as data_dict %}
+                        {% with message|create_alert_data as data_dict %}
+                            <div class="message--{% if data_dict.class %}{{ data_dict.class }}{% else %}{{ message.level_tag }}{% endif %}">
                                 {% dsfr_notice data_dict %}
-                            {% endwith %}
-                        </div>
+                            </div>
+                        {% endwith %}
                     {% endfor %}
                 </div>
             {% endif %}

--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -66,6 +66,15 @@ STATUS_TO_ALERT_TITLE = {
     SimulationProjet.STATUS_PROCESSING: "Projet en traitement",
 }
 
+STATUS_TO_CLASS = {
+    SimulationProjet.STATUS_ACCEPTED: "success",
+    SimulationProjet.STATUS_REFUSED: "error",
+    SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED: "info",
+    SimulationProjet.STATUS_PROVISIONALLY_REFUSED: "brown",
+    SimulationProjet.STATUS_DISMISSED: "orange",
+    SimulationProjet.STATUS_PROCESSING: "grey",
+}
+
 
 @register.filter
 def create_alert_data(message: Any) -> dict[str, str | bool]:
@@ -76,13 +85,17 @@ def create_alert_data(message: Any) -> dict[str, str | bool]:
 
     if message.extra_tags in STATUS_TO_ALERT_TITLE:
         data_dict["title"] = STATUS_TO_ALERT_TITLE[message.extra_tags]
+        data_dict["class"] = STATUS_TO_CLASS[message.extra_tags]
     elif message.extra_tags == "projet_note_deletion":
         data_dict["title"] = "Suppression de la note"
-    elif message.extra_tags == "delete-modele-arrete":
+        data_dict["class"] = "error"
+    elif message.extra_tags == "delete_modele_arrete":
         data_dict["title"] = "Modèle supprimé"
+        data_dict["class"] = "grey"
         data_dict["icon"] = "fr-icon-delete-bin-fill"
-    elif message.extra_tags in ["info", "alert"]:
-        data_dict["type"] = message.extra_tags
+
+    if message.level_tag == "error":
+        data_dict["type"] = "alert"
 
     return data_dict
 

--- a/gsl_core/templatetags/tests/test_gsl_filters.py
+++ b/gsl_core/templatetags/tests/test_gsl_filters.py
@@ -48,60 +48,121 @@ def test_remove_first_word():
 
 
 @pytest.mark.parametrize(
-    "extra_tags, title_expected, has_message, type_expected",
+    "extra_tags, title_expected",
     (
-        ("valid", "Projet accepté", True, None),
-        ("cancelled", "Projet refusé", True, None),
-        (
-            "provisionally_accepted",
-            "Projet accepté provisoirement",
-            True,
-            None,
-        ),
-        (
-            "provisionally_refused",
-            "Projet refusé provisoirement",
-            True,
-            None,
-        ),
-        (
-            "dismissed",
-            "Projet classé sans suite",
-            True,
-            None,
-        ),
-        (
-            "draft",
-            "Projet en traitement",
-            True,
-            None,
-        ),
-        ("projet_note_deletion", "Suppression de la note", "Test description", None),
-        ("info", None, True, "info"),
-        ("alert", None, True, "alert"),
-        ("other", None, True, None),
-        (None, None, True, None),
+        ("valid", "Projet accepté"),
+        ("cancelled", "Projet refusé"),
+        ("provisionally_accepted", "Projet accepté provisoirement"),
+        ("provisionally_refused", "Projet refusé provisoirement"),
+        ("dismissed", "Projet classé sans suite"),
+        ("draft", "Projet en traitement"),
+        ("projet_note_deletion", "Suppression de la note"),
+        ("delete_modele_arrete", "Modèle supprimé"),
+        ("info", None),
+        ("alert", None),
+        ("other", None),
+        (None, None),
     ),
 )
-def test_create_alert_data(extra_tags, title_expected, has_message, type_expected):
+def test_create_alert_data_title(extra_tags, title_expected):
     message_text = "Test description"
-    message = type("Message", (object,), {})()
+    message = type("Message", (object,), {"level_tag": "success"})()
     message.message = message_text
     message.extra_tags = extra_tags
 
     data = create_alert_data(message)
 
     assert data["is_collapsible"] is True
+    assert data["description"] == message_text
 
     if title_expected:
         assert data["title"] == title_expected
     else:
         assert "title" not in data
 
-    if has_message:
-        assert data["description"] == message_text
+
+@pytest.mark.parametrize(
+    "extra_tags, class_expected",
+    (
+        ("valid", "success"),
+        ("cancelled", "error"),
+        ("provisionally_accepted", "info"),
+        ("provisionally_refused", "brown"),
+        ("dismissed", "orange"),
+        ("draft", "grey"),
+        ("projet_note_deletion", "error"),
+        ("delete_modele_arrete", "grey"),
+        ("alert", None),
+        ("error", None),
+        ("other", None),
+        (None, None),
+    ),
+)
+def test_create_alert_data_class(extra_tags, class_expected):
+    message = type(
+        "Message", (object,), {"message": "Mon message", "level_tag": "success"}
+    )()
+    message.extra_tags = extra_tags
+
+    data = create_alert_data(message)
+
+    if class_expected:
+        assert data["class"] == class_expected
     else:
-        assert "description" not in data
+        assert "class" not in data
+
+
+@pytest.mark.parametrize(
+    "extra_tags, icon_expected",
+    (
+        ("valid", None),
+        ("cancelled", None),
+        ("provisionally_accepted", None),
+        ("provisionally_refused", None),
+        ("dismissed", None),
+        ("draft", None),
+        ("projet_note_deletion", None),
+        ("delete_modele_arrete", "fr-icon-delete-bin-fill"),
+        ("alert", None),
+        ("error", None),
+        ("other", None),
+        (None, None),
+    ),
+)
+def test_create_alert_data_icon(extra_tags, icon_expected):
+    message = type(
+        "Message", (object,), {"message": "Mon message", "level_tag": "success"}
+    )()
+    message.extra_tags = extra_tags
+
+    data = create_alert_data(message)
+
+    if icon_expected:
+        assert data["icon"] == icon_expected
+    else:
+        assert "icon" not in data
+
+
+@pytest.mark.parametrize(
+    "level_tag, type_expected",
+    (
+        ("info", None),
+        ("warning", None),
+        (
+            "success",
+            None,
+        ),
+        ("error", "alert"),
+    ),
+)
+def test_create_alert_data_type(level_tag, type_expected):
+    message = type(
+        "Message",
+        (object,),
+        {"message": "Mon message", "level_tag": level_tag, "extra_tags": ""},
+    )()
+
+    data = create_alert_data(message)
 
     if type_expected:
         assert data["type"] == type_expected

--- a/gsl_notification/views/modele_views.py
+++ b/gsl_notification/views/modele_views.py
@@ -398,7 +398,7 @@ def delete_modele_view(request, modele_type, modele_id):
         messages.info(
             request,
             f"Le modèle {type_and_article} “{name}” a été supprimé.",
-            extra_tags="delete-modele-arrete",
+            extra_tags="delete_modele_arrete",
         )
 
     except ProtectedError:

--- a/gsl_simulation/models.py
+++ b/gsl_simulation/models.py
@@ -126,18 +126,18 @@ class SimulationProjet(BaseModel):
     def _validate_montant(self, errors):
         if self.dotation_projet.assiette is not None:
             if self.montant and self.montant > self.dotation_projet.assiette:
-                errors["montant"] = {
-                    f"Le montant de la simulation ne peut pas être supérieur à l'assiette du projet ({self.projet.pk})."
-                }
+                errors["montant"] = (
+                    "Le montant de la simulation ne peut pas être supérieur à l'assiette du projet."
+                )
         else:
             if (
                 self.montant
                 and self.projet.dossier_ds.finance_cout_total
                 and self.montant > self.projet.dossier_ds.finance_cout_total
             ):
-                errors["montant"] = {
-                    f"Le montant de la simulation ne peut pas être supérieur au coût total du projet ({self.projet.pk})."
-                }
+                errors["montant"] = (
+                    "Le montant de la simulation ne peut pas être supérieur au coût total du projet."
+                )
 
     def _validate_dotation(self, errors):
         if self.dotation_projet.dotation != self.simulation.enveloppe.dotation:

--- a/gsl_simulation/views/simulation_projet_annotations_views.py
+++ b/gsl_simulation/views/simulation_projet_annotations_views.py
@@ -54,7 +54,6 @@ class SimulationProjetAnnotationsView(SimulationProjetDetailView):
             messages.success(
                 request,
                 "La note a été ajoutée avec succès.",
-                extra_tags="info",
             )
             return redirect_to_same_page_or_to_simulation_detail_by_default(
                 request, simulation_projet
@@ -63,7 +62,6 @@ class SimulationProjetAnnotationsView(SimulationProjetDetailView):
             messages.error(
                 request,
                 "Une erreur s'est produite lors de la soumission du formulaire.",
-                extra_tags="alert",
             )
             self.object = simulation_projet
             context = self.get_context_data(**kwargs)
@@ -113,7 +111,6 @@ class ProjetNoteEditView(UpdateView):
         messages.success(
             self.request,
             "La note a été mise à jour avec succès.",
-            extra_tags="info",
         )
         return reverse(
             "gsl_simulation:simulation-projet-annotations",

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -88,7 +88,6 @@ def patch_dotation_projet(request, pk):
         messages.success(
             request,
             "Les modifications ont été enregistrées avec succès.",
-            extra_tags="info",
         )
         return redirect_to_same_page_or_to_simulation_detail_by_default(
             request, simulation_projet
@@ -97,7 +96,6 @@ def patch_dotation_projet(request, pk):
     messages.error(
         request,
         "Une erreur s'est produite lors de la soumission du formulaire.",
-        extra_tags="alert",
     )
 
     return redirect_to_same_page_or_to_simulation_detail_by_default(
@@ -116,7 +114,6 @@ def patch_projet(request, pk):
         messages.success(
             request,
             "Les modifications ont été enregistrées avec succès.",
-            extra_tags="info",
         )
         try:
             simulation_projet.refresh_from_db()
@@ -133,7 +130,6 @@ def patch_projet(request, pk):
     messages.error(
         request,
         "Une erreur s'est produite lors de la soumission du formulaire. Veuillez sélectionner au moins une dotation.",
-        extra_tags="alert",
     )
 
     return redirect_to_same_page_or_to_simulation_detail_by_default(
@@ -185,7 +181,6 @@ class SimulationProjetDetailView(CorrectUserPerimeterRequiredMixin, DetailView):
             messages.success(
                 request,
                 "Les modifications ont été enregistrées avec succès.",
-                extra_tags="info",
             )
             return redirect_to_same_page_or_to_simulation_detail_by_default(
                 request, simulation_projet
@@ -194,7 +189,6 @@ class SimulationProjetDetailView(CorrectUserPerimeterRequiredMixin, DetailView):
         messages.error(
             request,
             "Une erreur s'est produite lors de la soumission du formulaire.",
-            extra_tags="alert",
         )
         self.object = simulation_projet
         self.simulation_projet = simulation_projet


### PR DESCRIPTION
## 🌮 Objectif

Faire en sorte que lorsqu'on utilise `messages.info` ça fasse un bandeau bleu, `.error` un rouge et `.success` un vert.