### PR TITLE
Mise à jour des champs CRTE et budget vert dans DS

### DIFF
--- a/gsl_demarches_simplifiees/exceptions.py
+++ b/gsl_demarches_simplifiees/exceptions.py
@@ -16,4 +16,4 @@ class FieldError(DsServiceException):
 
 
 class UserRightsError(DsServiceException):
-    DEFAULT_MESSAGE = "Vous n'avez pas les droits suffisants pour modifier ce champ."
+    DEFAULT_MESSAGE = "Vous n'avez pas les droits suffisants pour modifier ce dossier."

--- a/gsl_demarches_simplifiees/services.py
+++ b/gsl_demarches_simplifiees/services.py
@@ -24,17 +24,11 @@ class DsService:
             dossier, user, value, field="annotations_is_qpv"
         )
 
-    def update_ds_is_budget_vert(self, dossier: Dossier, user: Collegue, value: str):
-        # Here, we do this because DS API only accepts a boolean field for checkbox
-        # It does not consider "Oui/Non/Non renseigné fields"
-        if value == "True":
-            bool_value = True
-        elif value == "False":
-            bool_value = False
-        else:
-            bool_value = False
+    def update_ds_is_budget_vert(
+        self, dossier: Dossier, user: Collegue, value: bool | str
+    ):
         return self._update_boolean_field(
-            dossier, user, bool_value, field="annotations_is_budget_vert"
+            dossier, user, bool(value), field="annotations_is_budget_vert"
         )
 
     def update_ds_is_attached_to_a_crte(

--- a/gsl_demarches_simplifiees/tests/test_services.py
+++ b/gsl_demarches_simplifiees/tests/test_services.py
@@ -57,7 +57,7 @@ def test_update_boolean_field_functions_call_generic_function_success(
 
 
 @pytest.mark.parametrize(
-    "value, expected_param", (("True", True), ("False", False), ("", False))
+    "value, expected_param", ((True, True), (False, False), ("", False))
 )
 @mock.patch.object(DsService, "_update_boolean_field")
 def test_update_ds_is_budget_vert_functions_call_generic_function_success(
@@ -131,7 +131,7 @@ def test_update_update_boolean_field_field_error(
         side_effect=FieldMappingForComputer.DoesNotExist,
     ):
         with pytest.raises(FieldError) as exc_info:
-            ds_service._update_boolean_field(dossier, user, "true", field)
+            ds_service._update_boolean_field(dossier, user, True, field)
 
     assert (
         str(exc_info.value)
@@ -158,7 +158,7 @@ possible_responses = [
             }
         },
         UserRightsError,
-        "Vous n'avez pas les droits suffisants pour modifier ce champ.",
+        "Vous n'avez pas les droits suffisants pour modifier ce dossier.",
         logging.INFO,
         "Instructeur has no rights on the dossier",
     ),

--- a/gsl_projet/tests/forms/test_projet_form.py
+++ b/gsl_projet/tests/forms/test_projet_form.py
@@ -9,7 +9,7 @@ from gsl_projet.tests.factories import DotationProjetFactory, ProjetFactory
 
 @pytest.fixture
 def projet():
-    projet = ProjetFactory()
+    projet = ProjetFactory(is_budget_vert=None)
     DotationProjetFactory(projet=projet, dotation=DOTATION_DETR)
     return projet
 
@@ -107,4 +107,22 @@ def test_projet_form_save(projet):
     assert projet.is_in_qpv is True
     assert projet.is_attached_to_a_crte is True
     assert projet.is_budget_vert is False
+    assert projet.dotations == [DOTATION_DSIL]
+
+
+@pytest.mark.django_db
+def test_projet_form_save_with_field_exceptions(projet):
+    data = {
+        "is_in_qpv": True,
+        "is_attached_to_a_crte": True,
+        "is_budget_vert": False,
+        "dotations": [DOTATION_DSIL],
+    }
+    form = ProjetForm(instance=projet, data=data)
+    assert form.is_valid()
+    projet = form.save(commit=True, field_exceptions=["is_budget_vert"])
+    assert isinstance(projet, Projet)
+    assert projet.is_in_qpv is True
+    assert projet.is_attached_to_a_crte is True
+    assert projet.is_budget_vert is None  # Default value
     assert projet.dotations == [DOTATION_DSIL]

--- a/gsl_simulation/services/projet_updater.py
+++ b/gsl_simulation/services/projet_updater.py
@@ -1,0 +1,39 @@
+from django.db import transaction
+
+from gsl_demarches_simplifiees.exceptions import (
+    DsServiceException,
+    InstructeurUnknown,
+    UserRightsError,
+)
+from gsl_demarches_simplifiees.services import DsService
+
+FIELDS_UPDATABLE_ON_DS = ["is_in_qpv", "is_attached_to_a_crte", "is_budget_vert"]
+
+
+def process_projet_update(form, projet, user):
+    """
+    Returns a tuple(errors, has_blocking_error).
+    - errors: field and errors mapping
+    - has_blocking_error: True if global error (ex: UserRightsError)
+    """
+    errors = {}
+    ds_service = DsService()
+
+    with transaction.atomic():
+        for field in FIELDS_UPDATABLE_ON_DS:
+            if field in form.changed_data:
+                try:
+                    update_function = getattr(ds_service, f"update_ds_{field}")
+                    update_function(
+                        projet.dossier_ds,
+                        user,
+                        form.cleaned_data[field],
+                    )
+                except (UserRightsError, InstructeurUnknown) as e:
+                    return {"all": e}, True  # global error -> stop
+                except DsServiceException as e:
+                    errors[field] = str(e)
+
+        form.save(field_exceptions=errors.keys())
+
+    return errors, False

--- a/gsl_simulation/utils.py
+++ b/gsl_simulation/utils.py
@@ -43,3 +43,19 @@ def add_success_message(
             STATUS_TO_MESSAGE[message_type],
             extra_tags=message_type,
         )
+
+
+FIELD_TO_LABEL_MAP = {
+    "is_in_qpv": "QPV",
+    "is_attached_to_a_crte": "CRTE",
+    "is_budget_vert": "Budget vert",
+}
+
+
+def build_error_message(errors):
+    parts = []
+    for field, msg in errors.items():
+        label = FIELD_TO_LABEL_MAP.get(field, field)
+        complete_message = f"{label} => {msg}" if msg else label
+        parts.append(complete_message)
+    return " / ".join(parts)


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir mettre à jour CRTE et budget vert sur DS.


## ⚠️ Informations supplémentaires

~A noter que l'on va vivre avec de cas de désynchro potentielle avec DS. Si le formulaire est valide, que le premier champ est mis à jour sur DS, puis que la MAJ du deuxième champ échoue, alors on annule l'enregistrement du formulaire et on affiche une erreur. Sur DS, le premier champ a alors changé.~
~=> A corriger avec un enregistrement champ par champ (auto-save sur l'app)~
Finalement on enregistre les champs valides et qui ont été mis à jour sur DS.
Suite possible, faire de l'auto-save (bonus)

- [x] Split `test_views` dans une autre PR + bouger `test_views` dans `tests/views`
