### PR TITLE
MAJ des dépendances

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,15 +14,15 @@ asgiref==3.9.1
     #   django-htmx
 asttokens==3.0.0
     # via stack-data
-beautifulsoup4==4.13.4
+beautifulsoup4==4.13.5
     # via bs4
 billiard==4.2.1
     # via celery
-boto3==1.40.3
+boto3==1.40.30
     # via
     #   django-storages
     #   gsl (pyproject.toml)
-botocore==1.40.3
+botocore==1.40.30
     # via
     #   boto3
     #   s3transfer
@@ -41,7 +41,7 @@ certifi==2025.8.3
     # via
     #   requests
     #   sentry-sdk
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   cryptography
     #   weasyprint
@@ -49,7 +49,7 @@ cfgv==3.4.0
     # via pre-commit
 chardet==5.2.0
     # via diff-cover
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via requests
 click==8.2.1
     # via
@@ -67,11 +67,11 @@ click-repl==0.3.0
     # via celery
 colorama==0.4.6
     # via djlint
-coverage[toml]==7.10.2
+coverage[toml]==7.10.6
     # via pytest-cov
-cron-descriptor==1.4.5
+cron-descriptor==2.0.6
     # via django-celery-beat
-cryptography==45.0.6
+cryptography==45.0.7
     # via
     #   josepy
     #   mozilla-django-oidc
@@ -91,7 +91,7 @@ distlib==0.4.0
     # via virtualenv
 dj-database-url==3.0.1
     # via gsl (pyproject.toml)
-django==5.2.5
+django==5.2.6
     # via
     #   dj-database-url
     #   django-celery-beat
@@ -122,7 +122,7 @@ django-csp==4.0
     # via gsl (pyproject.toml)
 django-debug-toolbar==6.0.0
     # via gsl (pyproject.toml)
-django-dsfr==3.0.0
+django-dsfr==3.1.0
     # via gsl (pyproject.toml)
 django-extensions==4.1
     # via gsl (pyproject.toml)
@@ -132,7 +132,7 @@ django-formtools==2.5.1
     # via gsl (pyproject.toml)
 django-fsm-2==4.0.0
     # via gsl (pyproject.toml)
-django-htmx==1.23.2
+django-htmx==1.24.1
     # via gsl (pyproject.toml)
 django-import-export==4.3.9
     # via gsl (pyproject.toml)
@@ -156,27 +156,27 @@ et-xmlfile==2.0.0
     # via openpyxl
 execnet==2.1.1
     # via pytest-xdist
-executing==2.2.0
+executing==2.2.1
     # via stack-data
 factory-boy==3.3.3
     # via gsl (pyproject.toml)
-faker==37.5.3
+faker==37.6.0
     # via factory-boy
-filelock==3.18.0
+filelock==3.19.1
     # via virtualenv
-fonttools[woff]==4.59.0
+fonttools[woff]==4.59.2
     # via weasyprint
-freezegun==1.5.4
+freezegun==1.5.5
     # via gsl (pyproject.toml)
 gunicorn==23.0.0
     # via gsl (pyproject.toml)
-identify==2.6.12
+identify==2.6.14
     # via pre-commit
 idna==3.10
     # via requests
 iniconfig==2.1.0
     # via pytest
-ipython==9.4.0
+ipython==9.5.0
     # via gsl (pyproject.toml)
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -194,7 +194,7 @@ jsbeautifier==1.15.4
     # via
     #   cssbeautifier
     #   djlint
-json5==0.12.0
+json5==0.12.1
     # via djlint
 kombu==5.5.4
     # via celery
@@ -218,7 +218,7 @@ packaging==25.0
     #   kombu
     #   pyproject-toml
     #   pytest
-parso==0.8.4
+parso==0.8.5
     # via jedi
 pathspec==0.12.1
     # via djlint
@@ -228,30 +228,30 @@ pillow==11.3.0
     # via weasyprint
 pip-tools==7.5.0
     # via gsl (pyproject.toml)
-platformdirs==4.3.8
+platformdirs==4.4.0
     # via virtualenv
 pluggy==1.6.0
     # via
     #   diff-cover
     #   pytest
     #   pytest-cov
-pre-commit==4.2.0
+pre-commit==4.3.0
     # via gsl (pyproject.toml)
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via
     #   click-repl
     #   ipython
-psycopg[binary]==3.2.9
+psycopg[binary]==3.2.10
     # via gsl (pyproject.toml)
-psycopg-binary==3.2.9
+psycopg-binary==3.2.10
     # via psycopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pycparser==2.22
+pycparser==2.23
     # via cffi
-pydantic==2.11.7
+pydantic==2.11.9
     # via pyproject-toml
 pydantic-core==2.33.2
     # via pydantic
@@ -271,14 +271,14 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pyproject-toml==0.1.0
     # via gsl (pyproject.toml)
-pytest==8.4.1
+pytest==8.4.2
     # via
     #   gsl (pyproject.toml)
     #   pytest-cov
     #   pytest-django
     #   pytest-ruff
     #   pytest-xdist
-pytest-cov==6.2.1
+pytest-cov==7.0.0
     # via gsl (pyproject.toml)
 pytest-django==4.11.1
     # via gsl (pyproject.toml)
@@ -299,29 +299,29 @@ pyyaml==6.0.2
     # via
     #   djlint
     #   pre-commit
-redis==6.3.0
+redis==6.4.0
     # via gsl (pyproject.toml)
-regex==2025.7.34
+regex==2025.9.1
     # via djlint
-requests==2.32.4
+requests==2.32.5
     # via
     #   django-dsfr
     #   gsl (pyproject.toml)
     #   mozilla-django-oidc
-ruff==0.12.7
+ruff==0.13.0
     # via
     #   gsl (pyproject.toml)
     #   pytest-ruff
-s3transfer==0.13.1
+s3transfer==0.14.0
     # via boto3
-sentry-sdk==2.34.1
+sentry-sdk==2.37.1
     # via gsl (pyproject.toml)
 six==1.17.0
     # via
     #   cssbeautifier
     #   jsbeautifier
     #   python-dateutil
-soupsieve==2.7
+soupsieve==2.8
     # via beautifulsoup4
 sqlparse==0.5.3
     # via
@@ -345,9 +345,10 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   beautifulsoup4
+    #   cron-descriptor
     #   pydantic
     #   pydantic-core
     #   typing-inspection
@@ -368,7 +369,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.33.1
+virtualenv==20.34.0
     # via pre-commit
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -383,7 +384,7 @@ wheel==0.45.1
     # via
     #   pip-tools
     #   pyproject-toml
-whitenoise==6.9.0
+whitenoise==6.10.0
     # via gsl (pyproject.toml)
 xlrd==2.0.2
     # via tablib

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,15 +12,15 @@ asgiref==3.9.1
     #   django-htmx
 asttokens==3.0.0
     # via stack-data
-beautifulsoup4==4.13.4
+beautifulsoup4==4.13.5
     # via bs4
 billiard==4.2.1
     # via celery
-boto3==1.40.3
+boto3==1.40.30
     # via
     #   django-storages
     #   gsl (pyproject.toml)
-botocore==1.40.3
+botocore==1.40.30
     # via
     #   boto3
     #   s3transfer
@@ -37,11 +37,11 @@ certifi==2025.8.3
     # via
     #   requests
     #   sentry-sdk
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   cryptography
     #   weasyprint
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via requests
 click==8.2.1
     # via
@@ -55,9 +55,9 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-cron-descriptor==1.4.5
+cron-descriptor==2.0.6
     # via django-celery-beat
-cryptography==45.0.6
+cryptography==45.0.7
     # via
     #   josepy
     #   mozilla-django-oidc
@@ -71,7 +71,7 @@ diff-match-patch==20241021
     # via django-import-export
 dj-database-url==3.0.1
     # via gsl (pyproject.toml)
-django==5.2.5
+django==5.2.6
     # via
     #   dj-database-url
     #   django-celery-beat
@@ -99,7 +99,7 @@ django-crispy-forms==2.4
     # via django-dsfr
 django-csp==4.0
     # via gsl (pyproject.toml)
-django-dsfr==3.0.0
+django-dsfr==3.1.0
     # via gsl (pyproject.toml)
 django-extensions==4.1
     # via gsl (pyproject.toml)
@@ -109,7 +109,7 @@ django-formtools==2.5.1
     # via gsl (pyproject.toml)
 django-fsm-2==4.0.0
     # via gsl (pyproject.toml)
-django-htmx==1.23.2
+django-htmx==1.24.1
     # via gsl (pyproject.toml)
 django-import-export==4.3.9
     # via gsl (pyproject.toml)
@@ -125,15 +125,15 @@ django-widget-tweaks==1.5.0
     # via django-dsfr
 et-xmlfile==2.0.0
     # via openpyxl
-executing==2.2.0
+executing==2.2.1
     # via stack-data
-fonttools[woff]==4.59.0
+fonttools[woff]==4.59.2
     # via weasyprint
 gunicorn==23.0.0
     # via gsl (pyproject.toml)
 idna==3.10
     # via requests
-ipython==9.4.0
+ipython==9.5.0
     # via gsl (pyproject.toml)
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -160,25 +160,25 @@ packaging==25.0
     #   django-csp
     #   gunicorn
     #   kombu
-parso==0.8.4
+parso==0.8.5
     # via jedi
 pexpect==4.9.0
     # via ipython
 pillow==11.3.0
     # via weasyprint
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via
     #   click-repl
     #   ipython
-psycopg[binary]==3.2.9
+psycopg[binary]==3.2.10
     # via gsl (pyproject.toml)
-psycopg-binary==3.2.9
+psycopg-binary==3.2.10
     # via psycopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pycparser==2.22
+pycparser==2.23
     # via cffi
 pydyf==0.11.0
     # via weasyprint
@@ -196,20 +196,20 @@ python-dateutil==2.9.0.post0
     #   celery
 python-dotenv==1.1.1
     # via gsl (pyproject.toml)
-redis==6.3.0
+redis==6.4.0
     # via gsl (pyproject.toml)
-requests==2.32.4
+requests==2.32.5
     # via
     #   django-dsfr
     #   gsl (pyproject.toml)
     #   mozilla-django-oidc
-s3transfer==0.13.1
+s3transfer==0.14.0
     # via boto3
-sentry-sdk==2.35.2
+sentry-sdk==2.37.1
     # via gsl (pyproject.toml)
 six==1.17.0
     # via python-dateutil
-soupsieve==2.7
+soupsieve==2.8
     # via beautifulsoup4
 sqlparse==0.5.3
     # via django
@@ -229,8 +229,10 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.14.1
-    # via beautifulsoup4
+typing-extensions==4.15.0
+    # via
+    #   beautifulsoup4
+    #   cron-descriptor
 tzdata==2025.2
     # via
     #   django-celery-beat
@@ -254,7 +256,7 @@ webencodings==0.5.1
     #   cssselect2
     #   tinycss2
     #   tinyhtml5
-whitenoise==6.9.0
+whitenoise==6.10.0
     # via gsl (pyproject.toml)
 xlrd==2.0.2
     # via tablib


### PR DESCRIPTION
## 🌮 Objectif

Les fichiers requirements.txt et requirements-dev.txt n'étaient plus synchro. Comme je fais toujours l'installation en tapant `time pip install -r requirements.txt -r requirements-dev.txt`, ça ne marchait pas pour installer les dépendances chez moi.

J'ai supprimé et régénéré les deux les fichiers de dépendances avec la commande suivante : 

```
rm requirements.txt requirements-dev.txt
pip-compile --output-file=requirements.txt pyproject.toml && pip-compile --extra=dev --output-file=requirements-dev.txt pyproject.toml
```

L'effet de bord c'est qu'on fait la MAJ de toutes les dépendances en dev et en prod. Chez Hashbang on appelle ça "les mises à jour big bang".


## 🔍 Liste des modifications

- _Liste des modifications_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
