### PR TITLE
Rendre dotation_not_treated déterministe pour stabiliser un test flaky

### DIFF
--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -448,7 +448,7 @@ class Projet(BaseModel):
         return next(
             (
                 dp.dotation
-                for dp in self.dotationprojet_set.all()
+                for dp in self.dotationprojet_set.order_by("dotation")
                 if dp.status == PROJET_STATUS_PROCESSING
             ),
             None,


### PR DESCRIPTION
## 🌮 Objectif

Corriger un test flaky qui a fait échouer la merge queue.

## 🔍 Liste des modifications

- Ajouter `.order_by("dotation")` à la requête de `Projet.dotation_not_treated` pour garantir un ordre déterministe lorsqu'un projet a deux dotations en statut `processing`.

## ⚠️ Informations supplémentaires

Le test `gsl_projet/tests/models/test_projet.py::test_dotation_not_treated_with_multiple_dotations_one_processing[processing-processing-DETR]` échouait par intermittence en CI :

```
AssertionError: assert 'DSIL' == 'DETR'
```

La propriété utilisait `dotationprojet_set.all()` sans `order_by()`. PostgreSQL ne garantissant aucun ordre par défaut, la propriété pouvait renvoyer DSIL au lieu de DETR attendu par le test. L'ajout de `.order_by("dotation")` fixe un ordre alphabétique stable (DETR < DSIL).