### PR TITLE
Réparation de la mise à jour d'un projet

### DIFF
--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -67,10 +67,12 @@ class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
 
     @admin.action(description="Rafraîchir depuis le dossier DS")
     def refresh_from_dossier(self, request, queryset):
-        from gsl_projet.tasks import update_projet_from_dossier
+        from gsl_projet.tasks import create_or_update_projet_and_co_from_dossier
 
         for projet in queryset.select_related("dossier_ds"):
-            update_projet_from_dossier.delay(projet.dossier_ds.ds_number)
+            create_or_update_projet_and_co_from_dossier.delay(
+                projet.dossier_ds.ds_number
+            )
 
     def dotations(self, obj):
         return ", ".join(obj.dotations)

--- a/gsl_projet/signals.py
+++ b/gsl_projet/signals.py
@@ -10,14 +10,14 @@ from gsl_projet.constants import (
 )
 from gsl_projet.models import DotationProjet
 
-from .tasks import update_projet_from_dossier
+from .tasks import create_or_update_projet_and_co_from_dossier
 
 
 @receiver(post_save, sender=Dossier, dispatch_uid="create_projet")
 def create_projet_from_valid_dossier(sender, instance: Dossier, *args, **kwargs):
     if not instance.ds_state:
         return
-    update_projet_from_dossier.delay(instance.ds_number)
+    create_or_update_projet_and_co_from_dossier.delay(instance.ds_number)
 
 
 @receiver(

--- a/gsl_projet/tasks.py
+++ b/gsl_projet/tasks.py
@@ -14,23 +14,23 @@ from .services.projet_services import ProjetService
 
 
 @shared_task
-def create_or_update_projets_and_its_simulation_and_programmation_projets_from_all_dossiers(
+def create_or_update_projets_and_co_from_all_dossiers(
     batch_size=500,
 ):
     dossiers = Dossier.objects.exclude(ds_state="").values_list("ds_number", flat=True)
 
     for batch in batched(dossiers, batch_size):
-        create_or_update_projets_batch.delay(batch)
+        create_or_update_projets_and_co_batch.delay(batch)
 
 
 @shared_task
-def create_or_update_projets_batch(dossier_numbers: tuple[int]):
+def create_or_update_projets_and_co_batch(dossier_numbers: tuple[int]):
     for ds_number in dossier_numbers:
-        update_projet_from_dossier.delay(ds_number)
+        create_or_update_projet_and_co_from_dossier.delay(ds_number)
 
 
 @shared_task
-def update_projet_from_dossier(
+def create_or_update_projet_and_co_from_dossier(
     ds_dossier_number,
 ):
     ds_dossier = Dossier.objects.get(ds_number=ds_dossier_number)

--- a/gsl_projet/tests/test_signals.py
+++ b/gsl_projet/tests/test_signals.py
@@ -20,15 +20,21 @@ pytestmark = pytest.mark.django_db
 
 
 def test_dont_create_projets_from_incomplete_data():
-    with mock.patch("gsl_projet.tasks.update_projet_from_dossier.delay") as task_mock:
+    with mock.patch(
+        "gsl_projet.tasks.create_or_update_projet_and_co_from_dossier.delay"
+    ) as task_mock:
         d = DossierFactory(ds_state=Dossier.STATE_EN_CONSTRUCTION)
         d.save()
         task_mock.assert_called_once_with(d.ds_number)
-    with mock.patch("gsl_projet.tasks.update_projet_from_dossier.delay") as task_mock:
+    with mock.patch(
+        "gsl_projet.tasks.create_or_update_projet_and_co_from_dossier.delay"
+    ) as task_mock:
         d = DossierFactory(ds_state="")
         d.save()
         task_mock.assert_not_called()
-    with mock.patch("gsl_projet.tasks.update_projet_from_dossier.delay") as task_mock:
+    with mock.patch(
+        "gsl_projet.tasks.create_or_update_projet_and_co_from_dossier.delay"
+    ) as task_mock:
         dossier = DossierFactory(ds_state=Dossier.STATE_EN_INSTRUCTION)
         dossier.save()
         task_mock.assert_called_once_with(dossier.ds_number)


### PR DESCRIPTION
## 🌮 Objectif

Lorsqu'un dossier était mis à jour, alors on appelait une tâche qui mettait à jour le projet et ses dotation projets, mais pas ses simulation projets ni ses programmation projet.
Or on veut que tout soit mis à jour.

## 🔍 Liste des modifications

- Fusion des deux méthodes (on garde l'usage de la moins complète et on garde la fonction de la plus complète)
