### PR TITLE
Mise à jour de l'enveloppe lorsqu'on modifie les montants des projets acceptés

### DIFF
--- a/gsl_core/templates/includes/_enveloppe_summary_line.html
+++ b/gsl_core/templates/includes/_enveloppe_summary_line.html
@@ -1,6 +1,8 @@
 {% load gsl_filters %}
 
-<tr class="{% if level == 2 %}sous-enveloppe{% else %}fr-text--bold{% endif %}">
+<tr id="enveloppe-summary-line-{{ enveloppe.id }}"
+    {% if oob_swap %}hx-swap-oob="outerHTML"{% endif %}
+    class="{% if level == 2 %}sous-enveloppe{% else %}fr-text--bold{% endif %}">
     <td>
         {% if enveloppe.is_deleguee %}
             <div class="sub">

--- a/gsl_simulation/templates/htmx/projet_update.html
+++ b/gsl_simulation/templates/htmx/projet_update.html
@@ -5,4 +5,5 @@
 <span hx-swap-oob="innerHTML" id="total-amount-granted">{{ total_amount_granted | euro }}</span>
 <template>
     {% include "includes/_simulation_detail_row.html" %}
+    {% include "includes/_enveloppe_summary_line.html" with enveloppe=enveloppe oob_swap=True %}
 </template>

--- a/gsl_simulation/templates/htmx/projet_update.html
+++ b/gsl_simulation/templates/htmx/projet_update.html
@@ -5,5 +5,7 @@
 <span hx-swap-oob="innerHTML" id="total-amount-granted">{{ total_amount_granted | euro }}</span>
 <template>
     {% include "includes/_simulation_detail_row.html" %}
-    {% include "includes/_enveloppe_summary_line.html" with enveloppe=enveloppe oob_swap=True %}
+    {% if enveloppe %}
+        {% include "includes/_enveloppe_summary_line.html" with enveloppe=enveloppe oob_swap=True %}
+    {% endif %}
 </template>

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -34,6 +34,7 @@ from gsl_core.templatetags.gsl_filters import euro
 from gsl_core.view_mixins import OpenHtmxModalMixin
 from gsl_demarches_simplifiees.exceptions import DsServiceException
 from gsl_demarches_simplifiees.importer.dossier import save_one_dossier_from_ds
+from gsl_programmation.models import Enveloppe
 from gsl_projet.constants import (
     DOTATION_DETR,
     DOTATION_DSIL,
@@ -113,6 +114,7 @@ class SimulationTableCellEditMixin(UpdateView):
         total_amount_granted = self.object.simulation.get_total_amount_granted(
             self._get_projets_queryset_with_filters()
         )
+        enveloppe = Enveloppe.objects.get(pk=self.object.simulation.enveloppe_id)
 
         return render(
             self.request,
@@ -125,6 +127,7 @@ class SimulationTableCellEditMixin(UpdateView):
                 "total_amount_granted": total_amount_granted,
                 "columns": SIMULATION_TABLE_COLUMNS,
                 "dotations": DOTATIONS,
+                "enveloppe": enveloppe,
             },
         )
 

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -114,22 +114,23 @@ class SimulationTableCellEditMixin(UpdateView):
         total_amount_granted = self.object.simulation.get_total_amount_granted(
             self._get_projets_queryset_with_filters()
         )
-        enveloppe = Enveloppe.objects.get(pk=self.object.simulation.enveloppe_id)
+        context = {
+            "simu": self.object,
+            "dotation_projet": self.object.dotation_projet,
+            "projet": self.object.projet,
+            "status_summary": self.object.simulation.get_projet_status_summary(),
+            "total_amount_granted": total_amount_granted,
+            "columns": SIMULATION_TABLE_COLUMNS,
+            "dotations": DOTATIONS,
+        }
+        # We only update the enveloppe summary line when the project is accepted,
+        # as it's the only case when the enveloppe amount can be changed
+        if self.object.status == SimulationProjet.STATUS_ACCEPTED:
+            context["enveloppe"] = Enveloppe.objects.get(
+                pk=self.object.simulation.enveloppe_id
+            )
 
-        return render(
-            self.request,
-            "htmx/projet_update.html",
-            {
-                "simu": self.object,
-                "dotation_projet": self.object.dotation_projet,
-                "projet": self.object.projet,
-                "status_summary": self.object.simulation.get_projet_status_summary(),
-                "total_amount_granted": total_amount_granted,
-                "columns": SIMULATION_TABLE_COLUMNS,
-                "dotations": DOTATIONS,
-                "enveloppe": enveloppe,
-            },
-        )
+        return render(self.request, "htmx/projet_update.html", context=context)
 
 
 class EditAssietteView(SimulationTableCellEditMixin):


### PR DESCRIPTION
## 🌮 Objectif

Vu que HTMX met à jour les montants, alors il faut qu'il mette à jour l'enveloppe d'une simulation !
