### PR TITLE
Changement de statut en lot sur la page de simulation

### DIFF
--- a/gsl_core/matomo_constants.py
+++ b/gsl_core/matomo_constants.py
@@ -13,6 +13,7 @@ MATOMO_ACTION_MODIFICATION_ASSIETTE = "modification_assiette"
 MATOMO_ACTION_MODIFICATION_MONTANT = "modification_montant"
 MATOMO_ACTION_MODIFICATION_TAUX = "modification_taux"
 MATOMO_ACTION_CHANGEMENT_STATUT = "changement_statut"
+MATOMO_ACTION_CHANGEMENT_STATUT_BULK = "changement_statut_bulk"
 
 # Matomo event actions — Programmation
 MATOMO_ACTION_MODIFICATION_MONTANTS = "modification_montants"

--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -337,33 +337,44 @@ ul.no-list-style li {
     overflow: visible;
 }
 
-/* Custom properties for sticky offsets – adjusted by :has() rules when columns hide */
-#projet-table-wrapper,
+/* Custom properties for sticky offsets – adjusted by :has() rules when columns hide.
+   --sticky-checkbox-width reserves room for the sticky checkbox column when present. */
+#projet-table-wrapper {
+    --sticky-checkbox-width: 0px;
+    --sticky-left-1-width: 100px;
+    --sticky-right-2-width: 120px;
+}
+
 #simulation-table-wrapper {
+    --sticky-checkbox-width: 2.75rem;
     --sticky-left-1-width: 100px;
     --sticky-right-2-width: 120px;
 }
 
 #programmation-table-wrapper {
+    --sticky-checkbox-width: 0px;
     --sticky-left-1-width: 60px;
     --sticky-right-2-width: 120px;
 }
 
-/* Left offsets for tables with Date as first column (projets, simulation) */
+/* Left offsets for tables with Date as first column (projets, simulation).
+   Simulation also has a sticky checkbox before Date, so offsets are shifted by
+   --sticky-checkbox-width (which is 0 on the projets table). */
 #table-projets .gsl-projet-table__sticky-left-1,
 #table-simulation .gsl-projet-table__sticky-left-1 {
+    left: var(--sticky-checkbox-width);
     min-width: var(--sticky-left-1-width);
 }
 
 #table-projets .gsl-projet-table__sticky-left-2,
 #table-simulation .gsl-projet-table__sticky-left-2 {
-    left: var(--sticky-left-1-width);
+    left: calc(var(--sticky-checkbox-width) + var(--sticky-left-1-width));
     min-width: 180px;
 }
 
 #table-projets .gsl-projet-table__sticky-left-3,
 #table-simulation .gsl-projet-table__sticky-left-3 {
-    left: calc(var(--sticky-left-1-width) + 180px);
+    left: calc(var(--sticky-checkbox-width) + var(--sticky-left-1-width) + 180px);
     box-shadow: 2px 0 4px rgb(0 0 0 / 8%);
 }
 

--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -531,6 +531,7 @@ ul.no-list-style li {
 
 
 .gsl-dropdown-content {
+  text-align: left;
   display: none;
   position: absolute;
   background-color: var(--background-default-grey);
@@ -540,7 +541,7 @@ ul.no-list-style li {
   z-index: 1000;
   gap: 1rem;
   max-height: 80vh;
-  overflow-y: auto;
+  overflow: hidden auto;
 }
 
 
@@ -636,13 +637,13 @@ ul.no-list-style li {
 .gsl-column-visibility-dropdown {
     position: relative;
     margin-bottom: 0;
+    min-width: min(560px, 90vw);
 }
 
 .gsl-column-visibility-dropdown .gsl-column-visibility-list {
     display: none;
     right: 0;
     padding: 0;
-    width: min(560px, 90vw);
     border: 1px solid var(--border-default-grey);
     box-shadow: 0 8px 24px rgb(0 0 0 / 20%);
 }

--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -58,7 +58,8 @@
                     "bindAmountFields": "/static/js/controllers/bindAmountTields.js",
                     "formUtils": "/static/js/controllers/formUtils.js",
                     "dotationDropdown": "/static/js/controllers/dotationDropdown.js",
-                    "commentArbitrage": "/static/js/controllers/commentArbitrage.js"
+                    "commentArbitrage": "/static/js/controllers/commentArbitrage.js",
+                    "bulkStatusChange": "/static/js/controllers/bulkStatusChange.js"
                 }
             }
             </script>
@@ -131,6 +132,7 @@
             import { FormUtils } from "formUtils"
             import { DotationDropdown } from "dotationDropdown"
             import { CommentArbitrage } from "commentArbitrage"
+            import { BulkStatusChange } from "bulkStatusChange"
 
             window.Stimulus = Application.start()
 
@@ -144,6 +146,7 @@
             Stimulus.register("form-utils", FormUtils)
             Stimulus.register("dotation-dropdown", DotationDropdown)
             Stimulus.register("comment-arbitrage", CommentArbitrage)
+            Stimulus.register("bulk-status-change", BulkStatusChange)
         </script>
 
         {% block extra_js %}

--- a/gsl_core/templates/gsl_core/_column_visibility_dropdown.html
+++ b/gsl_core/templates/gsl_core/_column_visibility_dropdown.html
@@ -12,7 +12,7 @@
         {{ simulation.columns_visibility|json_script:"gsl-column-visibility-saved-state" }}
     {% endif %}
     <button type="button"
-            class="fr-btn fr-btn--secondary fr-btn--sm fr-btn--icon-right fr-icon-arrow-down-s-line">
+            class="fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-down-s-line">
         Colonnes affichées
     </button>
     <div class="gsl-dropdown-content gsl-column-visibility-list">

--- a/gsl_programmation/static/css/programmation_projet_list.css
+++ b/gsl_programmation/static/css/programmation_projet_list.css
@@ -11,17 +11,6 @@
 }
 
 
-.gsl-projet-table__header--checkbox {
-  /* position: sticky (from __sticky-left-1) already creates a containing block
-     for the absolutely-positioned checkbox and action menu inside */
-}
-
-.gsl-projet-table__header--checkbox .fr-checkbox-group {
-  position: absolute;
-  top: calc(50% - 12px);
-  left: 18px;
-}
-
 .gsl-projet-table__action-menu {
   position: absolute;
   left: 32px;
@@ -44,11 +33,6 @@
 /* Raise the header cell above body cells when the dropdown is open */
 .gsl-projet-table__header--checkbox:has(.gsl-projet-table__action-menu[open]) {
   z-index: 10;
-}
-
-.gsl-projet-table__checkbox-label {
-  position: absolute;
-  top: -14px;
 }
 
 .gsl-projet-table__row--select-all {

--- a/gsl_programmation/templates/gsl_programmation/programmation_projet_list.html
+++ b/gsl_programmation/templates/gsl_programmation/programmation_projet_list.html
@@ -47,7 +47,7 @@
         {% include "includes/_projet_list_filters.html" %}
 
         <div id="programmation-table-wrapper">
-            <div class="gsl-table-toolbar fr-my-1w">
+            <div class="gsl-table-toolbar fr-mt-11v fr-mb-6v">
                 <span>
                     {{ page_obj.paginator.count }} projet{{ page_obj.paginator.count|custom_pluralize }}
                 </span>

--- a/gsl_projet/static/css/projet_list.css
+++ b/gsl_projet/static/css/projet_list.css
@@ -26,3 +26,26 @@ td.gsl-projet-table__cell--dotation > span:not(:last-child) {
   text-align: end;
   font-style: italic;
 }
+
+/* Checkbox column: sticky at left: 0 with fixed width.
+   Sticky creates a containing block for the absolutely-positioned checkbox inside. */
+.gsl-projet-table__header--checkbox,
+.gsl-projet-table__cell--checkbox {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background-color: var(--background-default-grey);
+  min-width: 2.75rem;
+}
+
+.gsl-projet-table__header--checkbox .fr-checkbox-group,
+.gsl-projet-table__cell--checkbox .fr-checkbox-group {
+  position: absolute;
+  top: calc(50% - 12px);
+  left: 18px;
+}
+
+.gsl-projet-table__checkbox-label {
+  position: absolute;
+  top: -14px;
+}

--- a/gsl_projet/templates/includes/_projets_table.html
+++ b/gsl_projet/templates/includes/_projets_table.html
@@ -1,7 +1,7 @@
 {% load gsl_filters dsfr_tags custom_pluralize %}
 
 <div id="projet-table-wrapper">
-    <div class="gsl-table-toolbar fr-my-1w">
+    <div class="gsl-table-toolbar fr-mt-11v fr-mb-6v">
         <span>
             {{ page_obj.paginator.count }} projet{{ page_obj.paginator.count|custom_pluralize }}
             {% if missing_annotations_count %}

--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -1,3 +1,7 @@
+.gsl-table-toolbar .fr-btns-group .fr-btn {
+  margin-bottom: 0;
+}
+
 /* table */
 .gsl-projet-table__select {
   text-align: right;

--- a/gsl_simulation/static/js/controllers/bulkStatusChange.js
+++ b/gsl_simulation/static/js/controllers/bulkStatusChange.js
@@ -1,0 +1,105 @@
+import { Controller } from 'stimulus'
+
+export class BulkStatusChange extends Controller {
+  static targets = [
+    'pageCheckbox',
+    'rowCheckbox',
+    'counter',
+    'counterWrapper',
+    'idsInput',
+    'selectAllButton',
+    'applyButton'
+  ]
+
+  connect () {
+    this.selectedIds = new Set()
+    const selectableJson = document.getElementById('bulk-status-change-selectable-ids')
+    this.selectableIds = selectableJson ? JSON.parse(selectableJson.textContent) : []
+    this._refresh()
+  }
+
+  toggleRow (event) {
+    const id = parseInt(event.target.value, 10)
+    if (event.target.checked) {
+      this.selectedIds.add(id)
+    } else {
+      this.selectedIds.delete(id)
+    }
+    this._refresh()
+  }
+
+  togglePageSelection (event) {
+    const checked = event.target.checked
+    this.rowCheckboxTargets.forEach((checkbox) => {
+      this._setCheckbox(checkbox, checked)
+      const id = parseInt(checkbox.value, 10)
+      if (checked) {
+        this.selectedIds.add(id)
+      } else {
+        this.selectedIds.delete(id)
+      }
+    })
+    this._refresh()
+  }
+
+  toggleSelectAll () {
+    if (this.selectedIds.size >= this.selectableIds.length) {
+      this.selectedIds.clear()
+      this.rowCheckboxTargets.forEach((checkbox) => {
+        this._setCheckbox(checkbox, false)
+      })
+    } else {
+      this.selectableIds.forEach((id) => this.selectedIds.add(id))
+      this.rowCheckboxTargets.forEach((checkbox) => {
+        this._setCheckbox(checkbox, true)
+      })
+    }
+    this._refresh()
+  }
+
+  beforeSubmit (event) {
+    if (this.selectedIds.size === 0) {
+      event.preventDefault()
+      return
+    }
+    this._syncIdsInputs()
+  }
+
+  _refresh () {
+    const count = this.selectedIds.size
+    if (this.hasCounterTarget) {
+      this.counterTarget.textContent = count
+    }
+    if (this.hasCounterWrapperTarget) {
+      this.counterWrapperTarget.classList.toggle('fr-text-mention--grey', count === 0)
+    }
+    if (this.hasApplyButtonTarget) {
+      this.applyButtonTarget.disabled = count === 0
+    }
+    if (this.hasSelectAllButtonTarget) {
+      const allSelected = count > 0 && count >= this.selectableIds.length
+      this.selectAllButtonTarget.textContent = allSelected
+        ? 'Désélectionner tous les projets'
+        : `Sélectionner tous les ${this.selectableIds.length} projets`
+    }
+    if (this.hasPageCheckboxTarget) {
+      const visible = this.rowCheckboxTargets
+      const allChecked =
+        visible.length > 0 && visible.every((c) => c.checked)
+      this._setCheckbox(this.pageCheckboxTarget, allChecked)
+    }
+    this._syncIdsInputs()
+  }
+
+  _setCheckbox (element, value) {
+    element.checked = value
+    element.setAttribute('data-fr-js-checkbox-input', value)
+  }
+
+  _syncIdsInputs () {
+    const value = Array.from(this.selectedIds).join(',')
+    this.idsInputTargets.forEach((input) => {
+      input.value = value
+    })
+  }
+}

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -36,14 +36,8 @@
     {% include "includes/_enveloppe_summary.html" %}
     {% include "includes/_projet_list_filters.html" %}
 
-    <div id="simulation-table-wrapper">
-        <div class="gsl-table-toolbar fr-my-1w">
-            <span>
-                {{ page_obj.paginator.count }}
-                projet{{ page_obj.paginator.count|custom_pluralize }}
-            </span>
-            {% include "gsl_core/_column_visibility_dropdown.html" with table_wrapper_id="simulation-table-wrapper" simulation=simulation %}
-        </div>
+    <div id="simulation-table-wrapper" data-controller="bulk-status-change">
+        {% include "includes/_simulation_bulk_actions_toolbar.html" %}
         <div class="fr-table fr-table--multiline fr-table--sm fr-table--no-caption gsl-projet-table">
             <div class="fr-table__wrapper">
                 <div class="fr-table__container">
@@ -52,6 +46,17 @@
                             <caption>Détails de la simulation</caption>
                             <thead>
                                 <tr>
+                                    <th scope="col" class="gsl-projet-table__header--checkbox">
+                                        <div class="fr-checkbox-group fr-checkbox-group--sm">
+                                            <input id="bulk-status-page-checkbox"
+                                                   type="checkbox"
+                                                   data-bulk-status-change-target="pageCheckbox"
+                                                   data-action="change->bulk-status-change#togglePageSelection">
+                                            <label class="fr-label" for="bulk-status-page-checkbox">
+                                                <span class="fr-sr-only">Sélectionner tous les projets de la page</span>
+                                            </label>
+                                        </div>
+                                    </th>
                                     {% for column in columns %}
                                         <th scope="col"
                                             class="{{ column.th_classes }}"
@@ -74,7 +79,7 @@
                                     {% endwith %}
                                 {% empty %}
                                     <tr>
-                                        <td colspan="{{ columns|length }}">
+                                        <td colspan="{{ columns|length|add:1 }}">
                                             Liste vide.
                                         </td>
                                     </tr>

--- a/gsl_simulation/templates/gsl_simulation/table_cells/_other_dotation_row.html
+++ b/gsl_simulation/templates/gsl_simulation/table_cells/_other_dotation_row.html
@@ -3,6 +3,8 @@
 {% for other_dotation in dotation_projet.other_dotations %}
     <tr id="other-simulation-{{ simu.pk }}"
         class="gsl-projet-table__row--other-dotation">
+        <td class="gsl-projet-table__cell--checkbox">
+        </td>
         {% for column in columns %}
             <td class="{{ column.td_classes }}">
                 {% include "gsl_core/table_cells/_other_dotation_cell.html" %}

--- a/gsl_simulation/templates/includes/_simulation_bulk_actions_toolbar.html
+++ b/gsl_simulation/templates/includes/_simulation_bulk_actions_toolbar.html
@@ -1,0 +1,72 @@
+{% load custom_pluralize simulation_filters %}
+{% comment %}
+    Toolbar above the simulation projet table: counters, bulk selection and
+    bulk status change.
+
+    Required context:
+      - page_obj
+      - simulation
+      - columns
+      - selectable_ids_list (list of SimulationProjet IDs that can be bulk-changed)
+      - bulk_status_choices (iterable of status keys)
+{% endcomment %}
+
+<div class="gsl-table-toolbar fr-mt-11v fr-mb-6v">
+    {{ selectable_ids_list|json_script:"bulk-status-change-selectable-ids" }}
+    <span class="gsl-bulk-actions__count">
+        {{ page_obj.paginator.count }} projet{{ page_obj.paginator.count|custom_pluralize }}
+        <span class="fr-text-mention--grey fr-ml-2w"
+              data-bulk-status-change-target="counterWrapper">
+            <span data-bulk-status-change-target="counter">0</span> projets sélectionnés
+        </span>
+    </span>
+    <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-right">
+        <li>
+            <button type="button" class="fr-btn fr-btn--tertiary" data-bulk-status-change-target="selectAllButton" data-action="click->bulk-status-change#toggleSelectAll"
+                {% if not selectable_count %}
+                    disabled
+                {% endif %}
+                >
+                Sélectionner tous les {{ selectable_count }} projet{{ selectable_count|custom_pluralize }}
+            </button>
+        </li>
+        <li>
+            <div class="fr-nav fr-translate">
+                <div class="fr-nav__item">
+                    <button type="button"
+                            class="fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-down-s-line"
+                            aria-controls="bulk-status-change-menu"
+                            aria-expanded="false"
+                            data-bulk-status-change-target="applyButton"
+                            disabled>
+                        Modifier les statuts à
+                    </button>
+                    <div class="fr-menu fr-collapse" id="bulk-status-change-menu">
+                        <ul class="fr-menu__list">
+                            {% for status_key in bulk_status_choices %}
+                                <li>
+                                    <form method="post"
+                                          hx-post="{% url 'simulation:simulation-projet-bulk-update-simulation-status' status=status_key %}"
+                                          hx-swap="none"
+                                          data-action="submit->bulk-status-change#beforeSubmit">
+                                        {% csrf_token %}
+                                        <input type="hidden"
+                                               name="simulation_projet_ids"
+                                               value=""
+                                               data-bulk-status-change-target="idsInput">
+                                        <button type="submit" class="fr-nav__link">
+                                            {{ status_key|status_to_label|split_symbol_and_status|safe }}
+                                        </button>
+                                    </form>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </li>
+        <li>
+            {% include "gsl_core/_column_visibility_dropdown.html" with table_wrapper_id="simulation-table-wrapper" simulation=simulation %}
+        </li>
+    </ul>
+</div>

--- a/gsl_simulation/templates/includes/_simulation_detail_row.html
+++ b/gsl_simulation/templates/includes/_simulation_detail_row.html
@@ -4,6 +4,20 @@
     <tr id="simulation-{{ simu.pk }}"
         hx-swap-oob="true"
         {% if dotation_projet.other_dotations|length > 0 %}class="gsl-projet-table__row--double-dotation"{% endif %}>
+        <td class="gsl-projet-table__cell--checkbox">
+            {% if simu.id in selectable_ids_list %}
+                <div class="fr-checkbox-group fr-checkbox-group--sm">
+                    <input id="bulk-status-checkbox-{{ simu.pk }}"
+                           type="checkbox"
+                           value="{{ simu.pk }}"
+                           data-bulk-status-change-target="rowCheckbox"
+                           data-action="change->bulk-status-change#toggleRow">
+                    <label class="fr-label" for="bulk-status-checkbox-{{ simu.pk }}">
+                        <span class="fr-sr-only">Sélectionner le projet N°{{ projet.dossier_ds.ds_number }}</span>
+                    </label>
+                </div>
+            {% endif %}
+        </td>
         {% for column in columns %}
             {% if column.key == "statut" %}
                 <td class="gsl-projet-table__cell--status {{ column.td_classes }}">

--- a/gsl_simulation/tests/views/test_bulk_status_update.py
+++ b/gsl_simulation/tests/views/test_bulk_status_update.py
@@ -1,0 +1,215 @@
+from typing import cast
+
+import pytest
+from django.contrib.messages import get_messages
+from django.urls import reverse
+from django.utils import timezone
+
+from gsl_core.tests.factories import (
+    ClientWithLoggedUserFactory,
+    CollegueWithDSProfileFactory,
+    PerimetreDepartementalFactory,
+)
+from gsl_programmation.tests.factories import DetrEnveloppeFactory
+from gsl_projet.constants import DOTATION_DETR, PROJET_STATUS_PROCESSING
+from gsl_projet.tests.factories import DotationProjetFactory
+from gsl_simulation.models import SimulationProjet
+from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def perimetre_departemental():
+    return PerimetreDepartementalFactory()
+
+
+@pytest.fixture
+def detr_enveloppe(perimetre_departemental):
+    return DetrEnveloppeFactory(
+        perimetre=perimetre_departemental, annee=2025, montant=1_000_000
+    )
+
+
+@pytest.fixture
+def simulation(detr_enveloppe):
+    return SimulationFactory(enveloppe=detr_enveloppe)
+
+
+@pytest.fixture
+def collegue(perimetre_departemental):
+    return CollegueWithDSProfileFactory(perimetre=perimetre_departemental)
+
+
+@pytest.fixture
+def client_with_user_logged(collegue):
+    return ClientWithLoggedUserFactory(collegue)
+
+
+def _make_simu_projet(collegue, simulation, **kwargs):
+    dotation_projet = DotationProjetFactory(
+        status=PROJET_STATUS_PROCESSING,
+        projet__dossier_ds__perimetre=collegue.perimetre,
+        dotation=DOTATION_DETR,
+        assiette=10_000,
+    )
+    return cast(
+        SimulationProjet,
+        SimulationProjetFactory(
+            dotation_projet=dotation_projet,
+            status=SimulationProjet.STATUS_PROCESSING,
+            montant=1000,
+            simulation=simulation,
+            **kwargs,
+        ),
+    )
+
+
+def _bulk_url(status):
+    return reverse(
+        "simulation:simulation-projet-bulk-update-simulation-status", args=[status]
+    )
+
+
+def test_bulk_status_update_marks_all_selected_rows(
+    client_with_user_logged, collegue, simulation
+):
+    sp1 = _make_simu_projet(collegue, simulation)
+    sp2 = _make_simu_projet(collegue, simulation)
+    sp3 = _make_simu_projet(collegue, simulation)
+
+    response = client_with_user_logged.post(
+        _bulk_url(SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED),
+        data={"simulation_projet_ids": f"{sp1.id},{sp2.id},{sp3.id}"},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("HX-Refresh") == "true"
+    for sp in (sp1, sp2, sp3):
+        sp.refresh_from_db()
+        assert sp.status == SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED
+
+    assert list(get_messages(response.wsgi_request)) == []
+
+
+def test_bulk_status_update_rejects_ids_outside_user_perimeter(
+    client_with_user_logged, collegue, simulation
+):
+    mine = _make_simu_projet(collegue, simulation)
+
+    other_perimetre = PerimetreDepartementalFactory()
+    other_enveloppe = DetrEnveloppeFactory(perimetre=other_perimetre, annee=2025)
+    other_simulation = SimulationFactory(enveloppe=other_enveloppe)
+    other_dotation = DotationProjetFactory(
+        status=PROJET_STATUS_PROCESSING,
+        projet__dossier_ds__perimetre=other_perimetre,
+        dotation=DOTATION_DETR,
+        assiette=10_000,
+    )
+    outside = SimulationProjetFactory(
+        dotation_projet=other_dotation,
+        status=SimulationProjet.STATUS_PROCESSING,
+        montant=1000,
+        simulation=other_simulation,
+    )
+
+    response = client_with_user_logged.post(
+        _bulk_url(SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED),
+        data={"simulation_projet_ids": f"{mine.id},{outside.id}"},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == 404
+    mine.refresh_from_db()
+    assert mine.status == SimulationProjet.STATUS_PROCESSING
+
+
+def test_bulk_status_update_rejects_programmed_status(
+    client_with_user_logged, collegue, simulation
+):
+    sp = _make_simu_projet(collegue, simulation)
+
+    response = client_with_user_logged.post(
+        _bulk_url(SimulationProjet.STATUS_ACCEPTED),
+        data={"simulation_projet_ids": f"{sp.id}"},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == 404
+    sp.refresh_from_db()
+    assert sp.status == SimulationProjet.STATUS_PROCESSING
+
+
+def test_bulk_status_update_skips_notified_projects(
+    client_with_user_logged, collegue, simulation
+):
+    sp_ok = _make_simu_projet(collegue, simulation)
+    sp_notified = _make_simu_projet(collegue, simulation)
+    sp_notified.projet.notified_at = timezone.now()
+    sp_notified.projet.save()
+
+    response = client_with_user_logged.post(
+        _bulk_url(SimulationProjet.STATUS_PROVISIONALLY_REFUSED),
+        data={"simulation_projet_ids": f"{sp_ok.id},{sp_notified.id}"},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == 200
+    sp_ok.refresh_from_db()
+    sp_notified.refresh_from_db()
+    assert sp_ok.status == SimulationProjet.STATUS_PROVISIONALLY_REFUSED
+    assert sp_notified.status == SimulationProjet.STATUS_PROCESSING
+
+    msgs = list(get_messages(response.wsgi_request))
+    assert any("1 projet" in m.message and "ignoré" in m.message for m in msgs)
+
+
+def test_bulk_status_update_skips_projet_with_final_source_status(
+    client_with_user_logged, collegue, simulation
+):
+    sp_ok = _make_simu_projet(collegue, simulation)
+    sp_final = _make_simu_projet(collegue, simulation)
+    sp_final.status = SimulationProjet.STATUS_ACCEPTED
+    sp_final.save()
+
+    response = client_with_user_logged.post(
+        _bulk_url(SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED),
+        data={"simulation_projet_ids": f"{sp_ok.id},{sp_final.id}"},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == 200
+    sp_ok.refresh_from_db()
+    sp_final.refresh_from_db()
+    assert sp_ok.status == SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED
+    assert sp_final.status == SimulationProjet.STATUS_ACCEPTED
+
+    msgs = list(get_messages(response.wsgi_request))
+    assert any("1 projet" in m.message and "ignoré" in m.message for m in msgs)
+
+
+def test_bulk_status_update_empty_selection_shows_error(
+    client_with_user_logged, simulation
+):
+    response = client_with_user_logged.post(
+        _bulk_url(SimulationProjet.STATUS_PROCESSING),
+        data={"simulation_projet_ids": ""},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == 200
+    msgs = list(get_messages(response.wsgi_request))
+    assert len(msgs) == 1
+    assert "Aucun projet" in msgs[0].message
+
+
+def test_bulk_status_update_requires_htmx(
+    client_with_user_logged, collegue, simulation
+):
+    sp = _make_simu_projet(collegue, simulation)
+    response = client_with_user_logged.post(
+        _bulk_url(SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED),
+        data={"simulation_projet_ids": f"{sp.id}"},
+    )
+    assert response.status_code == 400

--- a/gsl_simulation/urls.py
+++ b/gsl_simulation/urls.py
@@ -10,6 +10,7 @@ from gsl_simulation.views.simulation_projet_notes_views import (
     get_note_card,
 )
 from gsl_simulation.views.simulation_projet_views import (
+    BulkSimulationProjetStatusUpdateView,
     EditAssietteView,
     EditCommentView,
     EditMontantView,
@@ -102,6 +103,11 @@ urlpatterns = [
         "<int:pk>/simuler/<str:status>/",
         SimulationProjetStatusUpdateView.as_view(),
         name="simulation-projet-update-simulation-status",
+    ),
+    path(
+        "bulk-simuler/<str:status>/",
+        BulkSimulationProjetStatusUpdateView.as_view(),
+        name="simulation-projet-bulk-update-simulation-status",
     ),
     path(
         "<int:pk>/programmer/<str:status>/",

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -1,11 +1,13 @@
 import json
 
 from django.contrib import messages
+from django.db import transaction
 from django.http import Http404 as DjangoHttp404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.views import View
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, UpdateView
 from django.views.generic.edit import BaseUpdateView
@@ -18,6 +20,7 @@ from gsl_core.matomo import queue_matomo_event
 from gsl_core.matomo_constants import (
     MATOMO_ACTION_CHANGEMENT_STATUT,
     MATOMO_ACTION_CHANGEMENT_STATUT_AVEC_NOTIFICATION_DEMANDE_CONFIRMATION,
+    MATOMO_ACTION_CHANGEMENT_STATUT_BULK,
     MATOMO_ACTION_CHANGEMENT_STATUT_CONFIRME,
     MATOMO_ACTION_CHANGEMENT_STATUT_SANS_NOTIFICATION_DEMANDE_CONFIRMATION,
     MATOMO_ACTION_MODIFICATION_ASSIETTE,
@@ -553,6 +556,89 @@ class SimulationProjetStatusUpdateView(OpenHtmxModalMixin, UpdateView):
                 self.request,
                 f"{str(e)}",
             )
+        return HttpResponseClientRefresh()
+
+
+@method_decorator(htmx_only, name="dispatch")
+@method_decorator(require_POST, name="dispatch")
+class BulkSimulationProjetStatusUpdateView(View):
+    """
+    Bulk status change for several SimulationProjet rows at once,
+    restricted to the three simulation-pending statuses (no notification,
+    no DS mutation, no confirmation modal). Reuses
+    `SimulationProjetStatusForm.save()` per row so the single-row
+    behavior stays authoritative.
+    """
+
+    def post(self, request, *args, **kwargs):
+        target_status = kwargs["status"]
+        if target_status not in SimulationProjet.SIMULATION_PENDING_STATUSES:
+            raise Http404(user_message="Statut de simulation invalide")
+
+        raw_ids = request.POST.get("simulation_projet_ids", "")
+        try:
+            ids = [int(i) for i in raw_ids.split(",") if i.strip()]
+        except ValueError:
+            raise Http404(user_message="Identifiants de projets invalides")
+
+        if not ids:
+            messages.error(
+                request, "Aucun projet sélectionné pour le changement de statut."
+            )
+            return HttpResponseClientRefresh()
+
+        qs = (
+            SimulationProjet.objects.in_user_perimeter(request.user)
+            .filter(id__in=ids)
+            .select_related(
+                "dotation_projet",
+                "dotation_projet__projet",
+                "simulation",
+                "simulation__enveloppe",
+            )
+        )
+        found_ids = {sp.id for sp in qs}
+        if found_ids != set(ids):
+            raise Http404(
+                user_message=(
+                    "Un ou plusieurs des projets sélectionnés n'est pas accessible "
+                    "(identifiant inconnu ou hors de votre périmètre)."
+                )
+            )
+
+        simulation_projets = [
+            sp
+            for sp in qs
+            if sp.dotation_projet.projet.notified_at is None
+            and sp.status in SimulationProjet.SIMULATION_PENDING_STATUSES
+        ]
+        skipped = len(ids) - len(simulation_projets)
+
+        with transaction.atomic():
+            for sp in simulation_projets:
+                SimulationProjetStatusForm(instance=sp, status=target_status).save(
+                    user=request.user
+                )
+
+        updated = len(simulation_projets)
+        if skipped:
+            messages.warning(
+                request,
+                (
+                    f"{skipped} projet{'s' if skipped > 1 else ''} non "
+                    f"modifiable{'s' if skipped > 1 else ''} "
+                    f"{'ont' if skipped > 1 else 'a'} été ignoré"
+                    f"{'s' if skipped > 1 else ''}."
+                ),
+            )
+
+        queue_matomo_event(
+            request,
+            MATOMO_CATEGORY_SIMULATION,
+            MATOMO_ACTION_CHANGEMENT_STATUT_BULK,
+            f"{target_status}:{updated}",
+        )
+
         return HttpResponseClientRefresh()
 
 

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -125,9 +125,20 @@ class SimulationDetailView(SingleObjectMixin, FilterView):
         aggregates["total_amount_granted"] = simulation.get_total_amount_granted(
             self.filterset.qs
         )
+        selectable_ids_list = list(
+            SimulationProjet.objects.filter(
+                simulation=simulation,
+                status__in=SimulationProjet.SIMULATION_PENDING_STATUSES,
+                dotation_projet__projet__in=self.filterset.qs,
+                dotation_projet__projet__notified_at__isnull=True,
+            ).values_list("id", flat=True)
+        )
         context.update(
             {
                 "simulation": simulation,
+                "selectable_ids_list": selectable_ids_list,
+                "selectable_count": len(selectable_ids_list),
+                "bulk_status_choices": SimulationProjet.SIMULATION_PENDING_STATUSES,
                 "title": f"{simulation.enveloppe.dotation} {simulation.enveloppe.annee} – {simulation.title}",
                 "status_summary": simulation.get_projet_status_summary(),
                 "enveloppe": simulation.enveloppe,


### PR DESCRIPTION
## 🌮 Objectif

Permettre de modifier le statut de plusieurs projets d'une simulation en une seule action, entre les trois statuts de simulation (en traitement, accepté provisoirement, refusé provisoirement).

## 🔍 Liste des modifications

- Ajout d'une barre d'outils au-dessus du tableau de simulation : compteur « N projets sélectionnés » (grisé quand aucun sélectionné), bouton « Sélectionner tous les X projets » (sélection à travers toutes les pages filtrées), menu déroulant « Modifier les statuts à ».
- Cases à cocher par ligne + case de sélection de toute la page dans l'en-tête du tableau. Les projets déjà notifiés ne sont pas sélectionnables.
- Nouvelle vue `BulkSimulationProjetStatusUpdateView` (POST + HTMX uniquement) restreinte aux trois statuts de simulation. Réutilisation de `SimulationProjetStatusForm` ligne par ligne afin de garder un seul chemin de code vis-à-vis du changement de statut unitaire. Les projets notifiés sont exclus côté serveur avec un message d'avertissement ; les identifiants hors périmètre renvoient 404.
- Nouveau contrôleur Stimulus `bulkStatusChange` pour les cases à cocher, la sélection inter-pages et la synchronisation des formulaires.
- Nouvelle constante Matomo `changement_statut_bulk`.
- Harmonisation visuelle des barres d'outils sur les pages projet, programmation et simulation : marges (`fr-mt-11v fr-mb-6v`) et taille normale du bouton « Colonnes affichées ».

## ⚠️ Informations supplémentaires

- 6 tests end-to-end sur la nouvelle vue (chemin heureux, hors périmètre, statut invalide, projets notifiés ignorés, sélection vide, HTMX obligatoire).
- Pas de modification de modèle ni de migration.

## 🖼️ Images

_à ajouter_