### PR TITLE
Validation de l'assiette avant acceptation d'une dotation

### DIFF
--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from dsfr.forms import DsfrBaseForm
 
 from gsl_core.models import Collegue
+from gsl_core.templatetags.gsl_filters import euro
 from gsl_demarches_simplifiees.ds_client import DsMutator
 from gsl_demarches_simplifiees.models import Dossier
 from gsl_demarches_simplifiees.services import DsService
@@ -225,26 +226,48 @@ class SimulationProjetStatusForm(DsfrBaseForm, forms.ModelForm):
     processing dotation).
     """
 
+    def __init__(self, *args, status=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.status = status
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if self.status == SimulationProjet.STATUS_ACCEPTED:
+            errors = []
+            dotation_projet = self.instance.dotation_projet
+            assiette = dotation_projet.assiette
+            montant = self.instance.montant
+            if assiette is None:
+                errors.append("L'assiette subventionnable est manquante.")
+            elif montant is not None and assiette < montant:
+                errors.append(
+                    f"L'assiette subventionnable ({euro(assiette)}) est "
+                    f"inférieure au montant accordé ({euro(montant)})."
+                )
+            if errors:
+                raise ValidationError(errors)
+        return cleaned_data
+
     @transaction.atomic
-    def save(self, status, user: Collegue, commit=True):
-        if status == SimulationProjet.STATUS_ACCEPTED:
+    def save(self, user: Collegue, commit=True):
+        if self.status == SimulationProjet.STATUS_ACCEPTED:
             self.instance.dotation_projet.accept(
                 montant=self.instance.montant,
                 enveloppe=self.instance.enveloppe,
                 user=user,
             )
-        elif status == SimulationProjet.STATUS_REFUSED:
+        elif self.status == SimulationProjet.STATUS_REFUSED:
             self.instance.dotation_projet.refuse(enveloppe=self.instance.enveloppe)
-        elif status == SimulationProjet.STATUS_DISMISSED:
+        elif self.status == SimulationProjet.STATUS_DISMISSED:
             self.instance.dotation_projet.dismiss(enveloppe=self.instance.enveloppe)
         elif (
-            status in SimulationProjet.SIMULATION_PENDING_STATUSES
+            self.status in SimulationProjet.SIMULATION_PENDING_STATUSES
             and self.instance.status not in SimulationProjet.SIMULATION_PENDING_STATUSES
         ):
             self.instance.dotation_projet.set_back_status_to_processing(user)
 
         self.instance.dotation_projet.save()
-        self.instance.status = status
+        self.instance.status = self.status
         self.instance.save()
 
         return self.instance
@@ -268,8 +291,8 @@ class RefuseProjetForm(SimulationProjetStatusForm):
     )
 
     @transaction.atomic
-    def save(self, status, user: Collegue):
-        super().save(status, user)
+    def save(self, user: Collegue):
+        super().save(user)
 
         # Dossier was recently refreshed DN thanks to RefuseProjetModalView.
         # Race conditions remain possible, but should be rare enough and just fail without any side effect.
@@ -304,8 +327,8 @@ class DismissProjetForm(SimulationProjetStatusForm):
     )
 
     @transaction.atomic
-    def save(self, status, user: Collegue):
-        super().save(status, user)
+    def save(self, user: Collegue):
+        super().save(user)
         # Dossier was recently refreshed DN thanks to DismissProjetModalView.
         # Race conditions remain possible, but should be rare enough and just fail without any side effect.
         if self.instance.dossier.ds_state == Dossier.STATE_EN_CONSTRUCTION:

--- a/gsl_simulation/templates/htmx/_base_htmx_modal.html
+++ b/gsl_simulation/templates/htmx/_base_htmx_modal.html
@@ -47,25 +47,27 @@ If POST, the modal is already opened and the form is being sent:
                         </div>
 
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                <li>
-                                    {% block confirmation_button %}
-                                        <button type="submit"
-                                                class="fr-btn fr-btn--primary"
-                                                form="{{ modal_id }}-form">
-                                            Confirmer
-                                        </button>
+                            {% block footer %}
+                                <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                    <li>
+                                        {% block confirmation_button %}
+                                            <button type="submit"
+                                                    class="fr-btn fr-btn--primary"
+                                                    form="{{ modal_id }}-form">
+                                                Confirmer
+                                            </button>
 
-                                    {% endblock confirmation_button %}
-                                </li>
-                                <li>
-                                    <button class="fr-btn fr-btn--secondary"
-                                            aria-controls="{{ modal_id }}"
-                                            id="{{ modal_id }}-cancel-button">
-                                        Annuler
-                                    </button>
-                                </li>
-                            </ul>
+                                        {% endblock confirmation_button %}
+                                    </li>
+                                    <li>
+                                        <button class="fr-btn fr-btn--secondary"
+                                                aria-controls="{{ modal_id }}"
+                                                id="{{ modal_id }}-cancel-button">
+                                            Annuler
+                                        </button>
+                                    </li>
+                                </ul>
+                            {% endblock footer %}
                         </div>
                     </div>
                 </div>

--- a/gsl_simulation/templates/htmx/acceptance_errors_modal.html
+++ b/gsl_simulation/templates/htmx/acceptance_errors_modal.html
@@ -1,0 +1,43 @@
+{% extends "htmx/_base_htmx_modal.html" %}
+
+{% block button_label %}
+    Impossible d'accepter
+{% endblock button_label %}
+
+{% block content %}
+    <h1 class="fr-modal__title fr-text-default--error"
+        id="{{ modal_id }}-title">
+        <span class="fr-icon-error-fill fr-icon--lg" aria-hidden="true"></span>
+        Impossible d'accepter cette demande
+    </h1>
+    <p>
+        Vous ne pouvez pas accepter cette dotation pour ce projet.
+    </p>
+    <div class="fr-alert fr-alert--error fr-alert--sm fr-mt-4w">
+        {% if acceptance_errors|length == 1 %}
+            <p>
+                {{ acceptance_errors.0 }}
+            </p>
+        {% else %}
+            <ul>
+                {% for error in acceptance_errors %}
+                    <li>
+                        {{ error }}
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </div>
+{% endblock content %}
+
+{% block footer %}
+    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
+        <li>
+            <button class="fr-btn fr-btn--primary"
+                    aria-controls="{{ modal_id }}"
+                    id="{{ modal_id }}-cancel-button">
+                OK
+            </button>
+        </li>
+    </ul>
+{% endblock footer %}

--- a/gsl_simulation/templates/htmx/notify_later_confirmation_modal.html
+++ b/gsl_simulation/templates/htmx/notify_later_confirmation_modal.html
@@ -12,46 +12,33 @@
               aria-hidden="true"></span>
         {{ new_simulation_status|status_to_action_word|capfirst }} la demande {{ object.enveloppe.dotation }}
     </h1>
-    {% if object.dotation_projet.assiette or new_simulation_status != "valid" %}
-        <p>
-            Ces changements vont être pris en compte dans toutes les simulations dans lesquelles le projet a été ajouté.
-            Il apparaîtra dans la programmation officielle {{ object.enveloppe.dotation }} {{ object.enveloppe.annee }}.
-        </p>
-        <p>
-            {% if simulation_projet.dotation_projet.other_dotations|length > 0 and new_simulation_status != "valid" %}
-                Le demandeur ne va pas être notifié tout de suite car le projet est en double dotation.
-            {% else %}
-                Le demandeur ne va pas être notifié tout de suite.
-            {% endif %}
-        </p>
-        <p>
-            Voulez-vous {{ new_simulation_status|status_to_action_word }} cette demande de dotation&nbsp;?
-        </p>
-        <form id="{{ modal_id }}-form"
-              hx-post="{{ request.path }}"
-              hx-encoding="multipart/form-data"
-              hx-target="#{{ modal_id }}"
-              hx-swap="outerHTML"
-              hx-disabled-elt="#{{ modal_id }}-submit-button, #{{ modal_id }}-cancel-button">
-            {{ form }}
-        </form>
-    {% else %}
-        <div class="fr-alert fr-alert--error fr-alert--sm fr-mt-6w">
-            <p class="fr-alert__title">
-                Impossible d'accepter le projet
-            </p>
-            <p>
-                Le projet ne peut pas être accepté car il manque l'assiette subventionnable.
-                Veuillez ajouter le montant des dépenses éligibles retenues avant d'accepter un projet.
-            </p>
-        </div>
-    {% endif %}
+    <p>
+        Ces changements vont être pris en compte dans toutes les simulations dans lesquelles le projet a été ajouté.
+        Il apparaîtra dans la programmation officielle {{ object.enveloppe.dotation }} {{ object.enveloppe.annee }}.
+    </p>
+    <p>
+        {% if simulation_projet.dotation_projet.other_dotations|length > 0 and new_simulation_status != "valid" %}
+            Le demandeur ne va pas être notifié tout de suite car le projet est en double dotation.
+        {% else %}
+            Le demandeur ne va pas être notifié tout de suite.
+        {% endif %}
+    </p>
+    <p>
+        Voulez-vous {{ new_simulation_status|status_to_action_word }} cette demande de dotation&nbsp;?
+    </p>
+    <form id="{{ modal_id }}-form"
+          hx-post="{{ request.path }}"
+          hx-encoding="multipart/form-data"
+          hx-target="#{{ modal_id }}"
+          hx-swap="outerHTML"
+          hx-disabled-elt="#{{ modal_id }}-submit-button, #{{ modal_id }}-cancel-button">
+        {{ form }}
+    </form>
 {% endblock content %}
 
 {% block confirmation_button %}
     <button type="submit"
             class="fr-btn fr-btn--primary"
-            {% if not object.dotation_projet.assiette and new_simulation_status == "valid" %}disabled="disabled"{% endif %}
             form="{{ modal_id }}-form"
             id="{{ modal_id }}-submit-button">
         {{ new_simulation_status|status_to_action_word|capfirst }}

--- a/gsl_simulation/tests/forms/test_double_dotation_status_forms.py
+++ b/gsl_simulation/tests/forms/test_double_dotation_status_forms.py
@@ -91,8 +91,10 @@ class TestRefuseOneDoubleDotation:
         )
 
         # Use SimulationProjetStatusForm (not RefuseProjetForm) since DSIL is still processing
-        form = SimulationProjetStatusForm(instance=detr_simulation_projet)
-        form.save(SimulationProjet.STATUS_REFUSED, user)
+        form = SimulationProjetStatusForm(
+            instance=detr_simulation_projet, status=SimulationProjet.STATUS_REFUSED
+        )
+        form.save(user)
 
         # Verify statuses
         detr_dotation.refresh_from_db()
@@ -138,9 +140,10 @@ class TestRefuseOneDoubleDotation:
             form = RefuseProjetForm(
                 data={"justification": "Budget insuffisant"},
                 instance=detr_simulation_projet,
+                status=SimulationProjet.STATUS_REFUSED,
             )
             assert form.is_valid()
-            form.save(SimulationProjet.STATUS_REFUSED, user)
+            form.save(user)
 
             # Verify DN was called (because all dotations are now refused)
             mock_ds_refuser.assert_called_once()
@@ -181,8 +184,10 @@ class TestRefuseOneDoubleDotation:
         )
 
         # Use SimulationProjetStatusForm since DSIL is accepted
-        form = SimulationProjetStatusForm(instance=detr_simulation_projet)
-        form.save(SimulationProjet.STATUS_REFUSED, user)
+        form = SimulationProjetStatusForm(
+            instance=detr_simulation_projet, status=SimulationProjet.STATUS_REFUSED
+        )
+        form.save(user)
 
         # Verify statuses
         detr_dotation.refresh_from_db()
@@ -220,8 +225,10 @@ class TestDismissOneDoubleDotation:
         )
 
         # Use SimulationProjetStatusForm (not DismissProjetForm) since DETR is still processing
-        form = SimulationProjetStatusForm(instance=dsil_simulation_projet)
-        form.save(SimulationProjet.STATUS_DISMISSED, user)
+        form = SimulationProjetStatusForm(
+            instance=dsil_simulation_projet, status=SimulationProjet.STATUS_DISMISSED
+        )
+        form.save(user)
 
         # Verify statuses
         detr_dotation.refresh_from_db()
@@ -268,9 +275,10 @@ class TestDismissOneDoubleDotation:
             form = DismissProjetForm(
                 data={"justification": "Projet abandonné"},
                 instance=dsil_simulation_projet,
+                status=SimulationProjet.STATUS_DISMISSED,
             )
             assert form.is_valid()
-            form.save(SimulationProjet.STATUS_DISMISSED, user)
+            form.save(user)
 
             # Verify DN was called (because all dotations are now dismissed)
             mock_ds_dismiss.assert_called_once()
@@ -320,9 +328,10 @@ class TestDismissOneDoubleDotation:
             form = DismissProjetForm(
                 data={"justification": "Projet abandonné"},
                 instance=dsil_simulation_projet,
+                status=SimulationProjet.STATUS_DISMISSED,
             )
             assert form.is_valid()
-            form.save(SimulationProjet.STATUS_DISMISSED, user)
+            form.save(user)
 
             # Verify DN was called (dismissed takes precedence over refused)
             mock_ds_dismiss.assert_called_once()
@@ -361,8 +370,10 @@ class TestAcceptOneDoubleDotation:
             montant=5_000,
         )
 
-        form = SimulationProjetStatusForm(instance=detr_simulation_projet)
-        form.save(SimulationProjet.STATUS_ACCEPTED, user)
+        form = SimulationProjetStatusForm(
+            instance=detr_simulation_projet, status=SimulationProjet.STATUS_ACCEPTED
+        )
+        form.save(user)
 
         # Verify DN update was called for DETR
         mock_ds_update.assert_called_once_with(
@@ -423,15 +434,19 @@ class TestAcceptOneDoubleDotation:
         )
 
         # Accept DETR first
-        form_detr = SimulationProjetStatusForm(instance=detr_simulation_projet)
-        form_detr.save(SimulationProjet.STATUS_ACCEPTED, user)
+        form_detr = SimulationProjetStatusForm(
+            instance=detr_simulation_projet, status=SimulationProjet.STATUS_ACCEPTED
+        )
+        form_detr.save(user)
 
         projet.refresh_from_db()
         assert projet.status == PROJET_STATUS_PROCESSING
 
         # Accept DSIL second
-        form_dsil = SimulationProjetStatusForm(instance=dsil_simulation_projet)
-        form_dsil.save(SimulationProjet.STATUS_ACCEPTED, user)
+        form_dsil = SimulationProjetStatusForm(
+            instance=dsil_simulation_projet, status=SimulationProjet.STATUS_ACCEPTED
+        )
+        form_dsil.save(user)
 
         # Verify both DN updates were called
         assert mock_ds_update.call_count == 2
@@ -478,8 +493,10 @@ class TestAcceptOneDoubleDotation:
             montant=5_000,
         )
 
-        form = SimulationProjetStatusForm(instance=detr_simulation_projet)
-        form.save(SimulationProjet.STATUS_ACCEPTED, user)
+        form = SimulationProjetStatusForm(
+            instance=detr_simulation_projet, status=SimulationProjet.STATUS_ACCEPTED
+        )
+        form.save(user)
 
         # Verify statuses - projet is ACCEPTED (optimistic)
         detr_dotation.refresh_from_db()
@@ -512,8 +529,10 @@ class TestNotificationBehaviorWithDoubleDotation:
         )
 
         # Use SimulationProjetStatusForm (doesn't notify)
-        form = SimulationProjetStatusForm(instance=detr_simulation_projet)
-        form.save(SimulationProjet.STATUS_REFUSED, user)
+        form = SimulationProjetStatusForm(
+            instance=detr_simulation_projet, status=SimulationProjet.STATUS_REFUSED
+        )
+        form.save(user)
 
         projet.refresh_from_db()
         assert projet.notified_at is None
@@ -542,9 +561,10 @@ class TestNotificationBehaviorWithDoubleDotation:
             form = RefuseProjetForm(
                 data={"justification": "Budget insuffisant"},
                 instance=detr_simulation_projet,
+                status=SimulationProjet.STATUS_REFUSED,
             )
             form.is_valid()
-            form.save(SimulationProjet.STATUS_REFUSED, user)
+            form.save(user)
 
         projet.refresh_from_db()
         assert projet.notified_at is not None
@@ -579,9 +599,10 @@ class TestNotificationBehaviorWithDoubleDotation:
             form = DismissProjetForm(
                 data={"justification": "Projet abandonné"},
                 instance=dsil_simulation_projet,
+                status=SimulationProjet.STATUS_DISMISSED,
             )
             form.is_valid()
-            form.save(SimulationProjet.STATUS_DISMISSED, user)
+            form.save(user)
 
         # Verify only DSIL programmation_projet is notified (not DETR)
         detr_prog.refresh_from_db()
@@ -608,8 +629,10 @@ class TestNotificationBehaviorWithDoubleDotation:
             status=SimulationProjet.STATUS_PROCESSING,
             montant=5_000,
         )
-        form_detr = SimulationProjetStatusForm(instance=detr_simulation_projet)
-        form_detr.save(SimulationProjet.STATUS_REFUSED, user)
+        form_detr = SimulationProjetStatusForm(
+            instance=detr_simulation_projet, status=SimulationProjet.STATUS_REFUSED
+        )
+        form_detr.save(user)
 
         dsil_enveloppe = DsilEnveloppeFactory(perimetre=projet.perimetre)
         dsil_simulation = SimulationFactory(enveloppe=dsil_enveloppe)
@@ -624,9 +647,10 @@ class TestNotificationBehaviorWithDoubleDotation:
             form_dsil = RefuseProjetForm(
                 data={"justification": "Budget insuffisant"},
                 instance=dsil_simulation_projet,
+                status=SimulationProjet.STATUS_REFUSED,
             )
             form_dsil.is_valid()
-            form_dsil.save(SimulationProjet.STATUS_REFUSED, user)
+            form_dsil.save(user)
 
         # Refresh to see refused statuses
         detr_dotation.refresh_from_db()
@@ -657,8 +681,11 @@ class TestNotificationBehaviorWithDoubleDotation:
             with mock.patch(
                 "gsl_demarches_simplifiees.services.DsService.repasser_en_instruction"
             ):
-                form_back = SimulationProjetStatusForm(instance=detr_simulation_projet)
-                form_back.save(SimulationProjet.STATUS_PROCESSING, user)
+                form_back = SimulationProjetStatusForm(
+                    instance=detr_simulation_projet,
+                    status=SimulationProjet.STATUS_PROCESSING,
+                )
+                form_back.save(user)
 
         # DETR programmation should be removed, DSIL should remain
         assert not ProgrammationProjet.objects.filter(

--- a/gsl_simulation/tests/forms/test_projet_status_forms.py
+++ b/gsl_simulation/tests/forms/test_projet_status_forms.py
@@ -75,11 +75,13 @@ def test_simulation_projet_transition_are_called(
                 args["montant"] = simulation_projet.montant
 
             form = form_class(
-                data={"justification": "justification"}, instance=simulation_projet
+                data={"justification": "justification"},
+                instance=simulation_projet,
+                status=simulation_projet_status,
             )
             form.is_valid()
             user = CollegueFactory()
-            form.save(simulation_projet_status, user)
+            form.save(user)
             mock_transition_dotation_projet.assert_called_once_with(**args, **kwargs)
 
             args = {}
@@ -108,8 +110,8 @@ def test_update_status_with_accepted(mock_ds_update, user):
     )
     new_status = SimulationProjet.STATUS_ACCEPTED
 
-    form = SimulationProjetStatusForm(instance=simulation_projet)
-    form.save(new_status, user)
+    form = SimulationProjetStatusForm(instance=simulation_projet, status=new_status)
+    form.save(user)
 
     mock_ds_update.assert_called_once_with(
         dossier=simulation_projet.projet.dossier_ds,
@@ -139,8 +141,8 @@ def test_update_status_with_processing_from_accepted_or_refused_or_dismissed(
     with mock.patch(
         "gsl_projet.models.DotationProjet.set_back_status_to_processing"
     ) as mock_set_back_a_simulation_projet_to_processing:
-        form = SimulationProjetStatusForm(instance=simulation_projet)
-        form.save(new_status, user)
+        form = SimulationProjetStatusForm(instance=simulation_projet, status=new_status)
+        form.save(user)
 
         mock_set_back_a_simulation_projet_to_processing.assert_called_once()
 
@@ -151,8 +153,8 @@ def test_update_status_with_processing(user):
     )
     new_status = SimulationProjet.STATUS_PROCESSING
 
-    form = SimulationProjetStatusForm(instance=simulation_projet)
-    form.save(new_status, user)
+    form = SimulationProjetStatusForm(instance=simulation_projet, status=new_status)
+    form.save(user)
 
     simulation_projet.refresh_from_db()
     assert simulation_projet.status == new_status
@@ -205,8 +207,8 @@ def test_update_status_with_provisionally_accepted_from_refused_or_accepted_or_d
     with mock.patch(
         "gsl_demarches_simplifiees.services.DsService.update_ds_annotations_for_one_dotation"
     ) as mock_ds_update:
-        form = SimulationProjetStatusForm(instance=simulation_projet)
-        form.save(new_status, user)
+        form = SimulationProjetStatusForm(instance=simulation_projet, status=new_status)
+        form.save(user)
 
         mock_ds_update.assert_called_once_with(
             dossier=simulation_projet.projet.dossier_ds,
@@ -246,8 +248,11 @@ def test_update_status_with_provisionally_accepted_remove_programmation_projet_f
     with mock.patch(
         "gsl_demarches_simplifiees.services.DsService.update_ds_annotations_for_one_dotation"
     ) as mock_ds_update:
-        form = SimulationProjetStatusForm(instance=simulation_projet)
-        form.save(SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED, user)
+        form = SimulationProjetStatusForm(
+            instance=simulation_projet,
+            status=SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED,
+        )
+        form.save(user)
         mock_ds_update.assert_called_once_with(
             dossier=simulation_projet.projet.dossier_ds,
             user=user,
@@ -281,8 +286,8 @@ def test_accept_a_simulation_projet_has_created_a_programmation_projet_with_moth
     )
     new_status = SimulationProjet.STATUS_ACCEPTED
 
-    form = SimulationProjetStatusForm(instance=simulation_projet)
-    form.save(new_status, user)
+    form = SimulationProjetStatusForm(instance=simulation_projet, status=new_status)
+    form.save(user)
 
     mock_ds_update.assert_called_once_with(
         dossier=simulation_projet.projet.dossier_ds,
@@ -344,8 +349,10 @@ def test_accept_a_simulation_projet_has_updated_a_programmation_projet_with_moth
     )
     assert programmation_projets_qs.count() == 1
 
-    form = SimulationProjetStatusForm(instance=simulation_projet)
-    form.save(new_projet_status, user)
+    form = SimulationProjetStatusForm(
+        instance=simulation_projet, status=new_projet_status
+    )
+    form.save(user)
 
     if new_projet_status == SimulationProjet.STATUS_ACCEPTED:
         mock_ds_update.assert_called_once_with(

--- a/gsl_simulation/tests/views/test_acceptance_validation.py
+++ b/gsl_simulation/tests/views/test_acceptance_validation.py
@@ -1,0 +1,257 @@
+"""
+Tests for the acceptance validation modal.
+
+When opening the acceptance modal from either the simulation detail page
+or the project detail page, the view must validate that:
+- DotationProjet.assiette is set
+- DotationProjet.assiette >= SimulationProjet.montant
+
+Otherwise a dedicated error modal is rendered with the detailed reasons.
+"""
+
+from unittest import mock
+
+import pytest
+from django.urls import reverse
+
+from gsl_core.tests.factories import (
+    ClientWithLoggedUserFactory,
+    CollegueWithDSProfileFactory,
+    PerimetreDepartementalFactory,
+)
+from gsl_programmation.tests.factories import DetrEnveloppeFactory
+from gsl_projet.constants import (
+    DOTATION_DETR,
+    DOTATION_DSIL,
+    PROJET_STATUS_PROCESSING,
+)
+from gsl_projet.tests.factories import DotationProjetFactory, ProjetFactory
+from gsl_simulation.forms import SimulationProjetStatusForm
+from gsl_simulation.models import SimulationProjet
+from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def mock_save_dossier():
+    with mock.patch(
+        "gsl_simulation.views.simulation_projet_views.save_one_dossier_from_ds"
+    ):
+        yield
+
+
+@pytest.fixture
+def perimetre():
+    return PerimetreDepartementalFactory()
+
+
+@pytest.fixture
+def collegue(perimetre):
+    return CollegueWithDSProfileFactory(perimetre=perimetre)
+
+
+@pytest.fixture
+def client_with_user_logged(collegue):
+    return ClientWithLoggedUserFactory(collegue)
+
+
+@pytest.fixture
+def detr_enveloppe(perimetre):
+    return DetrEnveloppeFactory(perimetre=perimetre, annee=2025, montant=1_000_000)
+
+
+@pytest.fixture
+def simulation(detr_enveloppe):
+    return SimulationFactory(enveloppe=detr_enveloppe)
+
+
+def _make_simulation_projet(collegue, simulation, *, assiette, montant):
+    dotation_projet = DotationProjetFactory(
+        status=PROJET_STATUS_PROCESSING,
+        projet__dossier_ds__perimetre=collegue.perimetre,
+        dotation=DOTATION_DETR,
+        assiette=assiette,
+    )
+    dotation_projet.projet.dossier_ds.ds_instructeurs.add(collegue.ds_profile)
+    return SimulationProjetFactory(
+        dotation_projet=dotation_projet,
+        status=SimulationProjet.STATUS_PROCESSING,
+        montant=montant,
+        simulation=simulation,
+    )
+
+
+def _accept_url(simulation_projet):
+    return reverse(
+        "simulation:simulation-projet-update-programmed-status",
+        args=[simulation_projet.id, SimulationProjet.STATUS_ACCEPTED],
+    )
+
+
+# --- Form-level unit tests ---------------------------------------------------
+
+
+class TestSimulationProjetStatusFormClean:
+    def test_valid_when_assiette_is_greater_than_or_equal_to_montant(
+        self, collegue, simulation
+    ):
+        simulation_projet = _make_simulation_projet(
+            collegue, simulation, assiette=10_000, montant=5_000
+        )
+        form = SimulationProjetStatusForm(
+            data={},
+            instance=simulation_projet,
+            status=SimulationProjet.STATUS_ACCEPTED,
+        )
+        assert form.is_valid(), form.errors
+
+    def test_invalid_when_assiette_is_missing(self, collegue, simulation):
+        simulation_projet = _make_simulation_projet(
+            collegue, simulation, assiette=None, montant=5_000
+        )
+        form = SimulationProjetStatusForm(
+            data={},
+            instance=simulation_projet,
+            status=SimulationProjet.STATUS_ACCEPTED,
+        )
+        assert not form.is_valid()
+        errors = form.non_field_errors()
+        assert len(errors) == 1
+        assert "assiette subventionnable est manquante" in errors[0].lower()
+
+    def test_invalid_when_assiette_is_lower_than_montant(self, collegue, simulation):
+        simulation_projet = _make_simulation_projet(
+            collegue, simulation, assiette=3_000, montant=5_000
+        )
+        form = SimulationProjetStatusForm(
+            data={},
+            instance=simulation_projet,
+            status=SimulationProjet.STATUS_ACCEPTED,
+        )
+        assert not form.is_valid()
+        errors = form.non_field_errors()
+        assert len(errors) == 1
+        assert "inférieure au montant accordé" in errors[0]
+
+    def test_no_validation_when_status_is_not_accepted(self, collegue, simulation):
+        simulation_projet = _make_simulation_projet(
+            collegue, simulation, assiette=None, montant=5_000
+        )
+        form = SimulationProjetStatusForm(
+            data={},
+            instance=simulation_projet,
+            status=SimulationProjet.STATUS_REFUSED,
+        )
+        assert form.is_valid(), form.errors
+
+
+# --- View integration tests -------------------------------------------------
+
+
+class TestAcceptanceModalView:
+    def test_get_renders_standard_modal_when_assiette_is_sufficient(
+        self, client_with_user_logged, collegue, simulation
+    ):
+        simulation_projet = _make_simulation_projet(
+            collegue, simulation, assiette=10_000, montant=5_000
+        )
+        response = client_with_user_logged.get(
+            _accept_url(simulation_projet), headers={"HX-Request": "true"}
+        )
+        assert response.status_code == 200
+        assert "htmx/notify_later_confirmation_modal.html" in [
+            t.name for t in response.templates if t.name
+        ]
+
+    def test_get_renders_error_modal_when_assiette_is_missing(
+        self, client_with_user_logged, collegue, simulation
+    ):
+        simulation_projet = _make_simulation_projet(
+            collegue, simulation, assiette=None, montant=5_000
+        )
+        response = client_with_user_logged.get(
+            _accept_url(simulation_projet), headers={"HX-Request": "true"}
+        )
+        assert response.status_code == 200
+        assert "htmx/acceptance_errors_modal.html" in [
+            t.name for t in response.templates if t.name
+        ]
+        content = response.content.decode()
+        assert "Vous ne pouvez pas accepter cette dotation pour ce projet." in content
+        assert "assiette subventionnable est manquante" in content.lower()
+
+    def test_get_renders_error_modal_when_assiette_is_lower_than_montant(
+        self, client_with_user_logged, collegue, simulation
+    ):
+        simulation_projet = _make_simulation_projet(
+            collegue, simulation, assiette=3_000, montant=5_000
+        )
+        response = client_with_user_logged.get(
+            _accept_url(simulation_projet), headers={"HX-Request": "true"}
+        )
+        assert response.status_code == 200
+        assert "htmx/acceptance_errors_modal.html" in [
+            t.name for t in response.templates if t.name
+        ]
+        content = response.content.decode()
+        assert "inférieure au montant accordé" in content
+
+    def test_get_renders_error_modal_for_double_dotation_projet(
+        self, client_with_user_logged, collegue, simulation
+    ):
+        """
+        Regression: on a DETR+DSIL projet whose DSIL is still PROCESSING, the
+        combined projet status is PROCESSING, so the GET-time validation must
+        be gated on the requested simulation status (not the combined projet
+        status) to still catch assiette < montant on the DETR acceptance.
+        """
+        projet = ProjetFactory(dossier_ds__perimetre=collegue.perimetre)
+        projet.dossier_ds.ds_instructeurs.add(collegue.ds_profile)
+        detr_dotation = DotationProjetFactory(
+            projet=projet,
+            dotation=DOTATION_DETR,
+            status=PROJET_STATUS_PROCESSING,
+            assiette=3_000,
+        )
+        DotationProjetFactory(
+            projet=projet,
+            dotation=DOTATION_DSIL,
+            status=PROJET_STATUS_PROCESSING,
+            assiette=15_000,
+        )
+        simulation_projet = SimulationProjetFactory(
+            dotation_projet=detr_dotation,
+            status=SimulationProjet.STATUS_PROCESSING,
+            montant=5_000,
+            simulation=simulation,
+        )
+
+        response = client_with_user_logged.get(
+            _accept_url(simulation_projet), headers={"HX-Request": "true"}
+        )
+
+        assert response.status_code == 200
+        assert "htmx/acceptance_errors_modal.html" in [
+            t.name for t in response.templates if t.name
+        ]
+        assert "inférieure au montant accordé" in response.content.decode()
+
+    @mock.patch("gsl_projet.models.DsService.update_ds_annotations_for_one_dotation")
+    def test_post_blocks_acceptance_when_validation_fails(
+        self,
+        mock_update,
+        client_with_user_logged,
+        collegue,
+        simulation,
+    ):
+        simulation_projet = _make_simulation_projet(
+            collegue, simulation, assiette=3_000, montant=5_000
+        )
+        response = client_with_user_logged.post(
+            _accept_url(simulation_projet), {}, headers={"HX-Request": "true"}
+        )
+        assert response.status_code == 200
+        simulation_projet.refresh_from_db()
+        assert simulation_projet.status == SimulationProjet.STATUS_PROCESSING
+        mock_update.assert_not_called()

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -517,6 +517,11 @@ class SimulationProjetStatusUpdateView(OpenHtmxModalMixin, UpdateView):
     def get_queryset(self):
         return SimulationProjet.objects.in_user_perimeter(self.request.user)
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["status"] = self.kwargs["status"]
+        return kwargs
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["new_simulation_status"] = self.kwargs["status"]
@@ -527,7 +532,7 @@ class SimulationProjetStatusUpdateView(OpenHtmxModalMixin, UpdateView):
 
     def form_valid(self, form):
         try:
-            form.save(status=self.kwargs["status"], user=self.request.user)
+            form.save(user=self.request.user)
             messages.info(
                 self.request,
                 {
@@ -555,6 +560,7 @@ class SimulationProjetStatusUpdateView(OpenHtmxModalMixin, UpdateView):
 class ProgrammationStatusUpdateView(OpenHtmxModalMixin, UpdateView):
     context_object_name = "simulation_projet"
     new_project_status: str = ""
+    acceptance_errors: list = []
 
     def dispatch(self, request, *args, **kwargs):
         if (
@@ -604,6 +610,17 @@ class ProgrammationStatusUpdateView(OpenHtmxModalMixin, UpdateView):
                 MATOMO_ACTION_CHANGEMENT_STATUT_SANS_NOTIFICATION_DEMANDE_CONFIRMATION,
                 f"{self.kwargs['status']}",
             )
+
+        self.acceptance_errors = []
+        if self.kwargs["status"] == SimulationProjet.STATUS_ACCEPTED:
+            validation_form = self.get_form_class()(
+                data={},
+                instance=self.object,
+                status=self.kwargs["status"],
+            )
+            if not validation_form.is_valid():
+                self.acceptance_errors = list(validation_form.non_field_errors())
+
         # On contourne BaseUpdateView.get() pour éviter un second appel à get_object()
         return super(BaseUpdateView, self).get(request, *args, **kwargs)
 
@@ -614,7 +631,13 @@ class ProgrammationStatusUpdateView(OpenHtmxModalMixin, UpdateView):
         context = super().get_context_data(**kwargs)
         context["new_projet_status"] = self.new_project_status
         context["new_simulation_status"] = self.kwargs["status"]
+        context["acceptance_errors"] = self.acceptance_errors
         return context
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["status"] = self.kwargs["status"]
+        return kwargs
 
     def get_form_class(self):
         if self.new_project_status == PROJET_STATUS_REFUSED:
@@ -630,6 +653,8 @@ class ProgrammationStatusUpdateView(OpenHtmxModalMixin, UpdateView):
             i.ds_id for i in self.object.dossier.ds_instructeurs.all()
         ]:
             return ["htmx/not_instructeur_error.html"]
+        if self.acceptance_errors:
+            return ["htmx/acceptance_errors_modal.html"]
         if self.new_project_status in [
             PROJET_STATUS_PROCESSING,
             PROJET_STATUS_ACCEPTED,
@@ -681,7 +706,7 @@ class ProgrammationStatusUpdateView(OpenHtmxModalMixin, UpdateView):
 
     def form_valid(self, form):
         try:
-            form.save(status=self.kwargs["status"], user=self.request.user)
+            form.save(user=self.request.user)
         except DsServiceException as e:
             if self.get_form_class() == SimulationProjetStatusForm:
                 # If the form is SimulationProjetStatusForm, we have no modal to display the error in, so we raise


### PR DESCRIPTION
## 🌮 Objectif

Bloquer l'acceptation d'une dotation tant que l'assiette subventionnable n'est pas saisie ou est inférieure au montant accordé, avec un message d'erreur dédié.

## 🔍 Liste des modifications

- Déplacement de la validation d'acceptation dans `SimulationProjetStatusForm.clean()`, conditionnée au statut cible (passé via `__init__` plutôt qu'à `save()`).
- Nouvelle modale `acceptance_errors_modal.html` affichée à l'ouverture ou à la soumission de la modale d'acceptation quand la validation échoue, listant les erreurs (assiette manquante, ou assiette inférieure au montant).
- Ajout d'un `{% block footer %}` dans `_base_htmx_modal.html` pour permettre à la modale d'erreur de n'afficher qu'un bouton « OK ».
- Nettoyage de `notify_later_confirmation_modal.html` : suppression de l'ancien message d'erreur inline et du bouton désactivé, désormais remplacés par la modale dédiée.
- Mise à jour des tests de formulaires (`test_projet_status_forms.py`, `test_double_dotation_status_forms.py`) pour refléter la nouvelle signature.
- Nouveaux tests `test_acceptance_validation.py` couvrant le formulaire et la vue (mono et double dotation).