### PR TITLE
Ne pas re-basculer un projet sur une enveloppe plus récente lors d'une mise à jour de dossier

### DIFF
--- a/gsl_projet/services/dotation_projet_services.py
+++ b/gsl_projet/services/dotation_projet_services.py
@@ -277,7 +277,12 @@ class DotationProjetService:
         if detr_avis_commission is not None:  # we only update if we have an info
             dotation_projet.detr_avis_commission = detr_avis_commission
 
-        enveloppe = cls._get_root_enveloppe_from_dotation_projet(dotation_projet)
+        if hasattr(
+            dotation_projet, "programmation_projet"
+        ):  # We keep previous enveloppe to avoid squashing manuel rectification (ex: enveloppe 2025)
+            enveloppe = dotation_projet.programmation_projet.enveloppe
+        else:
+            enveloppe = cls._get_root_enveloppe_from_dotation_projet(dotation_projet)
         montant = cls._get_montant_from_dossier(projet.dossier_ds, dotation)
         dotation_projet.accept_without_ds_update(montant=montant, enveloppe=enveloppe)
         dotation_projet.save()

--- a/gsl_projet/tests/services/dotation_projet/test_dotation_projet_services.py
+++ b/gsl_projet/tests/services/dotation_projet/test_dotation_projet_services.py
@@ -1243,3 +1243,39 @@ def test_update_accepted_dotation_projets_montant_from_dn_does_not_update_montan
     assert not ProgrammationProjet.objects.filter(
         dotation_projet=dotation_projet
     ).exists()
+
+
+# -- _accept_dotation_projet --
+
+
+@pytest.mark.django_db
+def test_accept_dotation_projet_conserve_enveloppe_existante(perimetres):
+    """
+    Lors de la mise à jour d'un dossier accepté, si le dotation_projet est déjà programmé
+    sur une enveloppe 2025, il ne doit pas être re-basculé sur l'enveloppe 2026.
+    """
+    arr_dijon, dep_21, *_ = perimetres
+    enveloppe_2025 = DetrEnveloppeFactory(perimetre=dep_21, annee=2025)
+    DetrEnveloppeFactory(perimetre=dep_21, annee=2026)
+
+    dotation_projet = DotationProjetFactory(
+        dotation=DOTATION_DETR,
+        status=PROJET_STATUS_ACCEPTED,
+        projet__dossier_ds__perimetre=arr_dijon,
+        projet__dossier_ds__ds_state=Dossier.STATE_ACCEPTE,
+        projet__dossier_ds__ds_date_traitement=datetime.datetime(
+            2026, 3, 1, tzinfo=UTC
+        ),
+        projet__dossier_ds__annotations_dotation=DOTATION_DETR,
+        projet__dossier_ds__annotations_montant_accorde_detr=5_000,
+    )
+    ProgrammationProjetFactory(
+        dotation_projet=dotation_projet,
+        enveloppe=enveloppe_2025,
+        montant=4_000,
+    )
+
+    dps._accept_dotation_projet(dotation_projet.projet, DOTATION_DETR)
+
+    dotation_projet.refresh_from_db()
+    assert dotation_projet.programmation_projet.enveloppe == enveloppe_2025


### PR DESCRIPTION
## 🌮 Objectif

Empêcher que la mise à jour d'un dossier accepté sur Turgot re-bascule un projet vers une enveloppe plus récente (ex. 2026) lorsqu'il a déjà été programmé sur une enveloppe antérieure (ex. 2025).

## 🔍 Liste des modifications

- `gsl_projet/services/dotation_projet_services.py` : dans `_accept_dotation_projet`, si le `dotation_projet` possède déjà une `programmation_projet`, on conserve son enveloppe existante plutôt que de recalculer une enveloppe à partir de `ds_date_traitement`

## ⚠️ Informations supplémentaires

Avant ce correctif, `_get_root_enveloppe_from_dotation_projet` calculait l'enveloppe à partir de `ds_date_traitement` : un dossier traité en 2026 renvoyait systématiquement l'enveloppe 2026, écrasant une programmation existante sur 2025.
