### PR TITLE
Correction de l'exécution des tests en parallèle avec pytest-xdist

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,0 @@
-pytest_plugins = ("celery.contrib.pytest",)

--- a/gsl/settings_test.py
+++ b/gsl/settings_test.py
@@ -9,6 +9,8 @@ GENERATE_DOCUMENT_SIZE = False
 CELERY_TASK_ALWAYS_EAGER = True
 CELERY_TASK_EAGER_PROPAGATES = True
 
+BYPASS_ANTIVIRUS = True
+
 STORAGES = {
     "default": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",

--- a/gsl_demarches_simplifiees/tests/importer/test_dossier_converter.py
+++ b/gsl_demarches_simplifiees/tests/importer/test_dossier_converter.py
@@ -24,11 +24,7 @@ from gsl_demarches_simplifiees.tests.factories import (
     CategorieDetrFactory,
 )
 
-pytestmark = [
-    pytest.mark.django_db,
-    pytest.mark.usefixtures("celery_session_app"),
-    pytest.mark.usefixtures("celery_session_worker"),
-]
+pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture

--- a/gsl_notification/tests/test_antivirus.py
+++ b/gsl_notification/tests/test_antivirus.py
@@ -251,8 +251,9 @@ def test_download_allowed_when_bypass_even_if_never_scanned(
 
 
 @pytest.mark.parametrize("factory", (ArreteEtLettreSignesFactory, AnnexeFactory))
+@patch("gsl_notification.tasks.scan_uploaded_document")
 def test_is_downloadable_false_when_never_scanned(
-    settings, programmation_projet, factory
+    _mock_scan, settings, programmation_projet, factory
 ):
     settings.BYPASS_ANTIVIRUS = False
     doc = factory(programmation_projet=programmation_projet)
@@ -261,7 +262,10 @@ def test_is_downloadable_false_when_never_scanned(
 
 
 @pytest.mark.parametrize("factory", (ArreteEtLettreSignesFactory, AnnexeFactory))
-def test_is_downloadable_false_when_infected(settings, programmation_projet, factory):
+@patch("gsl_notification.tasks.scan_uploaded_document")
+def test_is_downloadable_false_when_infected(
+    _mock_scan, settings, programmation_projet, factory
+):
     settings.BYPASS_ANTIVIRUS = False
     doc = factory(
         programmation_projet=programmation_projet,
@@ -272,8 +276,9 @@ def test_is_downloadable_false_when_infected(settings, programmation_projet, fac
 
 
 @pytest.mark.parametrize("factory", (ArreteEtLettreSignesFactory, AnnexeFactory))
+@patch("gsl_notification.tasks.scan_uploaded_document")
 def test_is_downloadable_true_when_scanned_and_clean(
-    settings, programmation_projet, factory
+    _mock_scan, settings, programmation_projet, factory
 ):
     settings.BYPASS_ANTIVIRUS = False
     doc = factory(


### PR DESCRIPTION
## 🌮 Objectif

Permettre l'exécution des tests en parallèle avec `pytest -n X`

## 🔍 Liste des modifications

- Ajout de `BYPASS_ANTIVIRUS = True` dans `settings_test.py` pour éviter que les signaux `post_save` n'appellent `clamdscan` de manière synchrone pendant les tests
- Suppression du plugin `celery.contrib.pytest` du `conftest.py` racine, qui causait des timeouts de shutdown du worker thread avec xdist et masquait le problème antivirus en remplaçant silencieusement l'app Celery
- Suppression des fixtures `celery_session_app` / `celery_session_worker` inutiles dans `test_dossier_converter`
- Ajout de mock `scan_uploaded_document` dans 3 tests antivirus qui désactivaient `BYPASS_ANTIVIRUS` sans mocker la tâche déclenchée par le signal

## ⚙️ Contexte technique

Les tests passaient en séquentiel grâce à un effet de bord : le plugin `celery.contrib.pytest` créait une `celery_session_app` (activée via `test_dossier_converter.py`) qui remplaçait l'app Celery par une version avec `task_always_eager=False`, empêchant les `.delay()` de s'exécuter. Avec `-n X`, certains workers ne recevaient pas ce fichier de test, donc le mode eager restait actif et `clamdscan` était appelé.

Résultat : 1875/1875 tests passent avec `pytest -n 4` (~47s au lieu de ~96s en séquentiel).