### PR TITLE
Ajout du logger weasyprint et unification du niveau de log des librairies

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -228,7 +228,9 @@ LOGOUT_REDIRECT_URL = "/"
 
 # Logs
 APP_LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO")
-DJANGO_LOGGING_LEVEL = os.getenv("DJANGO_LOGGING_LEVEL", "ERROR")
+LIBRARIES_LOGGING_LEVEL = os.getenv(
+    "LIBRARIES_LOGGING_LEVEL", os.getenv("DJANGO_LOGGING_LEVEL", "ERROR")
+)
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -269,7 +271,7 @@ LOGGING = {
         },
         "django": {
             "handlers": ["console", "sentry"],
-            "level": DJANGO_LOGGING_LEVEL,
+            "level": LIBRARIES_LOGGING_LEVEL,
             "propagate": False,
         },
         "django.server": {
@@ -284,7 +286,7 @@ LOGGING = {
         },
         "celery.worker": {
             "handlers": ["console", "sentry"],
-            "level": DJANGO_LOGGING_LEVEL,
+            "level": LIBRARIES_LOGGING_LEVEL,
             "propagate": False,
         },
         "gunicorn": {
@@ -300,6 +302,11 @@ LOGGING = {
         "pikepdf": {
             "handlers": ["console"],
             "level": "INFO",
+            "propagate": False,
+        },
+        "weasyprint": {
+            "handlers": ["console"],
+            "level": LIBRARIES_LOGGING_LEVEL,
             "propagate": False,
         },
     },


### PR DESCRIPTION
## 🌮 Objectif

Réduire le bruit dans Sentry causé par les erreurs WeasyPrint non-critiques (ancres internes manquantes issues de contenus LibreOffice collés dans l'éditeur TipTap).

Fix GESTION-SUBVENTIONS-LOCALES-3X3 (450 événements)

## 🔍 Liste des modifications

- Ajout d'un logger `weasyprint` dans la configuration de logging
- Remplacement de `DJANGO_LOGGING_LEVEL` par `LIBRARIES_LOGGING_LEVEL`, appliqué uniformément à `django`, `celery.worker` et `weasyprint`
- Rétrocompatibilité conservée : `LIBRARIES_LOGGING_LEVEL` utilise `DJANGO_LOGGING_LEVEL` comme fallback

## ⚠️ Informations supplémentaires

Aucune variable d'environnement à modifier en production : le comportement par défaut reste identique (niveau `ERROR`).