### PR TITLE
Maintien le filtre sélectionné après être allé sur une fiche projet

### DIFF
--- a/gsl_programmation/templates/gsl_programmation/programmation_projet_detail.html
+++ b/gsl_programmation/templates/gsl_programmation/programmation_projet_detail.html
@@ -9,7 +9,7 @@
 
 {% block go_back_button %}
     <div class="fr-mb-4w">
-        <a href="{% if go_back_link %}{{ go_back_link }}{% else %}{% url 'programmation:programmation-projet-list-dotation' dotation=programmation_projet.dotation_projet.dotation %}{% endif %}"
+        <a href="{% if go_back_link %}{{ go_back_link }}{% else %}{% url 'programmation:programmation-projet-list-dotation' dotation=programmation_projet.dotation_projet.dotation %}{% querystring %}{% endif %}"
            class="fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-btn--tertiary">
             Retour à la liste des projets programmés
         </a>

--- a/gsl_programmation/templates/gsl_programmation/programmation_projet_list.html
+++ b/gsl_programmation/templates/gsl_programmation/programmation_projet_list.html
@@ -232,7 +232,7 @@
                                     </td>
                                     <td>
                                         <a class="fr-btn--tertiary-no-outline gsl-no-underline"
-                                           href="{{ programmation_projet.get_absolute_url }}">
+                                           href="{{ programmation_projet.get_absolute_url }}{% querystring %}">
                                             <span class="fr-sr-only">Voir le projet programmé {{ programmation_projet.projet.dossier_ds.ds_number }}</span>
                                             <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
                                         </a>

--- a/gsl_programmation/templates/gsl_programmation/tab_programmation_projet/tabs.html
+++ b/gsl_programmation/templates/gsl_programmation/tab_programmation_projet/tabs.html
@@ -2,26 +2,26 @@
     <ul class="fake fr-tabs__list ul-list">
         <li>
             {% url "programmation:programmation-projet-detail" programmation_projet_id=programmation_projet.id as projet_url %}
-            <a href="{{ projet_url }}"
+            <a href="{{ projet_url }}{% querystring %}"
                {% if current_tab == "projet" %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-article-line fr-tabs__tab--icon-left">Programmation</a>
         </li>
         <li>
             {% url "programmation:programmation-projet-tab" programmation_projet_id=programmation_projet.id tab="annotations" as annotations_url %}
-            <a href="{{ annotations_url }}"
+            <a href="{{ annotations_url }}{% querystring %}"
                {% if current_tab == "annotations" %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-edit-line fr-tabs__tab--icon-left">Annotations</a>
         </li>
         <li role="presentation">
             {% url "programmation:programmation-projet-tab" programmation_projet_id=programmation_projet.id tab="historique" as historique_url %}
-            <a href="{{ historique_url }}"
+            <a href="{{ historique_url }}{% querystring %}"
                {% if current_tab == "historique" %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-archive-line fr-tabs__tab--icon-left">Historique du demandeur</a>
         </li>
         {% if programmation_projet.status == "accepted" %}
             <li>
                 {% url 'gsl_notification:documents' programmation_projet.id as notifications_url %}
-                <a href="{{ notifications_url }}"
+                <a href="{{ notifications_url }}{% querystring %}"
                    {% if "/notification/" in request.path %}aria-selected="true"{% endif %}
                    class="fr-tabs__tab fr-icon-mail-fill fr-tabs__tab--icon-left">Notifications du demandeur</a>
             </li>

--- a/gsl_projet/templates/gsl_projet/projet.html
+++ b/gsl_projet/templates/gsl_projet/projet.html
@@ -8,7 +8,7 @@
 {% block content %}
     {% block go_back_button %}
         <div class="fr-mb-4w">
-            <a href="{% url "projet:list" %}"
+            <a href="{% url "projet:list" %}{% querystring %}"
                class="fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-btn--tertiary">
                 Retour à la liste des projets
             </a>

--- a/gsl_projet/templates/gsl_projet/projet/tabs.html
+++ b/gsl_projet/templates/gsl_projet/projet/tabs.html
@@ -2,20 +2,20 @@
     <ul class="fake fr-tabs__list ul-list">
         <li>
             {% url "projet:get-projet" projet_id=projet.id as projet_url %}
-            <a href="{{ projet_url }}"
+            <a href="{{ projet_url }}{% querystring %}"
                {% if request.path == projet_url %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-article-line fr-tabs__tab--icon-left">Projet</a>
         </li>
         <li>
             {% url "projet:get-projet-tab" projet_id=projet.id tab="annotations" as annotations_url %}
-            <a href="{{ annotations_url }}"
+            <a href="{{ annotations_url }}{% querystring %}"
                {% if request.path == annotations_url %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-edit-line fr-tabs__tab--icon-left">Annotations</a>
         </li>
         <li role="presentation">
             {% url "projet:get-projet-tab" projet_id=projet.id tab="historique" as historique_url %}
 
-            <a href="{{ historique_url }}"
+            <a href="{{ historique_url }}{% querystring %}"
                {% if request.path == historique_url %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-archive-line fr-tabs__tab--icon-left">Historique du
             demandeur</a>

--- a/gsl_projet/templates/includes/_projets_table.html
+++ b/gsl_projet/templates/includes/_projets_table.html
@@ -114,7 +114,7 @@
                         </td>
                         <td class="fr-cell--right">
                             <a class="fr-btn--tertiary-no-outline gsl-no-underline"
-                               href="{{ projet.get_absolute_url }}">
+                               href="{{ projet.get_absolute_url }}{% querystring %}">
                                 <span class="fr-sr-only">Voir le projet {{ projet.dossier_ds.ds_number }}</span>
                                 <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
                             </a>

--- a/gsl_simulation/templates/gsl_simulation/simulation_projet_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_projet_detail.html
@@ -10,7 +10,7 @@
 
 {% block go_back_button %}
     <div class="fr-mb-4w">
-        <a href="{% url "simulation:simulation-detail" slug=simu.simulation.slug %}"
+        <a href="{% url "simulation:simulation-detail" slug=simu.simulation.slug %}{% querystring %}"
            class="fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-btn--tertiary">
             Retour à la simulation
         </a>

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tabs.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tabs.html
@@ -2,20 +2,20 @@
     <ul class="fake fr-tabs__list ul-list">
         <li>
             {% url "simulation:simulation-projet-detail" pk=simu.id as projet_url %}
-            <a href="{{ projet_url }}"
+            <a href="{{ projet_url }}{% querystring %}"
                {% if request.path == projet_url %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-article-fill fr-tabs__tab--icon-left">Projet</a>
         </li>
         <li>
             {% url "simulation:simulation-projet-tab" pk=simu.id tab="annotations" as annotations_url %}
-            <a href="{{ annotations_url }}"
+            <a href="{{ annotations_url }}{% querystring %}"
                {% if request.path == annotations_url %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-edit-fill fr-tabs__tab--icon-left">Annotations</a>
         </li>
         <li role="presentation">
             {% url "simulation:simulation-projet-tab" pk=simu.id tab="historique" as historique_url %}
 
-            <a href="{{ historique_url }}"
+            <a href="{{ historique_url }}{% querystring %}"
                {% if request.path == historique_url %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-archive-fill fr-tabs__tab--icon-left">Historique du
             demandeur</a>
@@ -24,7 +24,7 @@
         {% if dotation_projet.programmation_projet and dotation_projet.programmation_projet.status == "accepted" %}
             <li>
                 {% url 'gsl_notification:documents' dotation_projet.programmation_projet.id as notifications_url %}
-                <a href="{{ notifications_url }}"
+                <a href="{{ notifications_url }}{% querystring %}"
                    {% if request.path == notifications_url %}aria-selected="true"{% endif %}
                    class="fr-tabs__tab fr-icon-mail-fill fr-tabs__tab--icon-left">Notifications du demandeur</a>
             </li>

--- a/gsl_simulation/templates/includes/_simulation_detail_row.html
+++ b/gsl_simulation/templates/includes/_simulation_detail_row.html
@@ -60,7 +60,7 @@
         </td>
         <td class="fr-cell--right gsl-nowrap">
             <a class="fr-btn--tertiary-no-outline gsl-no-underline"
-               href="{{ simu.get_absolute_url }}">
+               href="{{ simu.get_absolute_url }}{% querystring %}">
                 <span class="fr-sr-only">Voir le projet {{ projet.dossier_ds.ds_number }}</span>
                 <span class="fr-icon-arrow-right-s-line" aria-hidden="true"></span>
             </a>


### PR DESCRIPTION
## 🌮 Objectif

Maintenir le filtre sélectionné après être allé sur une fiche projet

## 🔍 Liste des modifications

* conserve la querystring lors de la navigation sur les projets, les onglets et le bouton retour à la liste

## ⚠️ Informations supplémentaires

Les autres solutions étaient :
* utiliser l'API JS back du navigateur : inutilement complexe du fait des onglets qui font que la liste peut-être plusieurs page laod en arrière
* conserver en session côté serveur les filtres activés : peut être surprenant si les filtres sont reproduits d'un onglet à l'autre