### PR TITLE
Ajout du workflow de déploiement en production

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,76 @@
+name: Deploy to production
+
+on:
+  push:
+    tags:
+      - 'v[0-9][0-9].[0-9][0-9].[0-9][0-9]*'
+
+permissions:
+  contents: write
+
+jobs:
+  tests:
+    uses: ./.github/workflows/django.yml
+
+  release:
+    needs: tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub release with notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --target main
+
+  deploy:
+    needs: tests
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create source archive
+        run: git archive --format=tar.gz --prefix=source/ -o archive.tar.gz HEAD
+
+      - name: Deploy to Scalingo
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          SCALINGO_API_URL="https://api.osc-secnum-fr1.scalingo.com"
+
+          # 0. Exchange API token for a bearer JWT
+          BEARER_TOKEN=$(curl -sf -X POST \
+            -u ":$SCALINGO_API_TOKEN" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            "https://auth.scalingo.com/v1/tokens/exchange" \
+            | jq -r '.token')
+
+          # 1. Get upload/download URLs from Scalingo Sources API
+          SOURCES_RESPONSE=$(curl -sf -X POST \
+            -H "Authorization: Bearer $BEARER_TOKEN" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            "$SCALINGO_API_URL/v1/sources")
+
+          UPLOAD_URL=$(echo "$SOURCES_RESPONSE" | jq -r '.source.upload_url')
+          DOWNLOAD_URL=$(echo "$SOURCES_RESPONSE" | jq -r '.source.download_url')
+
+          # 2. Upload the archive
+          curl -sf -X PUT \
+            -H "Content-Type: application/x-gzip" \
+            --upload-file archive.tar.gz \
+            "$UPLOAD_URL"
+
+          # 3. Trigger deployment
+          curl -sf -X POST \
+            -H "Authorization: Bearer $BEARER_TOKEN" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -d "{\"deployment\": {\"git_ref\": \"$GITHUB_REF_NAME\", \"source_url\": \"$DOWNLOAD_URL\"}}" \
+            "$SCALINGO_API_URL/v1/apps/gsl-prod/deployments"

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [ "opened", "synchronize", "reopened" ]
   merge_group:
+  workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -99,3 +99,30 @@ Les raccourcis suivants existent :
 - `just shell`
 - `just makemigrations`
 - `just migrate`
+
+## Déploiement en production
+
+Le déploiement en production est automatisé via GitHub Actions.
+
+### Procédure
+
+1. Se placer sur le commit à déployer (pas nécessairement le dernier commit de `main` — on peut remonter de quelques commits pour exclure des changements pas encore testés)
+2. Lancer la commande :
+
+```bash
+just release
+```
+
+Cette commande crée automatiquement un tag au format `vYY.MM.DD` (avec un suffixe incrémental si un tag existe déjà pour la date) et le pousse sur le dépôt distant.
+
+3. Le workflow GitHub Actions se déclenche automatiquement et :
+   - exécute les tests
+   - crée une **Release GitHub** avec les notes auto-générées (liste des PRs depuis le dernier tag)
+   - déploie sur Scalingo via l'API Sources
+
+4. **Confirmer le déploiement côté GitHub** : le job `deploy` utilise l'environnement `production`, qui nécessite une approbation manuelle dans GitHub. Un reviewer autorisé doit approuver le déploiement depuis l'interface GitHub Actions avant que celui-ci ne s'exécute.
+
+### Prérequis
+
+- Le secret `SCALINGO_API_TOKEN` doit être configuré dans l'environnement GitHub `production`
+- L'environnement `production` doit avoir les règles de protection (reviewers requis) configurées dans **Settings > Environments** du dépôt GitHub

--- a/justfile
+++ b/justfile
@@ -35,6 +35,22 @@ test-watching folder_or_file:
     git ls-files | entr -c pytest -vv {{folder_or_file}}
 
 
+# Create a release tag (vYY.MM.DD) and push it to trigger production deployment
+release:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    git fetch --tags
+    BASE_TAG="v$(date +%y.%m.%d)"
+    if ! git tag --list | grep -qx "$BASE_TAG"; then
+        TAG="$BASE_TAG"
+    else
+        LAST=$(git tag --list "${BASE_TAG}.*" | sed "s/${BASE_TAG}\.//" | sort -n | tail -1)
+        TAG="${BASE_TAG}.$((${LAST:-0} + 1))"
+    fi
+    echo "Creating and pushing tag: $TAG"
+    git tag "$TAG"
+    git push origin "$TAG"
+
 # Scalingo: SSH
 scalingo-django-ssh environment:
     scalingo run --app gsl-{{environment}} bash


### PR DESCRIPTION
## 🌮 Objectif

Automatiser le déploiement en production via GitHub Actions, déclenché par un tag de version.

## 🔍 Liste des modifications

- Ajout du workflow `.github/workflows/deploy-prod.yml` qui, au push d'un tag `vYY.MM.DD` sur `main` :
  - exécute les tests
  - crée une Release GitHub avec notes auto-générées
  - déploie sur Scalingo production via l'API Sources
- Le job `deploy` utilise l'environnement GitHub `production`, ce qui nécessite une **approbation manuelle** par un reviewer autorisé avant l'exécution du déploiement
- Ajout de la recette `just release` pour créer et pousser un tag de version automatiquement
- Ajout des instructions de déploiement dans le README

## ⚠️ Informations supplémentaires

- Le secret `SCALINGO_API_TOKEN` doit être configuré dans l'environnement GitHub `production`
- L'environnement `production` doit avoir les règles de protection (reviewers requis) configurées dans **Settings > Environments** du dépôt GitHub