### PR TITLE
Amélioration de la mise en page des arrêtés et lettres

### DIFF
--- a/gsl_notification/admin.py
+++ b/gsl_notification/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.safestring import mark_safe
 
 from gsl_core.admin import AllPermsForStaffUser
 
@@ -17,10 +19,33 @@ from .tasks import scan_uploaded_document
 class ArreteAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     list_display = (
         "__str__",
-        "programmation_projet",
+        "dossier_link",
         "created_by",
         "created_at",
         "updated_at",
+    )
+    readonly_fields = ("dossier_link",)
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        qs = qs.select_related(
+            "programmation_projet__dotation_projet__projet__dossier_ds"
+        )
+        return qs
+
+    def dossier_link(self, obj):
+        dossier = obj.programmation_projet.dotation_projet.projet.dossier_ds
+        if dossier:
+            url = reverse(
+                "admin:gsl_demarches_simplifiees_dossier_change",
+                args=[dossier.id],
+            )
+            return mark_safe(f'<a href="{url}">{dossier.ds_number}</a>')
+        return None
+
+    dossier_link.short_description = "Dossier"
+    dossier_link.admin_order_field = (
+        "programmation_projet__dotation_projet__projet__dossier_ds__ds_number"
     )
 
 
@@ -44,15 +69,41 @@ def relaunch_antivirus_scan(modeladmin, request, queryset):
 class ArreteEtLettreSignesAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     list_display = (
         "__str__",
-        "programmation_projet",
+        "dossier_link",
         "file",
         "created_by",
         "created_at",
         "last_scan",
         "is_infected",
     )
-    readonly_fields = ("last_scan", "is_infected")
+    readonly_fields = (
+        "dossier_link",
+        "last_scan",
+        "is_infected",
+    )
     actions = [relaunch_antivirus_scan]
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        qs = qs.select_related(
+            "programmation_projet__dotation_projet__projet__dossier_ds"
+        )
+        return qs
+
+    def dossier_link(self, obj):
+        dossier = obj.programmation_projet.dotation_projet.projet.dossier_ds
+        if dossier:
+            url = reverse(
+                "admin:gsl_demarches_simplifiees_dossier_change",
+                args=[dossier.id],
+            )
+            return mark_safe(f'<a href="{url}">{dossier.ds_number}</a>')
+        return None
+
+    dossier_link.short_description = "Dossier"
+    dossier_link.admin_order_field = (
+        "programmation_projet__dotation_projet__projet__dossier_ds__ds_number"
+    )
 
 
 @admin.register(Annexe)

--- a/gsl_notification/static/css/pdf.css
+++ b/gsl_notification/static/css/pdf.css
@@ -68,7 +68,7 @@ html {
 
 p {
     margin: 1em 0;
-    font-size: 10px;
+    font-size: 12px;
 }
 
 /* Header */
@@ -99,4 +99,12 @@ h1 {
 
 h2 {
     font-size: 14px
+}
+
+ul, ol {
+    padding-left: 1.5em;
+}
+
+li {
+    font-size: 10px;
 }

--- a/gsl_notification/utils.py
+++ b/gsl_notification/utils.py
@@ -417,6 +417,23 @@ def _get_uploaded_document_pdf(document: Annexe | ArreteEtLettreSignes) -> io.By
     return output
 
 
+def _fix_empty_paragraphs_for_weasyprint(html: str) -> str:
+    """
+    WeasyPrint (comme les navigateurs) collapse les <p> qui ne contiennent que du
+    whitespace ou des <br> (ils finissent avec une hauteur nulle).
+    On remplace leur contenu par un espace insécable pour préserver les sauts de
+    ligne issus d'un éditeur riche.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    for p in soup.find_all("p"):
+        # get_text(strip=True) retire les espaces, tabs, \n — si vide, le <p> est
+        # visuellement vide (contient uniquement du whitespace et/ou des <br>)
+        if not p.get_text(strip=True):
+            p.clear()
+            p.append("\u00a0")
+    return str(soup)
+
+
 def generate_pdf_for_generated_document(document: Arrete | LettreNotification) -> bytes:
     """
     Generate PDF bytes for a GeneratedDocument (Arrete or LettreNotification).
@@ -424,12 +441,13 @@ def generate_pdf_for_generated_document(document: Arrete | LettreNotification) -
     This function generates the PDF content for a document and returns it as bytes.
     It can be used to calculate the document size without actually serving it.
     """
+    content = _fix_empty_paragraphs_for_weasyprint(document.content)
     context = {
         "doc_title": get_doc_title(document.document_type),
         "logo": get_logo_base64(document.modele.logo.url),
         "alt_logo": document.modele.logo_alt_text,
         "top_right_text": document.modele.top_right_text.strip(),
-        "content": mark_safe(document.content),
+        "content": mark_safe(content),
     }
 
     html_string = render_to_string("gsl_notification/pdf/document.html", context)

--- a/gsl_notification/utils.py
+++ b/gsl_notification/utils.py
@@ -417,7 +417,7 @@ def _get_uploaded_document_pdf(document: Annexe | ArreteEtLettreSignes) -> io.By
     return output
 
 
-def _fix_empty_paragraphs_for_weasyprint(html: str) -> str:
+def fix_empty_paragraphs_for_weasyprint(html: str) -> str:
     """
     WeasyPrint (comme les navigateurs) collapse les <p> qui ne contiennent que du
     whitespace ou des <br> (ils finissent avec une hauteur nulle).
@@ -441,7 +441,7 @@ def generate_pdf_for_generated_document(document: Arrete | LettreNotification) -
     This function generates the PDF content for a document and returns it as bytes.
     It can be used to calculate the document size without actually serving it.
     """
-    content = _fix_empty_paragraphs_for_weasyprint(document.content)
+    content = fix_empty_paragraphs_for_weasyprint(document.content)
     context = {
         "doc_title": get_doc_title(document.document_type),
         "logo": get_logo_base64(document.modele.logo.url),

--- a/gsl_notification/views/views.py
+++ b/gsl_notification/views/views.py
@@ -32,7 +32,7 @@ from gsl_notification.models import (
     GeneratedDocument,
 )
 from gsl_notification.utils import (
-    _fix_empty_paragraphs_for_weasyprint,
+    fix_empty_paragraphs_for_weasyprint,
     get_doc_title,
     get_form_class,
     get_generated_document_class,
@@ -479,7 +479,7 @@ class PrintDocumentView(WeasyTemplateResponseMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         document = self.get_object()
-        content = _fix_empty_paragraphs_for_weasyprint(document.content)
+        content = fix_empty_paragraphs_for_weasyprint(document.content)
         context.update(
             {
                 "doc_title": get_doc_title(self.document_type),

--- a/gsl_notification/views/views.py
+++ b/gsl_notification/views/views.py
@@ -32,6 +32,7 @@ from gsl_notification.models import (
     GeneratedDocument,
 )
 from gsl_notification.utils import (
+    _fix_empty_paragraphs_for_weasyprint,
     get_doc_title,
     get_form_class,
     get_generated_document_class,
@@ -478,13 +479,14 @@ class PrintDocumentView(WeasyTemplateResponseMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         document = self.get_object()
+        content = _fix_empty_paragraphs_for_weasyprint(document.content)
         context.update(
             {
                 "doc_title": get_doc_title(self.document_type),
                 "logo": document.modele.logo.url,
                 "alt_logo": document.modele.logo_alt_text,
                 "top_right_text": document.modele.top_right_text.strip(),
-                "content": mark_safe(document.content),
+                "content": mark_safe(content),
             }
         )
         return context


### PR DESCRIPTION
## 🌮 Objectif

Plusieurs points :
- les paragraphes vides étaient ignorés dans le rendu => on y injecte un espace insécable
- les bullets points n'étaient pas alignées avec le texte => on aligne
- on augmente la taille de police (je pense que personne ne va se plaindre de passer de 10 à 12 px, au contraire !)

<img width="651" height="157" alt="image" src="https://github.com/user-attachments/assets/2ab10611-d4b1-4a08-9761-b3832e631abc" />
