### PR TITLE
Correctif du contrôle de la valeur du champ `annotation_dotation`

### DIFF
--- a/gsl_projet/services/projet_services.py
+++ b/gsl_projet/services/projet_services.py
@@ -86,7 +86,7 @@ class ProjetService:
         dotation_annotation = getattr(projet.dossier_ds, field)
         dotations: list[Any] = []
 
-        if dotation_annotation is None:
+        if not dotation_annotation:
             logging.warning(f"Projet {projet} is missing annotation dotation")
             return dotations
 


### PR DESCRIPTION


## 🌮 Objectif

Résoudre des erreurs "qui n'aident pas" dans Celery : on vérifie la valeur d'un champ non nullable et on le compare à `None` : on ne rentre jamais dans ce cas de contrôle et on se retrouve avec des erreurs `annotation dotation  is unkown` qui n'aident pas.
