### PR TITLE
Mise à jour du taux et du montant

### DIFF
--- a/gsl_core/static/css/messages.css
+++ b/gsl_core/static/css/messages.css
@@ -8,6 +8,7 @@
   color: var(--text-default-error);
 }
 
+.message--warning > .fr-notice,
 .message--orange > .fr-notice {
   background-color: var(--brown-caramel-975-75);
   color: var(--text-default-warning);

--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -85,17 +85,7 @@
         {% endif %}
 
         {% block messages %}
-            {% if messages %}
-                <div class="messages">
-                    {% for message in messages %}
-                        {% with message|create_alert_data as data_dict %}
-                            <div class="message--{% if data_dict.class %}{{ data_dict.class }}{% else %}{{ message.level_tag }}{% endif %}">
-                                {% dsfr_notice data_dict %}
-                            </div>
-                        {% endwith %}
-                    {% endfor %}
-                </div>
-            {% endif %}
+            {% include "blocks/messages.html" %}
         {% endblock messages %}
 
         <div class="fr-container fr-mt-4w fr-mb-6w">

--- a/gsl_core/templates/blocks/messages.html
+++ b/gsl_core/templates/blocks/messages.html
@@ -1,0 +1,11 @@
+{% load dsfr_tags gsl_filters %}
+
+<div id="messages" hx-swap-oob="{{ hx_swap_oob }}">
+    {% for message in messages %}
+        {% with message|create_alert_data as data_dict %}
+            <div class="message--{% if data_dict.class %}{{ data_dict.class }}{% else %}{{ message.level_tag }}{% endif %}">
+                {% dsfr_notice data_dict %}
+            </div>
+        {% endwith %}
+    {% endfor %}
+</div>

--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -97,6 +97,9 @@ def create_alert_data(message: Any) -> dict[str, str | bool]:
     if message.level_tag == "error":
         data_dict["type"] = "alert"
 
+    if message.level_tag == "warning":
+        data_dict["type"] = "warning"
+
     return data_dict
 
 

--- a/gsl_core/templatetags/tests/test_gsl_filters.py
+++ b/gsl_core/templatetags/tests/test_gsl_filters.py
@@ -147,7 +147,7 @@ def test_create_alert_data_icon(extra_tags, icon_expected):
     "level_tag, type_expected",
     (
         ("info", None),
-        ("warning", None),
+        ("warning", "warning"),
         (
             "success",
             None,

--- a/gsl_demarches_simplifiees/exceptions.py
+++ b/gsl_demarches_simplifiees/exceptions.py
@@ -21,7 +21,3 @@ class FieldError(DsServiceException):
 
 class UserRightsError(DsServiceException):
     DEFAULT_MESSAGE = "Vous n'avez pas les droits suffisants pour modifier ce dossier."
-
-
-class NonBlockingDsError(DsServiceException):
-    pass

--- a/gsl_demarches_simplifiees/exceptions.py
+++ b/gsl_demarches_simplifiees/exceptions.py
@@ -21,3 +21,7 @@ class FieldError(DsServiceException):
 
 class UserRightsError(DsServiceException):
     DEFAULT_MESSAGE = "Vous n'avez pas les droits suffisants pour modifier ce dossier."
+
+
+class NonBlockingDsError(DsServiceException):
+    pass

--- a/gsl_demarches_simplifiees/mixins.py
+++ b/gsl_demarches_simplifiees/mixins.py
@@ -17,6 +17,7 @@ DsUpdatableFields = Literal[
     "is_budget_vert",
     "assiette",
     "montant",
+    "taux",
 ]
 FIELDS_UPDATABLE_ON_DS: List[DsUpdatableFields] = list(get_args(DsUpdatableFields))
 FIELDS_TO_DS_SERVICE_FUNCTIONS: Mapping[DsUpdatableFields, str] = {
@@ -25,14 +26,7 @@ FIELDS_TO_DS_SERVICE_FUNCTIONS: Mapping[DsUpdatableFields, str] = {
     "is_budget_vert": "update_ds_is_budget_vert",
     "assiette": "update_ds_assiette",
     "montant": "update_ds_montant",
-}
-FIELD_TO_LABEL_MAP = {
-    "is_in_qpv": "QPV",
-    "is_attached_to_a_crte": "CRTE",
-    "is_budget_vert": "Budget vert",
-    "assiette": "Assiette",
-    "montant": "Montant",
-    "taux": "Taux",
+    "taux": "update_ds_taux",
 }
 
 logger = getLogger(__name__)
@@ -63,7 +57,13 @@ class DSUpdateMixin:
                     f"No user provided to {self.__class__.__name__}.save, can't save to DS"
                 )
             else:
-                errors, blocking = self.process_projet_update(instance)
+                data = {field: self.cleaned_data[field] for field in self.changed_data}
+                errors, blocking = process_projet_update(
+                    data=data,
+                    dossier=self.get_dossier_ds(instance),
+                    fields=self.get_fields(),
+                    user=self.user,
+                )
 
                 if blocking:
                     error_msg = (
@@ -88,45 +88,6 @@ class DSUpdateMixin:
 
         return instance, error_msg
 
-    def build_error_message(self, errors):
-        parts = []
-        for field, msg in errors.items():
-            label = FIELD_TO_LABEL_MAP.get(field, field)
-            complete_message = f"{label} => {msg}" if msg else label
-            parts.append(complete_message)
-        return " / ".join(parts)
-
-    def process_projet_update(
-        self,
-        instance,
-    ) -> tuple[dict[str, str], bool]:
-        """
-        Returns a tuple(errors, has_blocking_error).
-        - errors: field and errors mapping
-        - has_blocking_error: True if global error (ex: UserRightsError)
-        """
-        errors: dict[str, str] = {}
-        ds_service = DsService()
-        dossier: Dossier = self.get_dossier_ds(instance)  # type: ignore
-
-        for field in self.get_fields():
-            if field in self.changed_data:  # type: ignore
-                try:
-                    update_function = getattr(
-                        ds_service, FIELDS_TO_DS_SERVICE_FUNCTIONS[field]
-                    )
-                    update_function(
-                        dossier,
-                        self.user,
-                        self.cleaned_data[field],  # type: ignore
-                    )
-                except (UserRightsError, InstructeurUnknown, DsConnectionError) as e:
-                    return {"all": str(e)}, True  # global error -> stop
-                except DsServiceException as e:
-                    errors[field] = str(e)
-
-        return errors, False
-
     def get_dossier_ds(self, instance):
         raise NotImplementedError
 
@@ -138,3 +99,57 @@ class DSUpdateMixin:
 
     def post_save(self, instance):
         raise NotImplementedError
+
+
+def process_projet_update(
+    data: dict,
+    dossier: Dossier,
+    fields: List[DsUpdatableFields],
+    user: Collegue,
+) -> tuple[dict[str, str], bool]:
+    """
+    Returns a tuple(errors, has_blocking_error).
+    - errors: field and errors mapping
+    - has_blocking_error: True if global error (ex: UserRightsError)
+    """
+    errors: dict[str, str] = {}
+    ds_service = DsService()
+
+    print("FIELDS_UPDATABLE_ON_DS", fields)
+
+    for field in fields:
+        if field in data.keys():
+            try:
+                update_function = getattr(
+                    ds_service, FIELDS_TO_DS_SERVICE_FUNCTIONS[field]
+                )
+                update_function(
+                    dossier,
+                    user,
+                    data[field],
+                )
+            except (UserRightsError, InstructeurUnknown, DsConnectionError) as e:
+                return {"all": str(e)}, True  # global error -> stop
+            except DsServiceException as e:
+                errors[field] = str(e)
+
+    return errors, False
+
+
+FIELD_TO_LABEL_MAP = {
+    "is_in_qpv": "QPV",
+    "is_attached_to_a_crte": "CRTE",
+    "is_budget_vert": "Budget vert",
+    "assiette": "Assiette",
+    "montant": "Montant",
+    "taux": "Taux",
+}
+
+
+def build_error_message(errors):
+    parts = []
+    for field, msg in errors.items():
+        label = FIELD_TO_LABEL_MAP.get(field, field)
+        complete_message = f"{label} => {msg}" if msg else label
+        parts.append(complete_message)
+    return " / ".join(parts)

--- a/gsl_demarches_simplifiees/mixins.py
+++ b/gsl_demarches_simplifiees/mixins.py
@@ -16,6 +16,7 @@ DsUpdatableFields = Literal[
     "is_attached_to_a_crte",
     "is_budget_vert",
     "assiette",
+    "montant",
 ]
 FIELDS_UPDATABLE_ON_DS: List[DsUpdatableFields] = list(get_args(DsUpdatableFields))
 FIELDS_TO_DS_SERVICE_FUNCTIONS: Mapping[DsUpdatableFields, str] = {
@@ -23,6 +24,7 @@ FIELDS_TO_DS_SERVICE_FUNCTIONS: Mapping[DsUpdatableFields, str] = {
     "is_attached_to_a_crte": "update_ds_is_attached_to_a_crte",
     "is_budget_vert": "update_ds_is_budget_vert",
     "assiette": "update_ds_assiette",
+    "montant": "update_ds_montant",
 }
 FIELD_TO_LABEL_MAP = {
     "is_in_qpv": "QPV",

--- a/gsl_demarches_simplifiees/mixins.py
+++ b/gsl_demarches_simplifiees/mixins.py
@@ -30,6 +30,9 @@ FIELD_TO_LABEL_MAP = {
     "is_in_qpv": "QPV",
     "is_attached_to_a_crte": "CRTE",
     "is_budget_vert": "Budget vert",
+    "assiette": "Assiette",
+    "montant": "Montant",
+    "taux": "Taux",
 }
 
 logger = getLogger(__name__)

--- a/gsl_demarches_simplifiees/mixins.py
+++ b/gsl_demarches_simplifiees/mixins.py
@@ -76,7 +76,7 @@ class DSUpdateMixin:
                     self.reset_field(field, instance)
 
                 if errors:
-                    fields_msg = self.build_error_message(errors)
+                    fields_msg = build_error_message(errors)
                     error_msg = (
                         "Une erreur est survenue lors de la mise à jour de certaines "
                         "informations sur Démarches Simplifiées "
@@ -115,8 +115,6 @@ def process_projet_update(
     errors: dict[str, str] = {}
     ds_service = DsService()
 
-    print("FIELDS_UPDATABLE_ON_DS", fields)
-
     for field in fields:
         if field in data.keys():
             try:
@@ -124,9 +122,9 @@ def process_projet_update(
                     ds_service, FIELDS_TO_DS_SERVICE_FUNCTIONS[field]
                 )
                 update_function(
-                    dossier,
-                    user,
-                    data[field],
+                    dossier=dossier,
+                    user=user,
+                    value=data[field],
                 )
             except (UserRightsError, InstructeurUnknown, DsConnectionError) as e:
                 return {"all": str(e)}, True  # global error -> stop

--- a/gsl_demarches_simplifiees/services.py
+++ b/gsl_demarches_simplifiees/services.py
@@ -51,6 +51,18 @@ class DsService:
             value = 0
         return self._update_decimal_field(dossier, user, value, "annotations_assiette")
 
+    def update_ds_montant(self, dossier: Dossier, user: Collegue, value: float | None):
+        if value is None:
+            value = 0
+        return self._update_decimal_field(
+            dossier, user, value, "annotations_montant_accorde"
+        )
+
+    def update_ds_taux(self, dossier: Dossier, user: Collegue, value: float | None):
+        if value is None:
+            value = 0
+        return self._update_decimal_field(dossier, user, value, "annotations_taux")
+
     # Private
 
     def _update_boolean_field(

--- a/gsl_demarches_simplifiees/tests/test_services.py
+++ b/gsl_demarches_simplifiees/tests/test_services.py
@@ -72,16 +72,24 @@ def test_update_ds_is_budget_vert_functions_call_generic_function_success(
     )
 
 
+@pytest.mark.parametrize(
+    "function, field_name",
+    (
+        ("update_ds_assiette", "annotations_assiette"),
+        ("update_ds_montant", "annotations_montant_accorde"),
+        ("update_ds_taux", "annotations_taux"),
+    ),
+)
 @mock.patch.object(DsService, "_update_decimal_field")
 def test_update_decimal_field_functions_call_generic_function_success(
-    update_boolean_field_mocker, user, dossier
+    update_boolean_field_mocker, user, dossier, function, field_name
 ):
     ds_service = DsService()
 
-    ds_service_function = getattr(ds_service, "update_ds_assiette")
+    ds_service_function = getattr(ds_service, function)
     ds_service_function(dossier, user, 250.33)
     update_boolean_field_mocker.assert_called_once_with(
-        dossier, user, 250.33, "annotations_assiette"
+        dossier, user, 250.33, field_name
     )
 
 

--- a/gsl_projet/services/dotation_projet_services.py
+++ b/gsl_projet/services/dotation_projet_services.py
@@ -1,6 +1,7 @@
 from datetime import date
 from decimal import Decimal, InvalidOperation
 
+from gsl_core.templatetags.gsl_filters import euro
 from gsl_demarches_simplifiees.models import Dossier
 from gsl_programmation.models import Enveloppe
 from gsl_projet.constants import (
@@ -128,10 +129,10 @@ class DotationProjetService:
             or montant > dotation_projet.assiette_or_cout_total
         ):
             raise ValueError(
-                f"Montant {montant} must be greatear or equal to 0 and less than or equal to {dotation_projet.assiette_or_cout_total}"
+                f"Le montant {euro(montant)} doit être supérieur ou égal à 0 € et inférieur ou égal à {euro(dotation_projet.assiette_or_cout_total)}."
             )
 
     @classmethod
     def validate_taux(cls, taux: float | Decimal) -> None:
         if type(taux) not in [float, Decimal, int] or taux < 0 or taux > 100:
-            raise ValueError(f"Taux {taux} must be between 0 and 100")
+            raise ValueError(f"Le taux {taux} doit être entre 0% and 100%")

--- a/gsl_projet/services/dotation_projet_services.py
+++ b/gsl_projet/services/dotation_projet_services.py
@@ -1,7 +1,7 @@
 from datetime import date
 from decimal import Decimal, InvalidOperation
 
-from gsl_core.templatetags.gsl_filters import euro
+from gsl_core.templatetags.gsl_filters import euro, percent
 from gsl_demarches_simplifiees.models import Dossier
 from gsl_programmation.models import Enveloppe
 from gsl_projet.constants import (
@@ -135,4 +135,4 @@ class DotationProjetService:
     @classmethod
     def validate_taux(cls, taux: float | Decimal) -> None:
         if type(taux) not in [float, Decimal, int] or taux < 0 or taux > 100:
-            raise ValueError(f"Le taux {taux} doit être entre 0% and 100%")
+            raise ValueError(f"Le taux {percent(taux)} doit être entre 0% and 100%")

--- a/gsl_projet/tests/forms/test_projet_form.py
+++ b/gsl_projet/tests/forms/test_projet_form.py
@@ -138,7 +138,7 @@ def test_projet_form_save_with_multiple_dotations(projet):
 @pytest.mark.django_db
 def test_projet_form_save_with_field_exceptions(projet, user):
     with patch(
-        "gsl_demarches_simplifiees.mixins.DSUpdateMixin.process_projet_update"
+        "gsl_demarches_simplifiees.mixins.process_projet_update"
     ) as mock_process_projet_update:
         mock_process_projet_update.return_value = (
             {"is_budget_vert": "Some error"},

--- a/gsl_projet/tests/services/test_dotation_projet_services.py
+++ b/gsl_projet/tests/services/test_dotation_projet_services.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 import pytest
 
-from gsl_core.templatetags.gsl_filters import euro
+from gsl_core.templatetags.gsl_filters import euro, percent
 from gsl_core.tests.factories import (
     PerimetreArrondissementFactory,
     PerimetreDepartementalFactory,
@@ -448,7 +448,9 @@ def test_compute_montant_from_taux_with_various_cout_total(
 )
 def test_validate_taux(taux, should_raise_exception):
     if should_raise_exception:
-        with pytest.raises(ValueError, match=f"Taux {taux} must be between 0 and 100"):
+        with pytest.raises(
+            ValueError, match=f"Le taux {percent(taux)} doit être entre 0% and 100%"
+        ):
             DotationProjetService.validate_taux(taux)
     else:
         DotationProjetService.validate_taux(taux)

--- a/gsl_projet/tests/services/test_dotation_projet_services.py
+++ b/gsl_projet/tests/services/test_dotation_projet_services.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 
 import pytest
 
+from gsl_core.templatetags.gsl_filters import euro
 from gsl_core.tests.factories import (
     PerimetreArrondissementFactory,
     PerimetreDepartementalFactory,
@@ -365,8 +366,8 @@ def test_validate_montant(
         with pytest.raises(
             ValueError,
             match=(
-                f"Montant {montant} must be greatear or equal to 0 and less than or "
-                f"equal to {dotation_projet.assiette_or_cout_total}"
+                f"Le montant {euro(montant)} doit être supérieur ou égal à 0 € et inférieur ou "
+                f"égal à {euro(dotation_projet.assiette_or_cout_total)}."
             ),
         ):
             DotationProjetService.validate_montant(montant, dotation_projet)

--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -136,7 +136,7 @@ class SimulationProjetForm(DSUpdateMixin, ModelForm, DsfrBaseForm):
         return instance.projet.dossier_ds
 
     def get_fields(self):
-        return ["assiette"]
+        return ["assiette", "montant"]
 
     def reset_field(self, field, instance):
         self._reset_field(field, instance, instance.dotation_projet)

--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -6,6 +6,7 @@ from django.forms import ModelForm
 from dsfr.forms import DsfrBaseForm
 
 from gsl_core.models import Perimetre
+from gsl_demarches_simplifiees.mixins import DsUpdatableFields
 from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL
 from gsl_projet.forms import DSUpdateMixin
 from gsl_projet.models import DotationProjet
@@ -135,8 +136,10 @@ class SimulationProjetForm(DSUpdateMixin, ModelForm, DsfrBaseForm):
     def get_dossier_ds(self, instance):
         return instance.projet.dossier_ds
 
-    def get_fields(self):
-        return ["assiette", "montant"]
+    def get_fields(self) -> list[DsUpdatableFields]:  # TODO test it !
+        if self.instance.status == SimulationProjet.STATUS_ACCEPTED:
+            return ["assiette", "montant", "taux"]
+        return ["assiette"]
 
     def reset_field(self, field, instance):
         self._reset_field(field, instance, instance.dotation_projet)

--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -136,7 +136,7 @@ class SimulationProjetForm(DSUpdateMixin, ModelForm, DsfrBaseForm):
     def get_dossier_ds(self, instance):
         return instance.projet.dossier_ds
 
-    def get_fields(self) -> list[DsUpdatableFields]:  # TODO test it !
+    def get_fields(self) -> list[DsUpdatableFields]:
         if self.instance.status == SimulationProjet.STATUS_ACCEPTED:
             return ["assiette", "montant", "taux"]
         return ["assiette"]
@@ -165,7 +165,7 @@ class SimulationProjetForm(DSUpdateMixin, ModelForm, DsfrBaseForm):
             )
 
         if field == "taux":
-            initial_taux = self.initial["taux"]
+            initial_taux = self.fields["taux"].initial
             self.cleaned_data["taux"] = initial_taux
             instance.montant = DotationProjetService.compute_montant_from_taux(
                 dotation_projet, initial_taux

--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -112,9 +112,15 @@ class SimulationProjetForm(DSUpdateMixin, ModelForm, DsfrBaseForm):
         dotation_projet: DotationProjet = self.instance.dotation_projet
 
         if "assiette" in self.changed_data or "montant" in self.changed_data:
-            computed_taux = compute_taux(
-                cleaned_data.get("montant"), cleaned_data.get("assiette")
-            )
+            assiette = cleaned_data.get("assiette")
+            if assiette is None:
+                assiette = dotation_projet.dossier_ds.finance_cout_total
+
+            computed_taux = compute_taux(cleaned_data.get("montant"), assiette)
+
+            if computed_taux != self.fields["taux"].initial:
+                self.changed_data.append("taux")
+
             cleaned_data["taux"] = computed_taux
 
         else:

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -151,7 +151,6 @@ class SimulationProjetService:
         new_montant = DotationProjetService.compute_montant_from_taux(
             simulation_projet.dotation_projet, new_taux
         )
-        # TODO verify if dsError like rights error => new_montant not save
         simulation_projet.montant = new_montant
         simulation_projet.save()
 
@@ -164,7 +163,6 @@ class SimulationProjetService:
     def update_montant(
         cls, simulation_projet: SimulationProjet, new_montant: float, user: Collegue
     ):
-        # TODO verify if dsError like rights error => new_montant not save
         simulation_projet.montant = new_montant
         simulation_projet.save()
 

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -151,7 +151,7 @@ class SimulationProjetService:
         new_montant = DotationProjetService.compute_montant_from_taux(
             simulation_projet.dotation_projet, new_taux
         )
-        # todo verify if dsError like rights error => new_montant not save
+        # TODO verify if dsError like rights error => new_montant not save
         simulation_projet.montant = new_montant
         simulation_projet.save()
 
@@ -164,7 +164,7 @@ class SimulationProjetService:
     def update_montant(
         cls, simulation_projet: SimulationProjet, new_montant: float, user: Collegue
     ):
-        # todo verify if dsError like rights error => new_montant not save
+        # TODO verify if dsError like rights error => new_montant not save
         simulation_projet.montant = new_montant
         simulation_projet.save()
 
@@ -198,7 +198,7 @@ class SimulationProjetService:
         dotation_projet.save()
 
         cls._update_ds_montant_and_taux(
-            dossier_ds=dotation_projet.projet.dossier_ds,
+            dossier=dotation_projet.projet.dossier_ds,
             montant=simulation_projet.montant,
             taux=simulation_projet.taux,
             user=user,
@@ -244,14 +244,14 @@ class SimulationProjetService:
 
     @classmethod
     def _update_ds_montant_and_taux(
-        cls, dossier_ds: Dossier, montant: float, taux: float, user: Collegue
+        cls, dossier: Dossier, montant: float, taux: float, user: Collegue
     ) -> None:
         data = {
             "montant": montant,
             "taux": taux,
         }
         errors, blocking = process_projet_update(
-            data, dossier_ds, ["montant", "taux"], user
+            data, dossier, ["montant", "taux"], user
         )
 
         if blocking:

--- a/gsl_simulation/services/simulation_projet_service.py
+++ b/gsl_simulation/services/simulation_projet_service.py
@@ -182,6 +182,8 @@ class SimulationProjetService:
     def get_simulation_projet_status(cls, dotation_projet: DotationProjet):
         return cls.PROJET_STATUS_TO_SIMULATION_PROJET_STATUS.get(dotation_projet.status)
 
+    # Private
+
     @classmethod
     def _accept_a_simulation_projet(
         cls, simulation_projet: SimulationProjet, user: Collegue

--- a/gsl_simulation/templates/htmx/projet_update.html
+++ b/gsl_simulation/templates/htmx/projet_update.html
@@ -1,5 +1,6 @@
 {% load gsl_filters %}
 
+{% include "blocks/messages.html" with hx_swap_oob="true" %}
 {% include "includes/_status_summary.html" with hx_swap_oob="true" %}
 <span hx-swap-oob="innerHTML" id="total-amount-granted">{{ total_amount_granted | euro }}</span>
 {% include "includes/table_forms/_montant_form.html" %}

--- a/gsl_simulation/tests/forms/test_simulation_projet_form.py
+++ b/gsl_simulation/tests/forms/test_simulation_projet_form.py
@@ -186,15 +186,15 @@ def user() -> Collegue:
 
 
 def test_save_with_assiette_field_exceptions(simulation_projet, user):
-    mock_process_projet_update = patch(
-        "gsl_simulation.services.projet_updater.process_projet_update"
-    )
-    mock_process_projet_update.return_value = ({"assiette": "Some error"}, False)
-
     data = {"assiette": 400, "montant": 300, "taux": 75}
     form = SimulationProjetForm(instance=simulation_projet, data=data, user=user)
     assert form.is_valid()
-    form.save()
+
+    with patch(
+        "gsl_demarches_simplifiees.mixins.DSUpdateMixin.process_projet_update"
+    ) as mock_process:
+        mock_process.return_value = ({"assiette": "Some error"}, False)
+        form.save()
 
     simulation_projet.refresh_from_db()
     assert simulation_projet.dotation_projet.assiette == 1_000  # not updated
@@ -203,33 +203,34 @@ def test_save_with_assiette_field_exceptions(simulation_projet, user):
 
 
 def test_save_with_montant_field_exceptions(simulation_projet, user):
+    data = {"assiette": 400, "montant": 300, "taux": 75}
+    form = SimulationProjetForm(instance=simulation_projet, data=data, user=user)
+    assert form.is_valid()
+
     with patch(
         "gsl_demarches_simplifiees.mixins.DSUpdateMixin.process_projet_update"
     ) as mock_process:
         mock_process.return_value = ({"montant": "Some error"}, False)
-
-        data = {"assiette": 400, "montant": 300, "taux": 75}
-        form = SimulationProjetForm(instance=simulation_projet, data=data, user=user)
-        assert form.is_valid()
         form.save()
 
-        simulation_projet.refresh_from_db()
-        assert simulation_projet.dotation_projet.assiette == 400  # updated
-        assert simulation_projet.montant == 200  # not updated
-        assert simulation_projet.taux == 50  # computed
+    simulation_projet.refresh_from_db()
+    assert simulation_projet.dotation_projet.assiette == 400  # updated
+    assert simulation_projet.montant == 200  # not updated
+    assert simulation_projet.taux == 50  # computed
 
 
 def test_save_with_assiette_field_exceptions_and_montant_cleaned(
     simulation_projet, user
 ):
-    mock_process_projet_update = patch(
-        "gsl_demarches_simplifiees.mixins.process_projet_update"
-    )
-    mock_process_projet_update.return_value = ({"assiette": "Some error"}, False)
-
     data = {"assiette": 2_000, "montant": 1_500, "taux": 75}
     form = SimulationProjetForm(instance=simulation_projet, data=data, user=user)
     assert form.is_valid()
-    # Error because assiette update is cancelled (=> 1_000) and then montant is higher than assiette, so model cleans do the job
-    with pytest.raises(ValidationError):
-        form.save()
+
+    with patch(
+        "gsl_demarches_simplifiees.mixins.DSUpdateMixin.process_projet_update"
+    ) as mock_process:
+        mock_process.return_value = ({"assiette": "Some error"}, False)
+
+        # Error because assiette update is cancelled (=> 1_000) and then montant is higher than assiette, so model cleans do the job
+        with pytest.raises(ValidationError):
+            form.save()

--- a/gsl_simulation/tests/services/test_simulation_projet_services.py
+++ b/gsl_simulation/tests/services/test_simulation_projet_services.py
@@ -7,9 +7,6 @@ import pytest
 from gsl_core.models import Collegue
 from gsl_core.tests.factories import (
     CollegueFactory,
-    PerimetreArrondissementFactory,
-    PerimetreDepartementalFactory,
-    PerimetreRegionalFactory,
 )
 from gsl_programmation.models import ProgrammationProjet
 from gsl_programmation.tests.factories import (
@@ -637,94 +634,6 @@ def test_update_montant_of_accepted_montant(mock_update_ds_montant, field_name, 
     programmation_projet.refresh_from_db()
     assert programmation_projet.montant == 500.0
     assert programmation_projet.taux == 50.0
-
-
-def test_is_simulation_projet_in_perimetre_regional():
-    perimetre_arrondissement = PerimetreArrondissementFactory()
-    perimetre_regional = PerimetreRegionalFactory(
-        region=perimetre_arrondissement.region
-    )
-    dotation_projet = DetrProjetFactory(projet__perimetre=perimetre_arrondissement)
-    simulation_projet = SimulationProjetFactory(dotation_projet=dotation_projet)
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            simulation_projet, perimetre_regional
-        )
-        is True
-    )
-
-    other_arrondissement_perimetre = PerimetreArrondissementFactory()
-    other_dotation_projet = DotationProjetFactory(
-        projet__perimetre=other_arrondissement_perimetre, dotation=DOTATION_DETR
-    )
-    other_simulation_projet = SimulationProjetFactory(
-        dotation_projet=other_dotation_projet
-    )
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            other_simulation_projet, perimetre_regional
-        )
-        is False
-    )
-
-
-def test_is_simulation_projet_in_perimetre_departemental():
-    perimetre_arrondissement = PerimetreArrondissementFactory()
-    perimetre_departemental = PerimetreDepartementalFactory(
-        departement=perimetre_arrondissement.departement
-    )
-    dotation_projet = DetrProjetFactory(projet__perimetre=perimetre_arrondissement)
-    simulation_projet = SimulationProjetFactory(dotation_projet=dotation_projet)
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            simulation_projet, perimetre_departemental
-        )
-        is True
-    )
-
-    other_arrondissement = PerimetreArrondissementFactory()
-    other_dotation_projet = DetrProjetFactory(projet__perimetre=other_arrondissement)
-    other_simulation_projet = SimulationProjetFactory(
-        dotation_projet=other_dotation_projet
-    )
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            other_simulation_projet, perimetre_departemental
-        )
-        is False
-    )
-
-
-def test_is_simulation_projet_in_perimetre_arrondissement():
-    perimetre_arrondissement = PerimetreArrondissementFactory()
-    dotation_projet = DetrProjetFactory(projet__perimetre=perimetre_arrondissement)
-    simulation_projet = SimulationProjetFactory(dotation_projet=dotation_projet)
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            simulation_projet, perimetre_arrondissement
-        )
-        is True
-    )
-
-    other_arrondissement_perimetre = PerimetreArrondissementFactory()
-    other_dotation_projet = DetrProjetFactory(
-        projet__perimetre=other_arrondissement_perimetre
-    )
-    other_simulation_projet = SimulationProjetFactory(
-        dotation_projet=other_dotation_projet
-    )
-
-    assert (
-        SimulationProjetService.is_simulation_projet_in_perimetre(
-            other_simulation_projet, perimetre_arrondissement
-        )
-        is False
-    )
 
 
 @pytest.mark.parametrize(

--- a/gsl_simulation/tests/test_urls.py
+++ b/gsl_simulation/tests/test_urls.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from unittest import mock
 
 import pytest
 from django.urls import reverse
@@ -270,15 +271,21 @@ status_update_expected_status_summary = {
 
 @pytest.mark.django_db
 def test_patch_status_simulation_projet_url(
-    client_with_cote_d_or_user_logged, cote_dorien_simulation_projet
+    client_with_cote_d_or_user_logged,
+    cote_dorien_simulation_projet,
 ):
     url = reverse(
         "simulation:patch-simulation-projet-status",
         kwargs={"pk": cote_dorien_simulation_projet.pk},
     )
-    response = client_with_cote_d_or_user_logged.post(
-        url, {"status": "valid"}, follow=True
-    )
+
+    with mock.patch(
+        "gsl_simulation.services.simulation_projet_service.SimulationProjetService._update_ds_montant_and_taux"
+    ) as mock_update_ds_montant_and_taux:
+        mock_update_ds_montant_and_taux.return_value = None
+        response = client_with_cote_d_or_user_logged.post(
+            url, {"status": "valid"}, follow=True
+        )
     assert response.status_code == 200
     assert response.templates[0].name == "gsl_simulation/simulation_detail.html"
     assert response.context["simu"] == cote_dorien_simulation_projet
@@ -299,9 +306,13 @@ def test_patch_status_simulation_projet_url_with_htmx(
         "simulation:patch-simulation-projet-status",
         kwargs={"pk": cote_dorien_simulation_projet.pk},
     )
-    response = client_with_cote_d_or_user_logged.post(
-        url, {"status": "valid"}, headers={"HX-Request": "true"}, follow=True
-    )
+    with mock.patch(
+        "gsl_simulation.services.simulation_projet_service.SimulationProjetService._update_ds_montant_and_taux"
+    ) as mock_update_ds_montant_and_taux:
+        mock_update_ds_montant_and_taux.return_value = None
+        response = client_with_cote_d_or_user_logged.post(
+            url, {"status": "valid"}, headers={"HX-Request": "true"}, follow=True
+        )
     assert response.status_code == 200
     assert response.templates[0].name == "htmx/projet_update.html"
     assert response.context["simu"] == cote_dorien_simulation_projet

--- a/gsl_simulation/tests/views/test_patch_simulation_projet.py
+++ b/gsl_simulation/tests/views/test_patch_simulation_projet.py
@@ -688,6 +688,10 @@ def test_patch_simulation_projet_with_ds_error(
             return_value=ds_field,
         ),
         patch("requests.post", return_value=mock_resp),
+        patch(
+            "gsl_demarches_simplifiees.services.DsService.update_ds_taux",
+            return_value=True,
+        ),
     ):
         url = reverse(
             "simulation:simulation-projet-detail",
@@ -695,7 +699,7 @@ def test_patch_simulation_projet_with_ds_error(
         )
         response = client_with_user_logged.post(
             url,
-            {"assiette": 2000, "montant": 500, "taux": 50},
+            {"assiette": 2000, "montant": 500, "taux": 25},
             follow=True,
         )
 

--- a/gsl_simulation/tests/views/test_patch_simulation_projet.py
+++ b/gsl_simulation/tests/views/test_patch_simulation_projet.py
@@ -179,12 +179,12 @@ data_test = (
 )
 
 
-@mock.patch("gsl_demarches_simplifiees.services.DsService.update_ds_taux")
-@mock.patch("gsl_demarches_simplifiees.services.DsService.update_ds_montant")
+@mock.patch(
+    "gsl_simulation.services.simulation_projet_service.SimulationProjetService._update_ds_montant_and_taux"
+)
 @pytest.mark.parametrize("status, expected_message, expected_tag", data_test)
 def test_patch_status_simulation_projet_with_refused_value_giving_message(
-    mock_update_ds_montant,
-    mock_update_ds_taux,
+    mock_ds_update,
     client_with_user_logged,
     simulation_projet,
     status,
@@ -207,15 +207,11 @@ def test_patch_status_simulation_projet_with_refused_value_giving_message(
     )
 
     if status == SimulationProjet.STATUS_ACCEPTED:
-        mock_update_ds_montant.assert_called_once_with(
+        mock_ds_update.assert_called_once_with(
             dossier=simulation_projet.projet.dossier_ds,
             user=client_with_user_logged.user,
-            value=Decimal(simulation_projet.montant),
-        )
-        mock_update_ds_taux.assert_called_once_with(
-            dossier=simulation_projet.projet.dossier_ds,
-            user=client_with_user_logged.user,
-            value=Decimal(simulation_projet.taux),
+            montant=Decimal(simulation_projet.montant),
+            taux=Decimal(simulation_projet.taux),
         )
 
     assert response.status_code == 200
@@ -269,11 +265,11 @@ def accepted_simulation_projet(collegue, simulation):
     )
 
 
-@mock.patch("gsl_demarches_simplifiees.services.DsService.update_ds_taux")
-@mock.patch("gsl_demarches_simplifiees.services.DsService.update_ds_montant")
+@mock.patch(
+    "gsl_simulation.services.simulation_projet_service.SimulationProjetService._update_ds_montant_and_taux"
+)
 def test_patch_taux_simulation_projet(
-    mock_update_ds_montant,
-    mock_update_ds_taux,
+    mock_ds_update,
     client_with_user_logged,
     accepted_simulation_projet,
 ):
@@ -291,18 +287,12 @@ def test_patch_taux_simulation_projet(
         id=accepted_simulation_projet.id
     )
 
-    mock_update_ds_montant.assert_called_once_with(
+    mock_ds_update.assert_called_once_with(
         dossier=accepted_simulation_projet.projet.dossier_ds,
         user=client_with_user_logged.user,
-        value=7_500,
+        montant=7_500,
+        taux=75.0,
     )
-
-    mock_update_ds_taux.assert_called_once_with(
-        dossier=accepted_simulation_projet.projet.dossier_ds,
-        user=client_with_user_logged.user,
-        value=75.0,
-    )
-
     assert response.status_code == 200
     assert updated_simulation_projet.taux == 75.0
     assert updated_simulation_projet.montant == 7_500
@@ -341,11 +331,11 @@ def test_patch_taux_simulation_projet_with_wrong_value(
     assert accepted_simulation_projet.montant == 1_000
 
 
-@mock.patch("gsl_demarches_simplifiees.services.DsService.update_ds_taux")
-@mock.patch("gsl_demarches_simplifiees.services.DsService.update_ds_montant")
+@mock.patch(
+    "gsl_simulation.services.simulation_projet_service.SimulationProjetService._update_ds_montant_and_taux"
+)
 def test_patch_montant_simulation_projet(
-    mock_update_ds_montant,
-    mock_update_ds_taux,
+    mock_ds_update,
     client_with_user_logged,
     accepted_simulation_projet,
 ):
@@ -364,15 +354,11 @@ def test_patch_montant_simulation_projet(
         id=accepted_simulation_projet.id
     )
 
-    mock_update_ds_montant.assert_called_once_with(
+    mock_ds_update.assert_called_once_with(
         dossier=accepted_simulation_projet.projet.dossier_ds,
         user=client_with_user_logged.user,
-        value=1267.32,
-    )
-    mock_update_ds_taux.assert_called_once_with(
-        dossier=accepted_simulation_projet.projet.dossier_ds,
-        user=client_with_user_logged.user,
-        value=Decimal("12.673"),
+        montant=1267.32,
+        taux=Decimal("12.673"),
     )
 
     assert response.status_code == 200

--- a/gsl_simulation/views/decorators.py
+++ b/gsl_simulation/views/decorators.py
@@ -6,6 +6,8 @@ from django.shortcuts import get_object_or_404
 from gsl_programmation.services.enveloppe_service import EnveloppeService
 from gsl_simulation.models import Simulation, SimulationProjet
 
+logger = logging.getLogger(__name__)
+
 
 def simulation_projet_must_be_visible_by_user(func):
     def wrapper(*args, **kwargs):
@@ -76,7 +78,7 @@ def exception_handler_decorator(func):
         try:
             return func(*args, **kwargs)
         except Http404 as e:
-            logging.info("An error occurred: %s", str(e), exc_info=True)
+            logger.info("An error occurred: %s", str(e), exc_info=True)
             return JsonResponse(
                 {
                     "error": "Not found.",
@@ -84,7 +86,7 @@ def exception_handler_decorator(func):
                 status=404,
             )
         except Exception as e:
-            logging.error("An error occurred: %s", str(e), exc_info=True)
+            logger.error("An error occurred: %s", str(e), exc_info=True)
             return JsonResponse(
                 {
                     "error": "An internal error has occurred.",

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -37,8 +37,15 @@ from gsl_simulation.views.simulation_views import SimulationDetailView
 def patch_taux_simulation_projet(request, pk):
     simulation_projet = get_object_or_404(SimulationProjet, id=pk)
     new_taux = replace_comma_by_dot(request.POST.get("taux"))
-    DotationProjetService.validate_taux(new_taux)
-    SimulationProjetService.update_taux(simulation_projet, new_taux, request.user)
+    try:
+        DotationProjetService.validate_taux(new_taux)
+        SimulationProjetService.update_taux(simulation_projet, new_taux, request.user)
+    except (ValueError, DsServiceException) as e:
+        messages.error(
+            request,
+            "Une erreur est survenue lors de la mise à jour du taux. " + str(e),
+        )
+
     return redirect_to_same_page_or_to_simulation_detail_by_default(
         request, simulation_projet
     )
@@ -50,12 +57,19 @@ def patch_taux_simulation_projet(request, pk):
 def patch_montant_simulation_projet(request, pk):
     simulation_projet = get_object_or_404(SimulationProjet, id=pk)
     new_montant = replace_comma_by_dot(request.POST.get("montant"))
-    DotationProjetService.validate_montant(
-        new_montant, simulation_projet.dotation_projet
-    )
-    SimulationProjetService.update_montant(
-        simulation_projet, new_montant, user=request.user
-    )
+    try:
+        DotationProjetService.validate_montant(
+            new_montant, simulation_projet.dotation_projet
+        )
+        SimulationProjetService.update_montant(
+            simulation_projet, new_montant, user=request.user
+        )
+    except (ValueError, DsServiceException) as e:
+        messages.error(
+            request,
+            "Une erreur est survenue lors de la mise à jour du montant. " + str(e),
+        )
+
     return redirect_to_same_page_or_to_simulation_detail_by_default(
         request, simulation_projet
     )

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -101,7 +101,9 @@ def patch_status_simulation_projet(request, pk):
     except DsServiceException as e:  # rollback the transaction + show error
         messages.error(
             request,
-            str(e) + " Le statut n'a pas été modifié.",
+            "Une erreur est survenue lors de la mise à jour du statut. "
+            + str(e)
+            + " Le statut n'a pas été modifié.",
         )
         return redirect_to_same_page_or_to_simulation_detail_by_default(
             request, simulation_projet

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -38,7 +38,7 @@ def patch_taux_simulation_projet(request, pk):
     simulation_projet = get_object_or_404(SimulationProjet, id=pk)
     new_taux = replace_comma_by_dot(request.POST.get("taux"))
     DotationProjetService.validate_taux(new_taux)
-    SimulationProjetService.update_taux(simulation_projet, new_taux)
+    SimulationProjetService.update_taux(simulation_projet, new_taux, request.user)
     return redirect_to_same_page_or_to_simulation_detail_by_default(
         request, simulation_projet
     )


### PR DESCRIPTION
## 🌮 Objectif

Mettre à jour le taux et le montant sur DS.
Sachant que :
- on met à jour le taux et/ou le montant si le projet est accepté.
- on les met à jour lorsqu'on accepte un projet
- si une erreur DS survient, on annule la modification des taux/montant si l'on est sur une page **simulation**
- idem si on accepte le projet
- dans la page projet modifiable, lorsqu'on soumet le formulaire avec les 3 champs (assiette, montant, taux), on met à jour sur DS chaque champs ayant changé. Si une erreur DS non bloquante intervient sur un de ces champs, on stocke l'erreur, on continue, puis on l'affiche à l'utilisateur.

## ⚠️ Informations supplémentaires

Il faut savoir qu'on peut avoir des désynchro entre DS et Turgot. Ex: je modifie l'assiette, le taux change => je mets à jour ces 2 champs dans DS. Erreur DS (non bloquante) sur l'assiette, mais pas sur le taux => sur DS, le taux sera bon par rapport à Turgot, mais pas l'assiette
