### PR TITLE
Ajout d'un filtre EPCI sur les pages projet, programmation et simulation

### DIFF
--- a/gsl_programmation/utils/programmation_projet_filters.py
+++ b/gsl_programmation/utils/programmation_projet_filters.py
@@ -162,6 +162,13 @@ class ProgrammationProjetFilters(FilterSet):
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
     )
 
+    epci = MultipleChoiceFilter(
+        label="EPCI",
+        field_name="dotation_projet__projet__dossier_ds__porteur_de_projet_epci",
+        choices=[],
+        widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
+    )
+
     filter_boolean = staticmethod(filter_boolean)
     filter_dotation_sollicitee = staticmethod(filter_dotation_sollicitee)
     filter_dossier_complet = staticmethod(filter_dossier_complet)
@@ -216,6 +223,7 @@ class ProgrammationProjetFilters(FilterSet):
         model = ProgrammationProjet
         fields = (
             "territoire",
+            "epci",
             "categorie_detr",
             "categorie_dsil",
             "porteur",
@@ -290,6 +298,16 @@ class ProgrammationProjetFilters(FilterSet):
             )
             .distinct()
             .order_by("id")
+        )
+
+        self.filters["epci"].extra["choices"] = tuple(
+            (epci, epci.split(" - ", 1)[1] if " - " in epci else epci)
+            for epci in visible_dossiers.values_list(
+                "porteur_de_projet_epci", flat=True
+            )
+            .distinct()
+            .order_by("porteur_de_projet_epci")
+            if epci
         )
 
     @property

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -284,6 +284,12 @@ class ProjetFilters(FilterSet):
         ),
     )
 
+    epci = MultipleChoiceFilter(
+        label="EPCI",
+        field_name="dossier_ds__porteur_de_projet_epci",
+        widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
+    )
+
     budget_vert_demandeur = MultipleChoiceFilter(
         label="Budget vert (demandeur)",
         field_name="dossier_ds__environnement_transition_eco",
@@ -362,6 +368,7 @@ class ProjetFilters(FilterSet):
         model = Projet
         fields = (
             "territoire",
+            "epci",
             "dotation",
             "porteur",
             "categorie_detr",

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -147,6 +147,16 @@ class ProjetListViewFilters(ProjetFilters):
 
         visible_dossiers = visible_projets.values("dossier_ds")
 
+        self.filters["epci"].extra["choices"] = tuple(
+            (epci, epci.split(" - ", 1)[1] if " - " in epci else epci)
+            for epci in visible_projets.values_list(
+                "dossier_ds__porteur_de_projet_epci", flat=True
+            )
+            .distinct()
+            .order_by("dossier_ds__porteur_de_projet_epci")
+            if epci
+        )
+
         self.filters["cofinancement"].extra["choices"] = tuple(
             (str(c.id), c.label)
             for c in Cofinancement.objects.filter(dossier__in=visible_dossiers)

--- a/gsl_simulation/filters.py
+++ b/gsl_simulation/filters.py
@@ -95,6 +95,16 @@ class SimulationProjetFilters(FilterSet):
             .order_by("id")
         )
 
+        self.filters["epci"].extra["choices"] = tuple(
+            (epci, epci.split(" - ", 1)[1] if " - " in epci else epci)
+            for epci in self.queryset.values_list(
+                "dossier_ds__porteur_de_projet_epci", flat=True
+            )
+            .distinct()
+            .order_by("dossier_ds__porteur_de_projet_epci")
+            if epci
+        )
+
     SIMULATION_ORDERING_MAP = {
         **ORDERING_MAP,
         "simu_montant": "montant_previsionnel",
@@ -240,6 +250,13 @@ class SimulationProjetFilters(FilterSet):
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
     )
 
+    epci = MultipleChoiceFilter(
+        label="EPCI",
+        field_name="dossier_ds__porteur_de_projet_epci",
+        choices=[],
+        widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
+    )
+
     order = ProjetOrderingFilter(
         fields=SIMULATION_ORDERING_MAP,
         empty_label="Tri",
@@ -276,6 +293,7 @@ class SimulationProjetFilters(FilterSet):
         model = Projet
         fields = (
             "territoire",
+            "epci",
             "categorie_detr",
             "categorie_dsil",
             "porteur",


### PR DESCRIPTION
## 🌮 Objectif

Ajout d'un filtre EPCI sur les pages projet, programmation et simulation.

## 🔍 Liste des modifications

- Correction du code de construction des choix EPCI dans `ProjetListViewFilters` (suppression du `print`, fix de la logique qui écrasait le tuple à chaque itération)
- Ajout du filtre `epci` dans `ProjetFilters` (`gsl_projet`)
- Ajout du filtre `epci` dans `ProgrammationProjetFilters` (`gsl_programmation`)
- Ajout du filtre `epci` dans `SimulationProjetFilters` (`gsl_simulation`)