### PR TITLE
Restriction de l'accès /admin par liste blanche d'IPs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ SCALEWAY_S3_SECRET=
 SCALEWAY_BUCKET=
 SCALEWAY_S3_REGION=
 # AWS_S3_ENDPOINT_URL= # optional: default to scaleway endpoint for region
+
+# Comma-separated list of IPs allowed to access /admin (empty = no restriction)
+ADMIN_ALLOWED_IPS=

--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -43,6 +43,12 @@ if ENV not in ("dev", "test", "staging", "prod", "demo"):
 ENV_SEPARATOR = ","
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost").split(ENV_SEPARATOR)
 
+ADMIN_ALLOWED_IPS = [
+    ip.strip()
+    for ip in os.getenv("ADMIN_ALLOWED_IPS", "127.0.0.1").split(",")
+    if ip.strip()
+]
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -82,6 +88,7 @@ MIDDLEWARE = [
     "csp.middleware.CSPMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "gsl_core.middlewares.AdminIPWhitelistMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/gsl_core/middlewares.py
+++ b/gsl_core/middlewares.py
@@ -1,5 +1,25 @@
+from django.conf import settings
+from django.http import HttpResponseForbidden
 from django.shortcuts import redirect
 from django.urls import reverse
+
+
+class AdminIPWhitelistMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path.startswith("/admin/"):
+            ip = self._get_client_ip(request)
+            if ip not in settings.ADMIN_ALLOWED_IPS:
+                return HttpResponseForbidden()
+        return self.get_response(request)
+
+    def _get_client_ip(self, request):
+        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+        if x_forwarded_for:
+            return x_forwarded_for.split(",")[0].strip()
+        return request.META.get("REMOTE_ADDR")
 
 
 class CheckPerimeterMiddleware:

--- a/gsl_core/tests/test_middlewares.py
+++ b/gsl_core/tests/test_middlewares.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.test import RequestFactory
 from django.urls import reverse
 
-from gsl_core.middlewares import CheckPerimeterMiddleware
+from gsl_core.middlewares import AdminIPWhitelistMiddleware, CheckPerimeterMiddleware
 
 
 @pytest.fixture
@@ -83,3 +83,68 @@ def test_authorized_paths_allowed(req, path):
     response = middleware(request)
 
     assert response.status_code == 200
+
+
+# --- AdminIPWhitelistMiddleware tests ---
+
+
+class TestAdminIPWhitelistMiddleware:
+    def test_allowed_ip_passes_through(self, req, settings):
+        settings.ADMIN_ALLOWED_IPS = ["1.2.3.4"]
+        request = req.get("/admin/")
+        request.META["REMOTE_ADDR"] = "1.2.3.4"
+
+        middleware = AdminIPWhitelistMiddleware(get_response)
+        response = middleware(request)
+
+        assert response.status_code == 200
+
+    def test_disallowed_ip_returns_403(self, req, settings):
+        settings.ADMIN_ALLOWED_IPS = ["1.2.3.4"]
+        request = req.get("/admin/")
+        request.META["REMOTE_ADDR"] = "9.9.9.9"
+
+        middleware = AdminIPWhitelistMiddleware(get_response)
+        response = middleware(request)
+
+        assert response.status_code == 403
+
+    def test_non_admin_path_always_passes(self, req, settings):
+        settings.ADMIN_ALLOWED_IPS = ["1.2.3.4"]
+        request = req.get("/projets/")
+        request.META["REMOTE_ADDR"] = "9.9.9.9"
+
+        middleware = AdminIPWhitelistMiddleware(get_response)
+        response = middleware(request)
+
+        assert response.status_code == 200
+
+    def test_empty_whitelist_blocks_all(self, req, settings):
+        settings.ADMIN_ALLOWED_IPS = []
+        request = req.get("/admin/")
+        request.META["REMOTE_ADDR"] = "9.9.9.9"
+
+        middleware = AdminIPWhitelistMiddleware(get_response)
+        response = middleware(request)
+
+        assert response.status_code == 403
+
+    def test_x_forwarded_for_is_used(self, req, settings):
+        settings.ADMIN_ALLOWED_IPS = ["10.0.0.1"]
+        request = req.get("/admin/", HTTP_X_FORWARDED_FOR="10.0.0.1, 192.168.0.1")
+        request.META["REMOTE_ADDR"] = "192.168.0.1"
+
+        middleware = AdminIPWhitelistMiddleware(get_response)
+        response = middleware(request)
+
+        assert response.status_code == 200
+
+    def test_x_forwarded_for_disallowed(self, req, settings):
+        settings.ADMIN_ALLOWED_IPS = ["10.0.0.1"]
+        request = req.get("/admin/", HTTP_X_FORWARDED_FOR="9.9.9.9, 192.168.0.1")
+        request.META["REMOTE_ADDR"] = "10.0.0.1"
+
+        middleware = AdminIPWhitelistMiddleware(get_response)
+        response = middleware(request)
+
+        assert response.status_code == 403


### PR DESCRIPTION
## 🌮 Objectif

Restreindre l'accès à l'interface `/admin/` aux seules adresses IP autorisées, via un middleware dédié.

## 🔍 Liste des modifications

- **gsl_core/middlewares.py** : Ajout de `AdminIPWhitelistMiddleware` — bloque avec une 403 toute requête vers `/admin/` dont l'IP (via `REMOTE_ADDR` ou `X-Forwarded-For`) n'est pas dans la liste blanche
- **gsl/settings.py** : Ajout du setting `ADMIN_ALLOWED_IPS` (liste d'IPs, par défaut `127.0.0.1`) et insertion du middleware dans `MIDDLEWARE`
- **.env.example** : Ajout de la variable `ADMIN_ALLOWED_IPS`
- **gsl_core/tests/test_middlewares.py** : 6 tests couvrant les cas : IP autorisée, IP refusée, chemin non-admin, liste vide, X-Forwarded-For autorisé/refusé

## ⚠️ Informations supplémentaires

- **Variable d'environnement** : `ADMIN_ALLOWED_IPS` — liste d'IPs séparées par des virgules. Si vide, aucun accès n'est autorisé. Par défaut en local : `127.0.0.1`
- À configurer sur chaque environnement (staging, prod, démo) avant déploiement