### PR TITLE
Réparation de l'import de démarche

### DIFF
--- a/gsl_demarches_simplifiees/importer/demarche.py
+++ b/gsl_demarches_simplifiees/importer/demarche.py
@@ -64,8 +64,11 @@ def get_or_create_demarche(demarche_data):
         f"ds_{field}": demarche_data[camelcase(field)] for field in ds_fields
     }
     if demarche_data["activeRevision"]:
-        django_data["active_revision_date"] = timezone.datetime.fromisoformat(
-            demarche_data["activeRevision"]["datePublication"]
+        active_revision_date = demarche_data["activeRevision"]["datePublication"]
+        django_data["active_revision_date"] = (
+            None
+            if active_revision_date is None
+            else timezone.datetime.fromisoformat(active_revision_date)
         )
         django_data["active_revision_id"] = demarche_data["activeRevision"]["id"]
     try:

--- a/gsl_demarches_simplifiees/tests/test_save_ds_demarche.py
+++ b/gsl_demarches_simplifiees/tests/test_save_ds_demarche.py
@@ -83,6 +83,32 @@ def test_get_new_demarche_prefills_ds_fields(demarche_data_without_dossier):
     assert demarche.raw_ds_data == demarche_data_without_dossier
 
 
+def test_get_or_create_demarche_with_no_active_revision():
+    demarche_data = {
+        "id": "un-id-qui-nest-pas-un-vrai==",
+        "number": 123456,
+        "title": "Titre de la démarche",
+        "state": "brouillon",
+        "dateCreation": "2023-10-07T14:47:24+02:00",
+        "dateFermeture": None,
+        "activeRevision": {
+            "id": "UHJvY2VkdXJlUmV2aXNpb24tMjEzMjk4",
+            "datePublication": None,
+            "champDesciptors": [],
+        },
+        "groupeInstructeurs": [],
+        "champs": [],
+    }
+    demarche = get_or_create_demarche(demarche_data)
+    assert demarche.ds_id == "un-id-qui-nest-pas-un-vrai=="
+    assert demarche.ds_number == 123456
+    assert demarche.ds_title == "Titre de la démarche"
+    assert demarche.ds_state == "brouillon"
+    assert demarche.active_revision_date is None
+    assert demarche.active_revision_id == "UHJvY2VkdXJlUmV2aXNpb24tMjEzMjk4"
+    assert demarche.raw_ds_data == demarche_data
+
+
 def test_save_groupe_instructeurs(demarche, demarche_data_without_dossier):
     save_groupe_instructeurs(demarche_data_without_dossier, demarche)
     assert Profile.objects.count() == 2


### PR DESCRIPTION
## 🌮 Objectif

Notre démarche test n'a pas de date de révision, ce qui a levé une erreur lors de l'import de celle-ci.
On permet désormais de gérer ce cas-là.

## 🔍 Liste des modifications

- Gestion du cas null et ajout d'un test