### PR TITLE
Utilisation de `responses` pour tester le client d'API DS

### DIFF
--- a/gsl_demarches_simplifiees/tests/ds_client/test_ds_client.py
+++ b/gsl_demarches_simplifiees/tests/ds_client/test_ds_client.py
@@ -1,33 +1,34 @@
 import logging
-from unittest.mock import MagicMock, patch
 
 import pytest
+import responses
+from django.conf import settings
 
 from gsl_demarches_simplifiees.ds_client import DsClient
 
 
+@responses.activate
 def test_launch_graphql_query_token_error_logs_and_raises(caplog):
-    error_response = {
-        "errors": [
-            {
-                "message": "Without a token, only persisted queries are allowed",
-                "extensions": {"code": "forbidden"},
-            }
-        ],
-        "data": None,
-    }
-    mock_resp = MagicMock()
-    mock_resp.status_code = 403
-    mock_resp.json.return_value = error_response
-    mock_resp.text = str(error_response)
+    responses.add(
+        responses.GET,
+        settings.DS_API_URL,
+        json={
+            "errors": [
+                {
+                    "message": "Without a token, only persisted queries are allowed",
+                    "extensions": {"code": "forbidden"},
+                }
+            ],
+            "data": None,
+        },
+        status=403,
+    )
 
-    with patch("requests.post", return_value=mock_resp):
-        client = DsClient()
-        with caplog.at_level(logging.CRITICAL):
-            with pytest.raises(Exception) as excinfo:
-                client.launch_graphql_query("someOperation")
-            assert (
-                "Nous n'arrivons pas à nous connecter à Démarches Simplifiées."
-                in str(excinfo.value)
-            )
-            assert "DS forbidden access : token problem ?" in caplog.text
+    client = DsClient()
+    with caplog.at_level(logging.CRITICAL):
+        with pytest.raises(Exception) as excinfo:
+            client.launch_graphql_query("someOperation")
+        assert "Nous n'arrivons pas à nous connecter à Démarches Simplifiées." in str(
+            excinfo.value
+        )
+        assert "DS forbidden access : token problem ?" in caplog.text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
     "pytest-ruff",
     "pytest-xdist",
     "pytest",
+    "responses",
     "ruff",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -299,6 +299,7 @@ pyyaml==6.0.2
     # via
     #   djlint
     #   pre-commit
+    #   responses
 redis==6.4.0
     # via gsl (pyproject.toml)
 regex==2025.9.1
@@ -308,6 +309,9 @@ requests==2.32.5
     #   django-dsfr
     #   gsl (pyproject.toml)
     #   mozilla-django-oidc
+    #   responses
+responses==0.25.8
+    # via gsl (pyproject.toml)
 ruff==0.13.0
     # via
     #   gsl (pyproject.toml)
@@ -363,6 +367,7 @@ urllib3==2.5.0
     # via
     #   botocore
     #   requests
+    #   responses
     #   sentry-sdk
 vine==5.1.0
     # via


### PR DESCRIPTION
## 🌮 Objectif

J'ai un test qui ne passe plus quand je coupe internet, ce qui me laisse penser qu'en réalité il va (tenter de) faire un appel réel à l'API DS.

Je crois que c'est lié à la manière dont on mock l'appel à requests.post. Il me semble judicieux d'utiliser `responses` pour ça. Le test ne passe toujours pas, mais pour une raison différente.

## 🔍 Liste des modifications

- _Liste des modifications_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
