### PR TITLE
Ajouter le script HeatmapSessionRecording de Matomo

### DIFF
--- a/gsl_core/static/js/matomo.js
+++ b/gsl_core/static/js/matomo.js
@@ -12,6 +12,12 @@ _paq.push(["enableLinkTracking"]);
   g.async = true;
   g.src = u + "matomo.js";
   s.parentNode.insertBefore(g, s);
+  // Add HeatmapSessionRecording/tracker.min.js cause stats.beta.gouv.fr doesn't
+  // https://developer.matomo.org/guides/heatmap-session-recording/setup#when-the-matomojs-in-your-piwik-directory-file-is-not-writable
+  var heatmapScript = d.createElement("script");
+  heatmapScript.async = true;
+  heatmapScript.src = u + "plugin/HeatmapSessionRecording/tracker.min.js";
+  s.parentNode.insertBefore(heatmapScript, s);
 })();
 
 // Fire Matomo events triggered via HX-Trigger header from HTMX partial responses.


### PR DESCRIPTION
## 🌮 Objectif

Activer le suivi des heatmaps et des enregistrements de session Matomo sur l'app.

## 🔍 Liste des modifications

- Chargement du tracker `plugin/HeatmapSessionRecording/tracker.min.js` en complément de `matomo.js` dans `gsl_core/static/js/matomo.js`.

## ⚠️ Informations supplémentaires

Le `matomo.js` servi par stats.beta.gouv.fr n'intègre pas le tracker du plugin HeatmapSessionRecording. On le charge donc manuellement côté client, en suivant [la procédure officielle Matomo](https://developer.matomo.org/guides/heatmap-session-recording/setup#when-the-matomojs-in-your-piwik-directory-file-is-not-writable) pour les installations où `matomo.js` n'est pas modifiable.

Plan de test :
- Vérifier dans l'onglet Network d'un navigateur que `tracker.min.js` est bien chargé après `matomo.js`.
- Vérifier côté Matomo (stats.beta.gouv.fr) que les heatmaps / enregistrements de session remontent.