### PR TITLE
Correctif des dépendances

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -109,9 +109,6 @@ MIDDLEWARE = [
 ]
 
 if DEBUG:
-    INSTALLED_APPS.append("query_counter")
-    MIDDLEWARE.append("query_counter.middleware.DjangoQueryCounterMiddleware")
-
     INSTALLED_APPS.append("debug_toolbar")
     MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
 
@@ -277,10 +274,6 @@ CONTENT_SECURITY_POLICY = {
 CONTENT_SECURITY_POLICY_REPORT_ONLY = {}
 
 # Dev configuration
-
-# syntax coloring queries in django-query-counters.
-# see https://pygments.org/demo/
-DQC_PYGMENTS_STYLE = os.getenv("DQC_PYGMENTS_STYLE", "monokai")
 
 
 # Storage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ build-backend = "setuptools.build_meta"
 [project.optional-dependencies]
 dev = [
     "diff-cover",
-    "django-query-counter",
+    "django-debug-toolbar",
     "djlint",
     "factory_boy",
     "freezegun",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -98,6 +98,7 @@ django==5.2.5
     #   django-celery-results
     #   django-crispy-forms
     #   django-csp
+    #   django-debug-toolbar
     #   django-dsfr
     #   django-extensions
     #   django-filter
@@ -119,6 +120,8 @@ django-crispy-forms==2.4
     # via django-dsfr
 django-csp==4.0
     # via gsl (pyproject.toml)
+django-debug-toolbar==6.0.0
+    # via gsl (pyproject.toml)
 django-dsfr==3.0.0
     # via gsl (pyproject.toml)
 django-extensions==4.1
@@ -132,8 +135,6 @@ django-fsm-2==4.0.0
 django-htmx==1.23.2
     # via gsl (pyproject.toml)
 django-import-export==4.3.9
-    # via gsl (pyproject.toml)
-django-query-counter==0.4.1
     # via gsl (pyproject.toml)
 django-referrer-policy==1.0
     # via gsl (pyproject.toml)
@@ -323,15 +324,15 @@ six==1.17.0
 soupsieve==2.7
     # via beautifulsoup4
 sqlparse==0.5.3
-    # via django
+    # via
+    #   django
+    #   django-debug-toolbar
 stack-data==0.6.3
     # via ipython
 tablib[ods,xls,xlsx]==3.8.0
     # via
     #   django-import-export
     #   gsl (pyproject.toml)
-tabulate==0.9.0
-    # via django-query-counter
 tinycss2==1.4.0
     # via
     #   cssselect2


### PR DESCRIPTION
## 🌮 Objectif

Dans la #302 il manque l'ajout de la dépendance django debug toolbar dans le pyproject et le requirements-dev.txt

Je les ajoute, et j'enlève django-query-counter qui se retrouve à faire double emploi (la debug toolbar compte elle aussi les requêtes).

