### PR TITLE
Empêcher les requêtes HTTP non mockées dans les tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+import responses
+
+
+@pytest.fixture(autouse=True)
+def _block_outbound_http():
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        yield rsps


### PR DESCRIPTION
## 🌮 Objectif

Bloquer toute requête HTTP sortante non mockée pendant l'exécution des tests pour éviter les appels accidentels à `demarche.numerique.gouv.fr`.

## 🔍 Liste des modifications

- Ajout d'une fixture `autouse` à la racine (`conftest.py`) qui enveloppe chaque test dans un contexte `responses.RequestsMock(assert_all_requests_are_fired=False)`.
- Toute requête `requests.get`/`requests.post` non enregistrée lève désormais `ConnectionError` au lieu de tenter une connexion réelle.
- Aucune modification nécessaire sur les tests existants (ceux qui utilisent `@responses.activate` ou `@patch` continuent de fonctionner).

## ⚠️ Informations supplémentaires

La dépendance `responses` est déjà présente dans `requirements-dev.txt`.

Les 1907 tests passent avec la protection activée : aucun test ne faisait en réalité un appel HTTP non mocké via `requests` au moment de l'ajout — la fixture sert de filet de sécurité pour les futurs tests.