### PR TITLE
Éviter les timeouts Scalingo du proxy DS via un heartbeat streamé

### DIFF
--- a/gsl_ds_proxy/tests/test_views.py
+++ b/gsl_ds_proxy/tests/test_views.py
@@ -10,6 +10,14 @@ from gsl_demarches_simplifiees.tests.factories import (
 from gsl_ds_proxy.tests.factories import ProxyTokenFactory
 
 
+def _read_stream(response):
+    return b"".join(response.streaming_content)
+
+
+def _parse_stream(response):
+    return json.loads(_read_stream(response).lstrip())
+
+
 @override_settings(DS_API_TOKEN="test-ds-token", DS_API_URL="https://ds.test/graphql")
 class GraphqlProxyViewTest(TestCase):
     def setUp(self):
@@ -121,7 +129,7 @@ class GraphqlProxyViewTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        data = response.json()
+        data = _parse_stream(response)
         nodes = data["data"]["demarche"]["dossiers"]["nodes"]
         self.assertEqual(len(nodes), 1)
         self.assertEqual(nodes[0]["number"], 1)
@@ -140,7 +148,12 @@ class GraphqlProxyViewTest(TestCase):
         mock_post.side_effect = req.exceptions.ConnectionError()
 
         response = self._post(self._get_demarche_payload())
-        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertEqual(
+            data,
+            {"errors": [{"message": "Erreur de connexion à Démarches Simplifiées."}]},
+        )
 
     @patch("gsl_ds_proxy.views.requests.post")
     def test_ds_http_error(self, mock_post):
@@ -150,7 +163,12 @@ class GraphqlProxyViewTest(TestCase):
         mock_post.return_value.raise_for_status.side_effect = req.exceptions.HTTPError()
 
         response = self._post(self._get_demarche_payload())
-        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertEqual(
+            data,
+            {"errors": [{"message": "Erreur de Démarches Simplifiées."}]},
+        )
 
     def test_getDemarche_wrong_demarche_number_rejected(self):
         response = self._post(self._get_demarche_payload(demarche_number=999))
@@ -186,6 +204,8 @@ class GraphqlProxyViewTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertIn("data", data)
 
     @patch("gsl_ds_proxy.views.requests.post")
     def test_getDossier_of_other_demarche_rejected(self, mock_post):
@@ -207,7 +227,9 @@ class GraphqlProxyViewTest(TestCase):
                 "variables": {"dossierNumber": 42},
             }
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertIn("errors", data)
 
     @patch("gsl_ds_proxy.views.requests.post")
     def test_getDossier_without_demarche_in_response_rejected(self, mock_post):
@@ -222,7 +244,9 @@ class GraphqlProxyViewTest(TestCase):
                 "variables": {"dossierNumber": 42},
             }
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertIn("errors", data)
 
     def test_getGroupeInstructeur_rejected(self):
         response = self._post(
@@ -262,7 +286,9 @@ class GraphqlProxyViewTest(TestCase):
                 "variables": {"demarcheNumber": self.demarche.ds_number},
             }
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertIn("errors", data)
 
     @patch("gsl_ds_proxy.views.requests.post")
     def test_getDemarche_response_without_number_field_rejected(self, mock_post):
@@ -278,7 +304,9 @@ class GraphqlProxyViewTest(TestCase):
                 "variables": {"demarcheNumber": self.demarche.ds_number},
             }
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertIn("errors", data)
 
     def test_mutation_with_leading_whitespace_rejected(self):
         response = self._post({"query": "\n\n  mutation { dossierAccepter { id } }"})
@@ -317,15 +345,26 @@ class GraphqlProxyViewTest(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertEqual(data["data"]["demarche"]["number"], self.demarche.ds_number)
 
     @patch("gsl_ds_proxy.views.requests.post")
-    def test_ds_timeout_returns_504(self, mock_post):
+    def test_ds_timeout_returns_in_band_error(self, mock_post):
         import requests as req
 
         mock_post.side_effect = req.exceptions.Timeout()
 
         response = self._post(self._get_demarche_payload())
-        self.assertEqual(response.status_code, 504)
+        self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertEqual(
+            data,
+            {
+                "errors": [
+                    {"message": "Délai d'attente dépassé pour Démarches Simplifiées."}
+                ]
+            },
+        )
 
     @patch("gsl_ds_proxy.views.requests.post")
     def test_query_forwarded_verbatim(self, mock_post):
@@ -345,13 +384,15 @@ class GraphqlProxyViewTest(TestCase):
             "query getDemarche { demarche { number dossiers { nodes "
             "{ number groupeInstructeur { instructeurs { id } } } } } }"
         )
-        self._post(
+        response = self._post(
             {
                 "query": query,
                 "operationName": "getDemarche",
                 "variables": {"demarcheNumber": self.demarche.ds_number},
             }
         )
+        # Drain the stream so the view has actually called DS.
+        _read_stream(response)
         self.assertEqual(mock_post.call_args.kwargs["json"]["query"], query)
 
     def test_document_with_multiple_operations_requires_operationName(self):
@@ -405,12 +446,104 @@ class GraphqlProxyViewTest(TestCase):
                 }
             }
         }
-        self._post(
+        response = self._post(
             {
                 "query": "query getDemarche { demarche { number } }",
                 "operationName": "getDemarche",
                 "variables": {"demarcheNumber": self.demarche.ds_number},
             }
         )
-        self.assertIn("timeout", mock_post.call_args.kwargs)
-        self.assertIsNotNone(mock_post.call_args.kwargs["timeout"])
+        _read_stream(response)
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], (5, 55))
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    def test_first_byte_is_heartbeat_space(self, mock_post):
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_post.return_value.json.return_value = {
+            "data": {
+                "demarche": {
+                    "number": self.demarche.ds_number,
+                    "dossiers": {"nodes": []},
+                }
+            }
+        }
+        response = self._post(
+            {
+                "query": "query getDemarche { demarche { number } }",
+                "operationName": "getDemarche",
+                "variables": {"demarcheNumber": self.demarche.ds_number},
+            }
+        )
+        first_chunk = next(iter(response.streaming_content))
+        self.assertEqual(first_chunk, b" ")
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    def test_final_payload_is_valid_json_with_leading_heartbeat(self, mock_post):
+        ds_data = {
+            "data": {
+                "demarche": {
+                    "number": self.demarche.ds_number,
+                    "dossiers": {"nodes": []},
+                }
+            }
+        }
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_post.return_value.json.return_value = ds_data
+
+        response = self._post(
+            {
+                "query": "query getDemarche { demarche { number } }",
+                "operationName": "getDemarche",
+                "variables": {"demarcheNumber": self.demarche.ds_number},
+            }
+        )
+        stream_bytes = _read_stream(response)
+        self.assertTrue(stream_bytes.startswith(b" "))
+        self.assertEqual(json.loads(stream_bytes.lstrip()), ds_data)
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    def test_connection_error_during_streaming_yields_graphql_error_with_200(
+        self, mock_post
+    ):
+        import requests as req
+
+        mock_post.side_effect = req.exceptions.ConnectionError()
+
+        response = self._post(self._get_demarche_payload())
+        self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertEqual(
+            data["errors"][0]["message"],
+            "Erreur de connexion à Démarches Simplifiées.",
+        )
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    def test_scope_check_failure_during_streaming_yields_graphql_error_with_200(
+        self, mock_post
+    ):
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_post.return_value.json.return_value = {
+            "data": {
+                "demarche": {
+                    "number": 999,
+                    "dossiers": {"nodes": []},
+                }
+            }
+        }
+        response = self._post(
+            {
+                "query": "query getDemarche { demarche { number } }",
+                "operationName": "getDemarche",
+                "variables": {"demarcheNumber": self.demarche.ds_number},
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertEqual(
+            data["errors"][0]["message"],
+            "Opération non autorisée pour cette démarche. "
+            "La requête doit inclure `demarche { number }`.",
+        )

--- a/gsl_ds_proxy/views.py
+++ b/gsl_ds_proxy/views.py
@@ -3,7 +3,7 @@ import logging
 
 import requests
 from django.conf import settings
-from django.http import JsonResponse
+from django.http import JsonResponse, StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from graphql import GraphQLError, OperationType, parse
@@ -20,11 +20,16 @@ _ALLOWED_OPERATIONS = {
     "getDossier",
 }
 
-_DS_TIMEOUT = (5, 30)
+# Read timeout stays below Scalingo's 59s post-first-byte inactivity ceiling.
+_DS_TIMEOUT = (5, 55)
 
 
 def _error_response(message, status):
     return JsonResponse({"errors": [{"message": message}]}, status=status)
+
+
+def _graphql_error_bytes(message):
+    return json.dumps({"errors": [{"message": message}]}).encode()
 
 
 def _pick_operation(doc, operation_name):
@@ -71,16 +76,17 @@ def _check_response_allowed(proxy_token, operation_name, response_data):
     This is the security boundary. The pre-forward check trusts request
     variables, which the caller controls; the only trustworthy scoping
     signal is the data DS actually returned.
+
+    Returns an error message string if the response is out of scope, else None.
     """
     data = (response_data or {}).get("data") or {}
 
     if operation_name == "getDemarche":
         demarche = data.get("demarche") or {}
         if demarche.get("number") != proxy_token.demarche.ds_number:
-            return _error_response(
+            return (
                 "Opération non autorisée pour cette démarche. "
-                "La requête doit inclure `demarche { number }`.",
-                403,
+                "La requête doit inclure `demarche { number }`."
             )
         return None
 
@@ -88,10 +94,9 @@ def _check_response_allowed(proxy_token, operation_name, response_data):
         dossier = data.get("dossier") or {}
         demarche_number = (dossier.get("demarche") or {}).get("number")
         if demarche_number != proxy_token.demarche.ds_number:
-            return _error_response(
+            return (
                 "Opération non autorisée pour cette démarche. "
-                "La requête doit inclure `dossier { demarche { number } }`.",
-                403,
+                "La requête doit inclure `dossier { demarche { number } }`."
             )
         return None
 
@@ -99,6 +104,7 @@ def _check_response_allowed(proxy_token, operation_name, response_data):
 
 
 def _forward_to_ds(query, variables, operation_name):
+    """Call DS and return (response_data, None) or (None, error_message)."""
     headers = {
         "Authorization": f"Bearer {settings.DS_API_TOKEN}",
         "Content-Type": "application/json",
@@ -118,20 +124,16 @@ def _forward_to_ds(query, variables, operation_name):
         )
     except requests.exceptions.ConnectionError:
         logger.exception("DS proxy: connection error to DS API")
-        return None, _error_response(
-            "Erreur de connexion à Démarches Simplifiées.", 502
-        )
+        return None, "Erreur de connexion à Démarches Simplifiées."
     except requests.exceptions.Timeout:
         logger.exception("DS proxy: timeout from DS API")
-        return None, _error_response(
-            "Délai d'attente dépassé pour Démarches Simplifiées.", 504
-        )
+        return None, "Délai d'attente dépassé pour Démarches Simplifiées."
 
     try:
         ds_response.raise_for_status()
     except requests.exceptions.HTTPError:
         logger.exception("DS proxy: HTTP %s from DS API", ds_response.status_code)
-        return None, _error_response("Erreur de Démarches Simplifiées.", 502)
+        return None, "Erreur de Démarches Simplifiées."
 
     return ds_response.json(), None
 
@@ -180,20 +182,30 @@ def graphql_proxy(request):
     if error is not None:
         return error
 
-    response_data, error = _forward_to_ds(query, variables, operation_name)
-    if error is not None:
-        return error
-
-    # Scope check: the authoritative check, against what DS actually returned.
-    error = _check_response_allowed(proxy_token, operation_name, response_data)
-    if error is not None:
-        return error
-
-    # Filter
     allowed_ids = set(proxy_token.instructeurs.values_list("ds_id", flat=True))
-    filtered = filter_response(response_data, allowed_ids)
+    stream = _stream_ds_response(
+        proxy_token, operation_name, query, variables, allowed_ids
+    )
+    return StreamingHttpResponse(stream, content_type="application/json", status=200)
 
-    return JsonResponse(filtered)
+
+def _stream_ds_response(proxy_token, operation_name, query, variables, allowed_ids):
+    # Send a single whitespace byte immediately to close Scalingo's
+    # 30s-to-first-byte window. Leading whitespace is valid JSON.
+    yield b" "
+
+    response_data, error_message = _forward_to_ds(query, variables, operation_name)
+    if error_message is not None:
+        yield _graphql_error_bytes(error_message)
+        return
+
+    scope_error = _check_response_allowed(proxy_token, operation_name, response_data)
+    if scope_error is not None:
+        yield _graphql_error_bytes(scope_error)
+        return
+
+    filtered = filter_response(response_data, allowed_ids)
+    yield json.dumps(filtered).encode()
 
 
 graphql_proxy.login_required = False


### PR DESCRIPTION
## 🌮 Objectif

Éviter les 504 Scalingo sur `/ds-proxy/graphql/` quand Démarches Simplifiées répond en plus de 30 s, en diffusant un octet d'espace immédiatement puis la payload finale.

## 🔍 Liste des modifications

- `gsl_ds_proxy/views.py` : `graphql_proxy` renvoie une `StreamingHttpResponse` pour le chemin qui appelle DS. Le générateur émet d'abord un octet d'espace (ferme la fenêtre Scalingo de 30 s pour le premier octet), puis appelle DS, puis émet la payload JSON filtrée ou une erreur GraphQL in-band.
- `_DS_TIMEOUT` passe de `(5, 30)` à `(5, 55)` pour rester sous le plafond d'inactivité Scalingo de 59 s post-premier-octet.
- `_forward_to_ds` et `_check_response_allowed` renvoient désormais `(résultat, message d'erreur)` en texte brut ; la vue wrappe le message en `JsonResponse` pour les erreurs fast-path et en erreur GraphQL in-band pour les erreurs survenues après le début du streaming.
- Les erreurs détectées avant l'appel DS (auth, JSON, parsing GraphQL, scope pré-forward) continuent de renvoyer des `JsonResponse` 400/401/403/405 inchangés.
- `gsl_ds_proxy/tests/test_views.py` : les tests du chemin streamé consomment `response.streaming_content` ; les tests d'erreurs DS (timeout, connexion, HTTP, scope réponse) attendent maintenant 200 + erreur GraphQL in-band. Ajout de tests dédiés : `test_first_byte_is_heartbeat_space`, `test_final_payload_is_valid_json_with_leading_heartbeat`, `test_connection_error_during_streaming_yields_graphql_error_with_200`, `test_scope_check_failure_during_streaming_yields_graphql_error_with_200`.

## ⚠️ Informations supplémentaires

Une fois le streaming commencé, le status HTTP est figé à 200 ; les erreurs DS après le premier octet deviennent donc des erreurs GraphQL in-band (convention GraphQL), plus des codes HTTP non-200.

À vérifier après déploiement staging : rejouer dans Sentry la requête DS la plus lente vue récemment et vérifier qu'elle renvoie une payload, puis vérifier dans `scalingo --app <app> logs` qu'aucun `H12` n'apparaît sur `/ds-proxy/graphql/` pendant une vraie réponse lente.

## 🖼️ Images

_N/A (pas de changement UI)_