### PR TITLE
feat: add sorting choices to projects

### DIFF
--- a/gsl_programmation/utils/programmation_projet_filters.py
+++ b/gsl_programmation/utils/programmation_projet_filters.py
@@ -4,7 +4,6 @@ from django_filters import (
     FilterSet,
     MultipleChoiceFilter,
     NumberFilter,
-    OrderingFilter,
 )
 
 from gsl_core.models import Perimetre
@@ -15,6 +14,7 @@ from gsl_projet.utils.django_filters_custom_widget import (
     CustomCheckboxSelectMultiple,
     CustomSelectWidget,
 )
+from gsl_projet.utils.projet_filters import ProjetOrderingFilter
 
 
 class ProgrammationProjetFilters(FilterSet):
@@ -153,13 +153,15 @@ class ProgrammationProjetFilters(FilterSet):
         "dotation_projet__projet__demandeur__name": "demandeur",
     }
 
-    order = OrderingFilter(
+    ORDERING_LABELS = {
+        "montant": "Montant accordé",
+        "dotation_projet__projet__dossier_ds__finance_cout_total": "Coût total",
+        "dotation_projet__projet__demandeur__name": "Demandeur",
+    }
+
+    order = ProjetOrderingFilter(
         fields=ORDERING_MAP,
-        field_labels={
-            "montant": "Montant",
-            "dotation_projet__projet__dossier_ds__finance_cout_total": "Coût",
-            "dotation_projet__projet__demandeur__name": "Demandeur",
-        },
+        field_labels=ORDERING_LABELS,
         empty_label="Tri",
         widget=CustomSelectWidget,
     )

--- a/gsl_programmation/utils/programmation_projet_filters.py
+++ b/gsl_programmation/utils/programmation_projet_filters.py
@@ -148,15 +148,17 @@ class ProgrammationProjetFilters(FilterSet):
             return queryset
 
     ORDERING_MAP = {
-        "montant": "montant",
         "dotation_projet__projet__dossier_ds__finance_cout_total": "cout",
         "dotation_projet__projet__demandeur__name": "demandeur",
+        "montant": "montant",
+        "dotation_projet__programmation_projet__montant": "Montant retenu",
     }
 
     ORDERING_LABELS = {
-        "montant": "Montant accordé",
         "dotation_projet__projet__dossier_ds__finance_cout_total": "Coût total",
         "dotation_projet__projet__demandeur__name": "Demandeur",
+        "montant": "Montant accordé",
+        "dotation_projet__programmation_projet__montant": "Montant retenu",
     }
 
     order = ProjetOrderingFilter(

--- a/gsl_projet/utils/filter_utils.py
+++ b/gsl_projet/utils/filter_utils.py
@@ -2,7 +2,7 @@ from functools import cached_property
 
 from gsl_core.models import Perimetre
 from gsl_demarches_simplifiees.models import NaturePorteurProjet
-from gsl_projet.utils.projet_filters import ProjetFilters
+from gsl_projet.utils.projet_filters import BaseProjetFilters
 
 
 class FilterUtils:
@@ -19,7 +19,7 @@ class FilterUtils:
         "notified": "includes/_filter_notified.html",
     }
 
-    DOTATION_MAPPING = dict(ProjetFilters.DOTATION_CHOICES)
+    DOTATION_MAPPING = dict(BaseProjetFilters.DOTATION_CHOICES)
     PORTEUR_MAPPING = dict(NaturePorteurProjet.TYPE_CHOICES)
 
     def enrich_context_with_filter_utils(

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -1,5 +1,7 @@
-from django.db.models import Count, Exists, OuterRef, Q
+from django.db.models import Count, Exists, F, OuterRef, Q
 from django.forms import NumberInput
+from django.forms.utils import pretty_name
+from django.utils.translation import gettext_lazy as _
 from django_filters import (
     FilterSet,
     MultipleChoiceFilter,
@@ -26,20 +28,52 @@ from gsl_projet.utils.django_filters_custom_widget import (
 from gsl_projet.utils.utils import order_couples_tuple_by_first_value
 
 
-class ProjetFilters(FilterSet):
+class ProjetOrderingFilter(OrderingFilter):
+    def build_choices(self, fields, labels):
+        return [
+            (
+                labels.get(field, _(pretty_name(field))),
+                (
+                    (f"-{param}", "La plus récente"),
+                    (param, "La plus ancienne"),
+                )
+                if param == "date"
+                else (
+                    (param, "Ascendant"),
+                    (f"-{param}", "Descendant"),
+                ),
+            )
+            for field, param in fields.items()
+        ]
+
+    def get_ordering_value(self, param):
+        descending = param.startswith("-")
+        param = param[1:] if descending else param
+        field_name = self.param_map.get(param, param)
+
+        return (
+            F(field_name).desc(nulls_last=True)
+            if descending
+            else F(field_name).asc(nulls_last=True)
+        )
+
+
+class BaseProjetFilters(FilterSet):
     ORDERING_MAP = {
         "dossier_ds__ds_date_depot": "date",
         "dossier_ds__finance_cout_total": "cout",
         "demandeur__name": "demandeur",
     }
 
-    order = OrderingFilter(
+    ORDERING_LABELS = {
+        "dossier_ds__ds_date_depot": "Date",
+        "dossier_ds__finance_cout_total": "Coût total",
+        "demandeur__name": "Demandeur",
+    }
+
+    order = ProjetOrderingFilter(
         fields=ORDERING_MAP,
-        field_labels={
-            "dossier_ds__ds_date_depot": "Date",
-            "dossier_ds__finance_cout_total": "Coût total",
-            "demandeur__name": "Demandeur",
-        },
+        field_labels=ORDERING_LABELS,
         empty_label="Tri",
         widget=CustomSelectWidget,
     )
@@ -237,5 +271,5 @@ class ProjetFilters(FilterSet):
         self.queryset = Projet.objects.all()
         qs = super().qs
         if not qs.query.order_by:
-            qs = qs.order_by("-dossier_ds__ds_date_depot")
+            qs = qs.order_by(F("dossier_ds__ds_date_depot").desc(nulls_last=True))
         return qs

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -1,6 +1,6 @@
 from functools import cached_property
 
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Sum
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -90,12 +90,12 @@ class ProjetListViewFilters(BaseProjetFilters):
 
     ORDERING_MAP = {
         **BaseProjetFilters.ORDERING_MAP,
-        "dotationprojet__programmation_projet__montant": "montant_retenu",
+        "montant_retenu_total": "montant_retenu",
     }
 
     ORDERING_LABELS = {
         **BaseProjetFilters.ORDERING_LABELS,
-        "dotationprojet__programmation_projet__montant": "Montant retenu",
+        "montant_retenu_total": "Montant retenu",
     }
 
     order = ProjetOrderingFilter(
@@ -121,6 +121,9 @@ class ProjetListViewFilters(BaseProjetFilters):
         from gsl_programmation.models import ProgrammationProjet
 
         qs = super().qs
+        qs = qs.annotate(
+            montant_retenu_total=Sum("dotationprojet__programmation_projet__montant")
+        )
         qs = qs.for_user(self.request.user)
         qs = qs.for_current_year()
         qs = qs.select_related(

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -10,8 +10,9 @@ from django_filters.views import FilterView
 
 from gsl_projet.constants import PROJET_STATUS_CHOICES
 from gsl_projet.services.projet_services import ProjetService
+from gsl_projet.utils.django_filters_custom_widget import CustomSelectWidget
 from gsl_projet.utils.filter_utils import FilterUtils
-from gsl_projet.utils.projet_filters import ProjetFilters
+from gsl_projet.utils.projet_filters import BaseProjetFilters, ProjetOrderingFilter
 from gsl_projet.utils.projet_page import PROJET_MENU
 
 from .models import CategorieDetr, Projet
@@ -71,7 +72,7 @@ def get_projet_tab(request, projet_id, tab):
     return render(request, f"gsl_projet/projet/tab_{tab}.html", context)
 
 
-class ProjetListViewFilters(ProjetFilters):
+class ProjetListViewFilters(BaseProjetFilters):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if hasattr(self.request, "user") and self.request.user.perimetre:
@@ -86,6 +87,23 @@ class ProjetListViewFilters(ProjetFilters):
                         perimetre.departement
                     )
                 )
+
+    ORDERING_MAP = {
+        **BaseProjetFilters.ORDERING_MAP,
+        "dotationprojet__programmation_projet__montant": "montant_retenu",
+    }
+
+    ORDERING_LABELS = {
+        **BaseProjetFilters.ORDERING_LABELS,
+        "dotationprojet__programmation_projet__montant": "Montant retenu",
+    }
+
+    order = ProjetOrderingFilter(
+        fields=ORDERING_MAP,
+        field_labels=ORDERING_LABELS,
+        empty_label="Tri",
+        widget=CustomSelectWidget,
+    )
 
     filterset = (
         "territoire",

--- a/gsl_simulation/tests/views/test_filters.py
+++ b/gsl_simulation/tests/views/test_filters.py
@@ -282,6 +282,20 @@ def test_view_with_filters(req, simulation, create_simulation_projets):
         )
 
 
+def test_view_with_order(req, simulation, create_simulation_projets):
+    filter_params = {
+        "order": "-montant_previsionnel",
+    }
+    view = _get_view_with_filter(req, simulation, filter_params)
+    projets = view.get_projet_queryset()
+
+    assert projets.count() == 7
+    assert (
+        projets.first().dotationprojet_set.first().simulationprojet_set.first().montant
+        == 500_000
+    )
+
+
 ## Test with multiple simulations
 
 

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -17,10 +17,14 @@ from gsl_programmation.services.enveloppe_service import EnveloppeService
 from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL, DOTATIONS
 from gsl_projet.models import CategorieDetr, DotationProjet, Projet
 from gsl_projet.services.projet_services import ProjetService
-from gsl_projet.utils.django_filters_custom_widget import CustomCheckboxSelectMultiple
+from gsl_projet.utils.django_filters_custom_widget import (
+    CustomCheckboxSelectMultiple,
+    CustomSelectWidget,
+)
 from gsl_projet.utils.filter_utils import FilterUtils
+from gsl_projet.utils.projet_filters import ProjetOrderingFilter
 from gsl_projet.utils.utils import order_couples_tuple_by_first_value
-from gsl_projet.views import ProjetFilters
+from gsl_projet.views import BaseProjetFilters
 from gsl_simulation.forms import SimulationForm
 from gsl_simulation.models import Simulation, SimulationProjet
 from gsl_simulation.resources import (
@@ -61,7 +65,7 @@ class SimulationListView(ListView):
         return qs
 
 
-class SimulationProjetListViewFilters(ProjetFilters):
+class SimulationProjetListViewFilters(BaseProjetFilters):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.slug = self.request.resolver_match.kwargs.get("slug")
@@ -94,6 +98,23 @@ class SimulationProjetListViewFilters(ProjetFilters):
         "montant_demande",
         "montant_previsionnel",
         "categorie_detr",
+    )
+
+    ORDERING_MAP = {
+        **BaseProjetFilters.ORDERING_MAP,
+        "dotationprojet__simulationprojet__montant": "montant_previsionnel",
+    }
+
+    ORDERING_LABELS = {
+        **BaseProjetFilters.ORDERING_LABELS,
+        "dotationprojet__simulationprojet__montant": "Montant prévisionnel",
+    }
+
+    order = ProjetOrderingFilter(
+        fields=ORDERING_MAP,
+        field_labels=ORDERING_LABELS,
+        empty_label="Tri",
+        widget=CustomSelectWidget,
     )
 
     ordered_status = (


### PR DESCRIPTION
## 🌮 Objectif

Ajoute des choix de tri sur les trois pages listant les projets, et modifie la présentation de ces tris.

## 🔍 Liste des modifications

- Renomme la classe `ProjetFilters` en `BaseProjetFilters` car elle n'est jamais utilisée directement (et ne doit pas l'être car il n'y a pas d'autorisation)
- Modifie les classes `ProjetListViewFilters`, `SimulationProjetListViewFilters`, et `ProgrammationProjetFilters` pour ajouter les filtres nécessaires
- Créer une classe `ProjetOrderingFilter` qui affiche les labels des choix en groupant par champ Ascendant / Descendant et place les valeurs NULL à la fin quelque soit l'ordre de tri