### PR TITLE
Retrait du Demandeur (doublon) pour ne conserver que le demandeur au niveau du dossier

### DIFF
--- a/gsl_core/table_columns.py
+++ b/gsl_core/table_columns.py
@@ -206,7 +206,9 @@ COLUMN_NUMERO_DN = Column(
 COLUMN_DEMANDEUR = Column(
     key="demandeur",
     label="Demandeur",
-    getter=lambda ctx: _format_demandeur_nom(ctx["projet"].demandeur.name),
+    getter=lambda ctx: _format_demandeur_nom(
+        ctx["projet"].dossier_ds.ds_demandeur.raison_sociale
+    ),
     max_3_lines=True,
     sort_param="demandeur",
 )

--- a/gsl_programmation/models.py
+++ b/gsl_programmation/models.py
@@ -153,7 +153,7 @@ class Enveloppe(BaseModel):
     @property
     def demandeurs_count(self):
         return self.enveloppe_projets_included.aggregate(
-            count=models.Count("demandeur", distinct=True)
+            count=models.Count("dossier_ds__ds_demandeur", distinct=True)
         )["count"]
 
     @property

--- a/gsl_programmation/tests/test_programmation_projet_filters.py
+++ b/gsl_programmation/tests/test_programmation_projet_filters.py
@@ -15,6 +15,7 @@ from gsl_demarches_simplifiees.models import NaturePorteurProjet
 from gsl_demarches_simplifiees.tests.factories import (
     DossierFactory,
     NaturePorteurProjetFactory,
+    PersonneMoraleFactory,
 )
 from gsl_programmation.models import ProgrammationProjet
 from gsl_programmation.tests.factories import (
@@ -26,7 +27,6 @@ from gsl_programmation.utils.programmation_projet_filters import (
 )
 from gsl_projet.constants import DOTATION_DETR
 from gsl_projet.tests.factories import (
-    DemandeurFactory,
     DotationProjetFactory,
     ProjetFactory,
 )
@@ -406,18 +406,19 @@ class TestProgrammationProjetFilters:
     def test_order_filter(self, mock_request, enveloppe, arrondissement):
         """Test le filtre de tri"""
         # Créer des programmations avec différents montants
-        demandeur_a = DemandeurFactory(name="Alpha")
-        demandeur_z = DemandeurFactory(name="Zulu")
-
         dossier_a = DossierFactory(
-            finance_cout_total=Decimal("100000.00"), perimetre=arrondissement
+            finance_cout_total=Decimal("100000.00"),
+            perimetre=arrondissement,
+            ds_demandeur=PersonneMoraleFactory(raison_sociale="Alpha"),
         )
         dossier_z = DossierFactory(
-            finance_cout_total=Decimal("200000.00"), perimetre=arrondissement
+            finance_cout_total=Decimal("200000.00"),
+            perimetre=arrondissement,
+            ds_demandeur=PersonneMoraleFactory(raison_sociale="Zulu"),
         )
 
-        projet_a = ProjetFactory(dossier_ds=dossier_a, demandeur=demandeur_a)
-        projet_z = ProjetFactory(dossier_ds=dossier_z, demandeur=demandeur_z)
+        projet_a = ProjetFactory(dossier_ds=dossier_a)
+        projet_z = ProjetFactory(dossier_ds=dossier_z)
 
         dotation_a = DotationProjetFactory(projet=projet_a, dotation=DOTATION_DETR)
         dotation_z = DotationProjetFactory(projet=projet_z, dotation=DOTATION_DETR)

--- a/gsl_programmation/tests/test_views.py
+++ b/gsl_programmation/tests/test_views.py
@@ -237,7 +237,6 @@ class TestProgrammationProjetDetailView:
         projet_context = response.context["projet"]
         assert hasattr(projet_context, "dossier_ds")
         assert hasattr(projet_context, "perimetre")
-        assert hasattr(projet_context, "demandeur")
         assert hasattr(projet_context, "dotationprojet_set")
 
     def test_get_go_back_link_with_dotation_in_query_string(

--- a/gsl_programmation/utils/programmation_projet_filters.py
+++ b/gsl_programmation/utils/programmation_projet_filters.py
@@ -39,7 +39,7 @@ from gsl_projet.utils.projet_filters import (
 
 PROGRAMMATION_ORDERING_MAP = {
     "dotation_projet__projet__dossier_ds__finance_cout_total": "cout",
-    "dotation_projet__projet__demandeur__name": "demandeur",
+    "dotation_projet__projet__dossier_ds__ds_demandeur__raison_sociale": "demandeur",
     "montant": "montant",
     "dotation_projet__projet__dossier_ds__ds_number": "numero_dn",
     "dotation_projet__projet__dossier_ds__porteur_de_projet_arrondissement__name": "arrondissement",

--- a/gsl_programmation/views.py
+++ b/gsl_programmation/views.py
@@ -70,7 +70,6 @@ class ProgrammationProjetDetailView(DetailView):
                 "dossier_ds",
                 "dossier_ds__perimetre",
                 "dossier_ds__perimetre__departement",
-                "demandeur",
             )
             .prefetch_related("dotationprojet_set__detr_categories")
         )
@@ -151,8 +150,8 @@ class ProgrammationProjetListView(FilterView, ListView):
             .select_related(
                 "dotation_projet",
                 "dotation_projet__projet",
-                "dotation_projet__projet__demandeur",
                 "dotation_projet__projet__dossier_ds",
+                "dotation_projet__projet__dossier_ds__ds_demandeur",
             )
             .prefetch_related(
                 "arrete",

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -11,21 +11,7 @@ from gsl_programmation.models import ProgrammationProjet
 from gsl_simulation.models import SimulationProjet
 
 from .constants import PROJET_STATUS_CHOICES
-from .models import CategorieDetr, Demandeur, DotationProjet, Projet, ProjetQuerySet
-
-
-@admin.register(Demandeur)
-class DemandeurAdmin(AllPermsForStaffUser, admin.ModelAdmin):
-    raw_id_fields = ("address",)
-    list_display = ("name", "address__commune__departement")
-    search_fields = ("name", "siret", "address__commune__name")
-
-    def get_queryset(self, request):
-        qs = super().get_queryset(request)
-        qs = qs.select_related(
-            "address", "address__commune", "address__commune__departement"
-        )
-        return qs
+from .models import CategorieDetr, DotationProjet, Projet, ProjetQuerySet
 
 
 class DotationProjetInline(admin.TabularInline):
@@ -81,7 +67,7 @@ class ArrondissementFilter(admin.SimpleListFilter):
 
 @admin.register(Projet)
 class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
-    raw_id_fields = ("address", "demandeur", "dossier_ds")
+    raw_id_fields = ("address", "dossier_ds")
     list_display = (
         "__str__",
         "dossier_ds__projet_intitule",

--- a/gsl_projet/migrations/0036_remove_projet_demandeur_delete_demandeur.py
+++ b/gsl_projet/migrations/0036_remove_projet_demandeur_delete_demandeur.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("gsl_projet", "0035_alter_dotationprojet_assiette"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="projet",
+            name="demandeur",
+        ),
+        migrations.DeleteModel(
+            name="Demandeur",
+        ),
+    ]

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -83,16 +83,6 @@ class CategorieDetr(models.Model):
         return f"{self.rang} - {self.libelle}"
 
 
-class Demandeur(models.Model):
-    siret = models.CharField("Siret", unique=True)
-    name = models.CharField("Nom")
-
-    address = models.ForeignKey(Adresse, on_delete=models.PROTECT)
-
-    def __str__(self):
-        return f"Demandeur {self.name}"
-
-
 class ProjetQuerySet(models.QuerySet):
     def for_user(self, user: Collegue):
         if user.perimetre is None:
@@ -293,7 +283,6 @@ class ProjetManager(models.Manager.from_queryset(ProjetQuerySet)):
 
 class Projet(BaseModel):
     dossier_ds = models.OneToOneField(Dossier, on_delete=models.PROTECT)
-    demandeur = models.ForeignKey(Demandeur, on_delete=models.PROTECT, null=True)
 
     address = models.ForeignKey(Adresse, on_delete=models.PROTECT, null=True)
     departement = models.ForeignKey(Departement, on_delete=models.PROTECT, null=True)

--- a/gsl_projet/services/projet_services.py
+++ b/gsl_projet/services/projet_services.py
@@ -1,7 +1,7 @@
 import logging
 
 from gsl_demarches_simplifiees.models import Dossier
-from gsl_projet.models import Demandeur, Projet
+from gsl_projet.models import Projet
 
 logger = logging.getLogger(__name__)
 
@@ -43,15 +43,6 @@ class ProjetService:
             ds_dossier, "annotations_is_contrat_local"
         )
         projet.contrat_local = ds_dossier.annotations_contrat_local
-
-        if ds_dossier.ds_demandeur:
-            projet.demandeur, _ = Demandeur.objects.get_or_create(
-                siret=ds_dossier.ds_demandeur.siret,
-                defaults={
-                    "name": ds_dossier.ds_demandeur.raison_sociale,
-                    "address": ds_dossier.ds_demandeur.address,
-                },
-            )
 
         projet.save()
         return projet

--- a/gsl_projet/templates/gsl_projet/projet_missing_annotations_list.html
+++ b/gsl_projet/templates/gsl_projet/projet_missing_annotations_list.html
@@ -83,7 +83,7 @@
                                         </a>
                                     </td>
                                     <td>
-                                        {{ projet.demandeur.name|format_demandeur_nom }}
+                                        {{ projet.dossier_ds.ds_demandeur.raison_sociale|format_demandeur_nom }}
                                     </td>
                                     <td>
                                         {% for detail in projet.dossier_ds.missing_annotations_details %}

--- a/gsl_projet/tests/factories.py
+++ b/gsl_projet/tests/factories.py
@@ -14,17 +14,7 @@ from gsl_projet.constants import (
     PROJET_STATUS_CHOICES,
 )
 
-from ..models import CategorieDetr, Demandeur, DotationProjet, Projet, ProjetNote
-
-
-class DemandeurFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = Demandeur
-
-    siret = factory.Sequence(lambda n: f"siret-{n}")
-    name = factory.Faker("city", locale="fr_FR")
-
-    address = factory.SubFactory(AdresseFactory)
+from ..models import CategorieDetr, DotationProjet, Projet, ProjetNote
 
 
 class ProjetFactory(factory.django.DjangoModelFactory):
@@ -34,7 +24,6 @@ class ProjetFactory(factory.django.DjangoModelFactory):
     dossier_ds = factory.SubFactory(DossierFactory)
     address = factory.SubFactory(AdresseFactory)
     departement = factory.SubFactory(DepartementFactory)
-    demandeur = factory.SubFactory(DemandeurFactory)
 
 
 class SubmittedProjetFactory(ProjetFactory):

--- a/gsl_projet/tests/test_factories.py
+++ b/gsl_projet/tests/test_factories.py
@@ -1,12 +1,10 @@
 import pytest
 
 from gsl_core.tests.factories import DepartementFactory
-from gsl_demarches_simplifiees.tests.factories import PersonneMoraleFactory
 
-from ..models import CategorieDetr, Demandeur, DotationProjet, Projet, ProjetNote
+from ..models import CategorieDetr, DotationProjet, Projet, ProjetNote
 from .factories import (
     CategorieDetrFactory,
-    DemandeurFactory,
     DotationProjetFactory,
     ProcessedProjetFactory,
     ProjetFactory,
@@ -17,7 +15,6 @@ from .factories import (
 pytestmark = pytest.mark.django_db
 
 test_data = (
-    (DemandeurFactory, Demandeur),
     (ProjetFactory, Projet),
     (SubmittedProjetFactory, Projet),
     (ProcessedProjetFactory, Projet),
@@ -32,12 +29,6 @@ def test_every_factory_can_be_called_twice(factory, expected_class):
     for _ in range(2):
         obj = factory()
         assert isinstance(obj, expected_class)
-
-
-def test_projet_factory_can_be_called_twice_with_same_demandeur():
-    demandeur = PersonneMoraleFactory()
-    ProjetFactory.create_batch(2, dossier_ds__ds_demandeur=demandeur)
-    assert Projet.objects.count() == 2
 
 
 def test_category_detr_factory_can_be_called_twice_with_same_parameters():

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -22,9 +22,8 @@ from gsl_demarches_simplifiees.models import NaturePorteurProjet
 from gsl_demarches_simplifiees.tests.factories import NaturePorteurProjetFactory
 from gsl_programmation.tests.factories import ProgrammationProjetFactory
 from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL
-from gsl_projet.models import Demandeur, Projet
+from gsl_projet.models import Projet
 from gsl_projet.tests.factories import (
-    DemandeurFactory,
     DetrProjetFactory,
     DsilProjetFactory,
     ProjetFactory,
@@ -57,11 +56,6 @@ def finisterien(perimetre) -> Collegue:
 
 
 @pytest.fixture
-def demandeur() -> Demandeur:
-    return DemandeurFactory()
-
-
-@pytest.fixture
 def req(finisterien) -> RequestFactory:
     return RequestFactory(user=finisterien)
 
@@ -81,8 +75,14 @@ def view() -> ProjetListView:
         ("date", (F("dossier_ds__ds_date_depot").asc(nulls_last=True),)),
         ("-cout", (F("dossier_ds__finance_cout_total").desc(nulls_last=True),)),
         ("cout", (F("dossier_ds__finance_cout_total").asc(nulls_last=True),)),
-        ("-demandeur", (F("demandeur__name").desc(nulls_last=True),)),
-        ("demandeur", (F("demandeur__name").asc(nulls_last=True),)),
+        (
+            "-demandeur",
+            (F("dossier_ds__ds_demandeur__raison_sociale").desc(nulls_last=True),),
+        ),
+        (
+            "demandeur",
+            (F("dossier_ds__ds_demandeur__raison_sociale").asc(nulls_last=True),),
+        ),
         (
             None,
             (F("dossier_ds__ds_date_depot").desc(nulls_last=True),),
@@ -106,16 +106,16 @@ def test_get_ordering(req, view, tri_param, expected_ordering):
 
 
 @pytest.fixture
-def projets(demandeur) -> list[Projet]:
+def projets() -> list[Projet]:
     projet0 = ProjetFactory(
         dossier_ds__ds_date_depot=timezone.datetime(2024, 9, 1, tzinfo=UTC),
         dossier_ds__finance_cout_total=1000,
-        demandeur__name="Commune A",
+        dossier_ds__ds_demandeur__raison_sociale="Commune A",
     )
     projet1 = ProjetFactory(
         dossier_ds__ds_date_depot=timezone.datetime(2024, 9, 2, tzinfo=UTC),
         dossier_ds__finance_cout_total=2000,
-        demandeur__name="Commune B",
+        dossier_ds__ds_demandeur__raison_sociale="Commune B",
     )
     return [projet0, projet1]
 
@@ -145,39 +145,31 @@ def test_projets_ordering(req, view, projets, tri_param, expected_ordering):
 
 
 @pytest.fixture
-def projets_detr(demandeur) -> list[Projet]:
-    dotation_projets = DetrProjetFactory.create_batch(
-        3,
-        projet__demandeur=demandeur,
-    )
+def projets_detr() -> list[Projet]:
+    dotation_projets = DetrProjetFactory.create_batch(3)
     return [dp.projet for dp in dotation_projets]
 
 
 @pytest.fixture
-def projets_dsil(demandeur) -> list[Projet]:
-    dotation_projets = DsilProjetFactory.create_batch(
-        2,
-        projet__demandeur=demandeur,
-    )
+def projets_dsil() -> list[Projet]:
+    dotation_projets = DsilProjetFactory.create_batch(2)
     return [dp.projet for dp in dotation_projets]
 
 
 @pytest.fixture
-def projets_with_double_dotations_values(demandeur) -> list[Projet]:
+def projets_with_double_dotations_values() -> list[Projet]:
     projets = []
     for _ in range(4):
-        detr_projet = DetrProjetFactory(projet__demandeur=demandeur)
+        detr_projet = DetrProjetFactory()
         DsilProjetFactory(projet=detr_projet.projet)
         projets.append(detr_projet.projet)
     return projets
 
 
 @pytest.fixture
-def projets_with_other_dotations_values(demandeur) -> list[Projet]:
+def projets_with_other_dotations_values() -> list[Projet]:
     return [
-        ProjetFactory(
-            dossier_ds__demande_dispositif_sollicite=dotation, demandeur=demandeur
-        )
+        ProjetFactory(dossier_ds__demande_dispositif_sollicite=dotation)
         for dotation in (
             "",
             "Fond vert",
@@ -356,7 +348,7 @@ def test_no_dispositif_filter(
 
 
 @pytest.fixture
-def projets_epci(demandeur) -> list[Projet]:
+def projets_epci() -> list[Projet]:
     projets = []
     for epci_label in (
         "EPCI",
@@ -368,7 +360,6 @@ def projets_epci(demandeur) -> list[Projet]:
         )
         projets.append(
             ProjetFactory(
-                demandeur=demandeur,
                 dossier_ds__porteur_de_projet_nature=nature_porteur_projet,
             )
         )
@@ -376,20 +367,19 @@ def projets_epci(demandeur) -> list[Projet]:
 
 
 @pytest.fixture
-def projets_communes(demandeur) -> list[Projet]:
+def projets_communes() -> list[Projet]:
     for commune_label in ("Commune",):
         nature_porteur_projet = NaturePorteurProjetFactory(
             label=commune_label, type=NaturePorteurProjet.COMMUNES
         )
         projet = ProjetFactory(
-            demandeur=demandeur,
             dossier_ds__porteur_de_projet_nature=nature_porteur_projet,
         )
     return [projet]
 
 
 @pytest.fixture
-def projets_other(demandeur) -> list[Projet]:
+def projets_other() -> list[Projet]:
     projets = []
     for commune_label in ("test_gsl", "Departement"):
         nature_porteur_projet = NaturePorteurProjetFactory(
@@ -397,7 +387,6 @@ def projets_other(demandeur) -> list[Projet]:
         )
         projets.append(
             ProjetFactory(
-                demandeur=demandeur,
                 dossier_ds__porteur_de_projet_nature=nature_porteur_projet,
             )
         )
@@ -405,13 +394,12 @@ def projets_other(demandeur) -> list[Projet]:
 
 
 @pytest.fixture
-def projets_unknown_projet(demandeur) -> list[Projet]:
+def projets_unknown_projet() -> list[Projet]:
     projets = []
     for porteur_label in ("Inconnu", "Fake", "Wrong"):
         nature_porteur_projet = NaturePorteurProjetFactory(label=porteur_label)
         projets.append(
             ProjetFactory(
-                demandeur=demandeur,
                 dossier_ds__porteur_de_projet_nature=nature_porteur_projet,
             )
         )
@@ -449,14 +437,9 @@ def test_filter_by_epci_porteur(
 
 
 @pytest.fixture
-def projets_with_finance_cout_total_from_dossier_ds(
-    demandeur,
-) -> list[Projet]:
+def projets_with_finance_cout_total_from_dossier_ds() -> list[Projet]:
     return [
-        ProjetFactory(
-            dossier_ds__finance_cout_total=amount,
-            demandeur=demandeur,
-        )
+        ProjetFactory(dossier_ds__finance_cout_total=amount)
         for amount in (120_000, 170_000, 220_000, 270_000, 320_000)
     ]
 
@@ -516,7 +499,7 @@ def test_filter_with_wrong_values(
 
 
 @pytest.fixture
-def projets_with_montant_retenu(demandeur, perimetre) -> list[Projet]:
+def projets_with_montant_retenu(perimetre) -> list[Projet]:
     projets = []
     for detr_montant, dsil_montant in (
         (None, 50_000),
@@ -527,7 +510,6 @@ def projets_with_montant_retenu(demandeur, perimetre) -> list[Projet]:
         (150_000, 150_000),
     ):
         projet = ProjetFactory(
-            demandeur=demandeur,
             dossier_ds__perimetre=perimetre,
         )
         detr_projet = DetrProjetFactory(projet=projet)
@@ -646,11 +628,11 @@ def test_order_by_montant_retenu(req, view, projets_with_montant_retenu):
     assert qs[0].dotation_detr.montant_retenu == 150_000
 
 
-def test_order_by_assiette(req, view, demandeur, perimetre):
-    projet_low = ProjetFactory(demandeur=demandeur, dossier_ds__perimetre=perimetre)
+def test_order_by_assiette(req, view, perimetre):
+    projet_low = ProjetFactory(dossier_ds__perimetre=perimetre)
     DetrProjetFactory(projet=projet_low, assiette=Decimal("50000"))
 
-    projet_high = ProjetFactory(demandeur=demandeur, dossier_ds__perimetre=perimetre)
+    projet_high = ProjetFactory(dossier_ds__perimetre=perimetre)
     DetrProjetFactory(projet=projet_high, assiette=Decimal("200000"))
 
     request = req.get("/", data={"order": "assiette"})
@@ -661,14 +643,14 @@ def test_order_by_assiette(req, view, demandeur, perimetre):
     assert result.index(projet_low) < result.index(projet_high)
 
 
-def test_order_by_taux(req, view, demandeur, perimetre):
+def test_order_by_taux(req, view, perimetre):
     # projet_low: montant=10000, assiette=100000 -> taux=10%
-    projet_low = ProjetFactory(demandeur=demandeur, dossier_ds__perimetre=perimetre)
+    projet_low = ProjetFactory(dossier_ds__perimetre=perimetre)
     dp_low = DetrProjetFactory(projet=projet_low, assiette=Decimal("100000"))
     ProgrammationProjetFactory(dotation_projet=dp_low, montant=Decimal("10000"))
 
     # projet_high: montant=80000, assiette=100000 -> taux=80%
-    projet_high = ProjetFactory(demandeur=demandeur, dossier_ds__perimetre=perimetre)
+    projet_high = ProjetFactory(dossier_ds__perimetre=perimetre)
     dp_high = DetrProjetFactory(projet=projet_high, assiette=Decimal("100000"))
     ProgrammationProjetFactory(dotation_projet=dp_high, montant=Decimal("80000"))
 
@@ -680,14 +662,12 @@ def test_order_by_taux(req, view, demandeur, perimetre):
     assert result.index(projet_low) < result.index(projet_high)
 
 
-def test_order_by_numero_dn(req, view, demandeur, perimetre):
+def test_order_by_numero_dn(req, view, perimetre):
     projet_low = ProjetFactory(
-        demandeur=demandeur,
         dossier_ds__ds_number=1000,
         dossier_ds__perimetre=perimetre,
     )
     projet_high = ProjetFactory(
-        demandeur=demandeur,
         dossier_ds__ds_number=9000,
         dossier_ds__perimetre=perimetre,
     )
@@ -704,12 +684,9 @@ def test_order_by_numero_dn(req, view, demandeur, perimetre):
 
 
 @pytest.fixture
-def projets_with_montant_demande(demandeur) -> list[Projet]:
+def projets_with_montant_demande() -> list[Projet]:
     return [
-        ProjetFactory(
-            dossier_ds__demande_montant=amount,
-            demandeur=demandeur,
-        )
+        ProjetFactory(dossier_ds__demande_montant=amount)
         for amount in (None, 30_000, 60_000, 90_000, 120_000, 150_000)
     ]
 
@@ -771,7 +748,7 @@ def test_filter_with_wrong_montant_demande_values(
 
 
 @pytest.fixture
-def projets_with_status(demandeur) -> list[Projet]:
+def projets_with_status() -> list[Projet]:
     projets = []
     for status, count in (
         ("accepted", 1),
@@ -780,7 +757,7 @@ def projets_with_status(demandeur) -> list[Projet]:
         ("dismissed", 5),
     ):
         for _ in range(count):
-            projet = ProjetFactory(demandeur=demandeur)
+            projet = ProjetFactory()
             DetrProjetFactory(projet=projet, status=status)
             projets.append(projet)
     return projets

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -74,7 +74,7 @@ DOTATION_CHOICES = (
 ORDERING_MAP = {
     "dossier_ds__ds_date_depot": "date",
     "dossier_ds__finance_cout_total": "cout",
-    "demandeur__name": "demandeur",
+    "dossier_ds__ds_demandeur__raison_sociale": "demandeur",
     "dossier_ds__ds_number": "numero_dn",
     "dossier_ds__porteur_de_projet_arrondissement__name": "arrondissement",
     "dossier_ds__porteur_de_projet_nom": "nom_demandeur",

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -218,8 +218,8 @@ class ProjetListViewFilters(ProjetFilters):
         qs = qs.select_related(
             "address",
             "address__commune",
-            "demandeur",
             "dossier_ds",
+            "dossier_ds__ds_demandeur",
         ).prefetch_related(
             "dossier_ds__perimetre",
             "dossier_ds__demande_categorie_detr",
@@ -295,9 +295,9 @@ class ProjetMissingAnnotationsListView(ListView):
             Projet.objects.for_user(self.request.user)
             .with_missing_annotations()
             .select_related(
-                "demandeur",
                 "dossier_ds",
+                "dossier_ds__ds_demandeur",
             )
-            .prefetch_related("dotationprojet_set")
+            .prefetch_related("dotationprojet_set", "dossier_ds__ds_demarche")
             .order_by("-dossier_ds__ds_date_depot")
         )

--- a/gsl_simulation/resources.py
+++ b/gsl_simulation/resources.py
@@ -94,7 +94,7 @@ class BaseSimulationProjetResource(ModelResource):
         column_name="Intitulé du projet",
     )
     demandeur_name = Field(
-        attribute="projet__demandeur__name",
+        attribute="projet__dossier_ds__ds_demandeur__raison_sociale",
         column_name="Demandeur",
     )
     arrondissement = Field(

--- a/gsl_simulation/tests/views/test_filters.py
+++ b/gsl_simulation/tests/views/test_filters.py
@@ -26,7 +26,6 @@ from gsl_programmation.tests.factories import (
 from gsl_projet.models import Projet
 from gsl_projet.services.dotation_projet_services import DotationProjetService
 from gsl_projet.tests.factories import (
-    DemandeurFactory,
     DotationProjetFactory,
     ProjetFactory,
 )
@@ -98,7 +97,6 @@ def projets(simulation, perimetre_departemental):
             DsilEnveloppeFactory(perimetre=perimetre, annee=year)
 
     for perimetre in (perimetre_departemental, other_perimeter):
-        demandeur = DemandeurFactory()
         for dotation in ("DETR", "DSIL"):
             for state in (
                 Dossier.STATE_ACCEPTE,
@@ -119,7 +117,6 @@ def projets(simulation, perimetre_departemental):
                 )
                 projet_last_year = ProjetFactory(
                     dossier_ds=dossier_last_year,
-                    demandeur=demandeur,
                 )
                 projets.append(projet_last_year)
 
@@ -136,10 +133,8 @@ def projets(simulation, perimetre_departemental):
                 )
                 projet_current_year = ProjetFactory(
                     dossier_ds=dossier_current_year,
-                    demandeur=demandeur,
                 )
                 projets.append(projet_current_year)
-            demandeur = DemandeurFactory()
             for state in (Dossier.STATE_EN_CONSTRUCTION, Dossier.STATE_EN_INSTRUCTION):
                 dossier_last_year = DossierFactory(
                     ds_state=state,
@@ -153,7 +148,6 @@ def projets(simulation, perimetre_departemental):
                 )
                 projet_last_year = ProjetFactory(
                     dossier_ds=dossier_last_year,
-                    demandeur=demandeur,
                 )
                 projets.append(projet_last_year)
 
@@ -169,7 +163,6 @@ def projets(simulation, perimetre_departemental):
                 )
                 projet_current_year = ProjetFactory(
                     dossier_ds=dossier_current_year,
-                    demandeur=demandeur,
                 )
                 projets.append(projet_current_year)
     for projet in projets:

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -174,7 +174,7 @@ class SimulationDetailView(SingleObjectMixin, FilterView):
             Projet.objects.filter(
                 dotationprojet__simulationprojet__simulation=self.object
             )
-            .select_related("demandeur", "address", "address__commune")
+            .select_related("address", "address__commune")
             .prefetch_related(
                 "dotationprojet_set",
                 "dotationprojet_set__programmation_projet",
@@ -182,6 +182,7 @@ class SimulationDetailView(SingleObjectMixin, FilterView):
                 "dossier_ds__demande_categorie_detr",
                 "dossier_ds__demande_categorie_dsil",
                 "dossier_ds__porteur_de_projet_arrondissement",
+                "dossier_ds__ds_demandeur",
                 "dossier_ds__ds_demarche",
                 "dossier_ds__demande_cofinancements",
                 "dossier_ds__projet_zonage",
@@ -342,16 +343,22 @@ class FilteredProjetsExportView(SimulationDetailView):
 
         self.object = self.get_object()
         queryset = self.get_projet_queryset()
-        simu_projet_qs = SimulationProjet.objects.filter(
-            simulation=self.object, dotation_projet__projet__in=queryset
-        ).select_related(
-            "dotation_projet",
-            "dotation_projet__projet",
-            "dotation_projet__projet__dossier_ds",
-            "dotation_projet__projet__demandeur",
-            "dotation_projet__projet__demandeur__address",
-            "dotation_projet__projet__demandeur__address__commune",
-            "dotation_projet__projet__demandeur__address__commune__arrondissement",
+        simu_projet_qs = (
+            SimulationProjet.objects.filter(
+                simulation=self.object, dotation_projet__projet__in=queryset
+            )
+            .select_related(
+                "dotation_projet",
+                "dotation_projet__projet",
+                "dotation_projet__projet__dossier_ds",
+                "dotation_projet__projet__dossier_ds__ds_demandeur",
+            )
+            .prefetch_related(
+                "dotation_projet__projet__dotationprojet_set",
+                "dotation_projet__projet__dossier_ds__demande_categorie_detr",
+                "dotation_projet__projet__dossier_ds__demande_categorie_dsil",
+                "dotation_projet__projet__dossier_ds__porteur_de_projet_arrondissement",
+            )
         )
 
         resource = (


### PR DESCRIPTION
## 🌮 Objectif

Simplifier le code, et faire moins d'opérations inutiles.
