### PR TITLE
Proxy DS : remonter les erreurs GraphQL d'amont au lieu de les masquer par le contrôle de périmètre

### DIFF
--- a/gsl_ds_proxy/tests/test_views.py
+++ b/gsl_ds_proxy/tests/test_views.py
@@ -170,6 +170,63 @@ class GraphqlProxyViewTest(TestCase):
             {"errors": [{"message": "Erreur de Démarches Simplifiées."}]},
         )
 
+    @patch("gsl_ds_proxy.views.requests.post")
+    def test_upstream_errors_forwarded_when_data_null(self, mock_post):
+        upstream = {
+            "data": None,
+            "errors": [{"message": "Field 'demaarche' doesn't exist on type 'Query'"}],
+        }
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_post.return_value.json.return_value = upstream
+
+        response = self._post(self._get_demarche_payload())
+
+        self.assertEqual(response.status_code, 200)
+        raw = _read_stream(response).decode()
+        self.assertEqual(json.loads(raw)["errors"], upstream["errors"])
+        self.assertNotIn("La requête doit inclure", raw)
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    def test_upstream_errors_forwarded_when_data_empty(self, mock_post):
+        upstream = {
+            "data": {},
+            "errors": [{"message": "Field 'demaarche' doesn't exist on type 'Query'"}],
+        }
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_post.return_value.json.return_value = upstream
+
+        response = self._post(self._get_demarche_payload())
+
+        self.assertEqual(response.status_code, 200)
+        raw = _read_stream(response).decode()
+        self.assertEqual(json.loads(raw)["errors"], upstream["errors"])
+        self.assertNotIn("La requête doit inclure", raw)
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    def test_upstream_errors_forwarded_for_getDossier(self, mock_post):
+        upstream = {
+            "data": {"dossier": None},
+            "errors": [{"message": "Dossier introuvable"}],
+        }
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_post.return_value.json.return_value = upstream
+
+        response = self._post(
+            {
+                "query": "query getDossier { dossier { number } }",
+                "operationName": "getDossier",
+                "variables": {"dossierNumber": 42},
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        raw = _read_stream(response).decode()
+        self.assertEqual(json.loads(raw)["errors"], upstream["errors"])
+        self.assertNotIn("La requête doit inclure", raw)
+
     def test_getDemarche_wrong_demarche_number_rejected(self):
         response = self._post(self._get_demarche_payload(demarche_number=999))
         self.assertEqual(response.status_code, 403)

--- a/gsl_ds_proxy/views.py
+++ b/gsl_ds_proxy/views.py
@@ -70,6 +70,20 @@ def _check_operation_allowed(proxy_token, operation_name, variables):
     return None
 
 
+def _scoped_field_present(operation_name, response_data):
+    data = (response_data or {}).get("data") or {}
+    if operation_name == "getDemarche":
+        return isinstance(data.get("demarche"), dict) and "number" in data["demarche"]
+    if operation_name == "getDossier":
+        dossier = data.get("dossier")
+        return (
+            isinstance(dossier, dict)
+            and isinstance(dossier.get("demarche"), dict)
+            and "number" in dossier["demarche"]
+        )
+    return True
+
+
 def _check_response_allowed(proxy_token, operation_name, response_data):
     """Post-fetch validation: authoritative check against the DS payload.
 
@@ -197,6 +211,16 @@ def _stream_ds_response(proxy_token, operation_name, query, variables, allowed_i
     response_data, error_message = _forward_to_ds(query, variables, operation_name)
     if error_message is not None:
         yield _graphql_error_bytes(error_message)
+        return
+
+    # If DS itself reported errors and returned no scopable data, forward the
+    # upstream response verbatim so the caller can see the real error. There is
+    # nothing to scope-check (data is null/absent), so no risk of leaking
+    # out-of-scope data.
+    if response_data.get("errors") and not _scoped_field_present(
+        operation_name, response_data
+    ):
+        yield json.dumps(response_data).encode()
         return
 
     scope_error = _check_response_allowed(proxy_token, operation_name, response_data)


### PR DESCRIPTION
## 🌮 Objectif

Quand DS renvoie une erreur GraphQL (champ inconnu, type invalide, etc.), le proxy renvoyait un 403 trompeur au lieu de transmettre l'erreur réelle au client.

## 🔍 Liste des modifications

- Ajout d'un helper `_scoped_field_present` qui détermine si la réponse contient le champ scopable (`demarche.number` ou `dossier.demarche.number`).
- Court-circuit dans `graphql_proxy` : si l'amont renvoie un tableau `errors` non vide **et** qu'aucune donnée scopable n'est présente, la réponse DS est transmise telle quelle (HTTP 200) — il n'y a rien à scoper, donc aucun risque de fuite hors périmètre.
- Le contrôle de périmètre continue de rejeter les vrais cas de mismatch (données présentes mais `number` manquant ou différent) — c'est la limite de sécurité, elle reste inchangée.
- Extraction de `_build_proxy_response` pour garder `graphql_proxy` sous le seuil de complexité C901.
- Tests : 3 nouveaux cas (`data: null`, `data: {}`, variante `getDossier`). La régression existante (`test_getDemarche_response_without_number_field_rejected`) reste verte.