### PR TITLE
Utilisation de l'adresse complète plutôt que reconstruite sur une ligne

### DIFF
--- a/gsl_notification/tests/test_utils.py
+++ b/gsl_notification/tests/test_utils.py
@@ -36,7 +36,10 @@ def programmation_projet():
         departement__name="Haute-Garonne",
     )
     adresse = AdresseFactory(
-        street_address="1 rue de la Paix", postal_code="75001", commune__name="Paris"
+        label="1 rue de la Paix 75001 Paris",
+        street_address="1 rue de la Paix",
+        postal_code="75001",
+        commune__name="Paris",
     )
     return ProgrammationProjetFactory(
         dotation_projet__projet__dossier_ds__ds_demandeur=PersonneMoraleFactory(
@@ -95,6 +98,26 @@ def test_replace_mentions_in_html(key, label, expected_value, programmation_proj
     expected_text = f"<p>Voici le mot: {expected_value} vous octroie une subvention</p><p>Bravo et merci !</p>"
 
     assert expected_text == replace_mentions_in_html(html_content, programmation_projet)
+
+
+@pytest.mark.django_db
+def test_replace_mentions_in_html_multiline_address():
+    perimetre = PerimetreDepartementalFactory()
+    adresse = AdresseFactory(
+        label="DIRECTION GENERALE DES COLLECTIVITES LOCALES\r\n\r\n2 PLACE DES SAUSSAIES\r\n75008 PARIS\r\nFRANCE",
+    )
+    pp = ProgrammationProjetFactory(
+        dotation_projet__projet__dossier_ds__ds_demandeur=PersonneMoraleFactory(
+            address=adresse,
+        ),
+        dotation_projet__projet__dossier_ds__perimetre=perimetre,
+    )
+    html_content = '<p><span class="mention" data-type="mention" data-id="adresse-demandeur" data-label="Adresse du demandeur" data-mention-suggestion-char="@">@Adresse du demandeur</span></p>'
+    result = replace_mentions_in_html(html_content, pp)
+    assert (
+        result
+        == "<p>DIRECTION GENERALE DES COLLECTIVITES LOCALES<br/><br/>2 PLACE DES SAUSSAIES<br/>75008 PARIS<br/>FRANCE</p>"
+    )
 
 
 @pytest.mark.django_db

--- a/gsl_notification/utils.py
+++ b/gsl_notification/utils.py
@@ -171,7 +171,7 @@ MENTIONS = [
     Mention(
         "adresse-demandeur",
         "Adresse du demandeur",
-        "dossier.ds_demandeur.address",
+        "dossier.ds_demandeur.address.label",
     ),
     Mention(
         "date-arrete",

--- a/gsl_notification/utils.py
+++ b/gsl_notification/utils.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 import boto3
 import img2pdf
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files import File
@@ -212,7 +212,18 @@ def replace_mentions_in_html(
         key = span.get("data-id")
         if key not in MENTION_KEY_TO_MENTION:
             raise ValueError(f"Mention {key!r} inconnue.")
-        span.replace_with(MENTION_KEY_TO_MENTION[key].get_value(programmation_projet))
+        value = MENTION_KEY_TO_MENTION[key].get_value(programmation_projet)
+        normalized = value.replace("\r\n", "\n").replace("\r", "\n")
+        if "\n" in normalized:
+            lines = normalized.split("\n")
+            fragment = BeautifulSoup("", "html.parser")
+            for i, line in enumerate(lines):
+                fragment.append(NavigableString(line))
+                if i < len(lines) - 1:
+                    fragment.append(soup.new_tag("br"))
+            span.replace_with(fragment)
+        else:
+            span.replace_with(value)
 
     return str(soup)
 

--- a/gsl_simulation/resources.py
+++ b/gsl_simulation/resources.py
@@ -98,7 +98,7 @@ class BaseSimulationProjetResource(ModelResource):
         column_name="Demandeur",
     )
     arrondissement = Field(
-        attribute="projet__demandeur__address__commune__arrondissement__name",
+        attribute="projet__dossier_ds__porteur_de_projet_arrondissement__name",
         column_name="Arrondissement du demandeur",
     )
     has_double_dotations = Field(


### PR DESCRIPTION
## 🌮 Objectif

Après avoir discuté avec des utilisateurs, ils utilisent plutôt les adresses de cette manière :

DIRECTION GENERALE DES COLLECTIVITES LOCALES

2 PLACE DES SAUSSAIES

75008 PARIS
FRANCE

plutôt que "DIRECTION GENERALE DES COLLECTIVITES LOCALES, 2 PLACE DES SAUSSAIES 75008 Paris 8e Arrondissement"

avec le "FRANCE" 😄 

## ⚠️ Informations supplémentaires

D'ailleurs, maintenant on prend bien compte les sauts de ligne. Pour adresse donc, mais aussi pour les commentaires.
