### PR TITLE
Mesure de la couverture de tests dans la CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -53,6 +53,10 @@ jobs:
     environment: test
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pull-requests: write
+
     env:
       DATABASE_URL: ${{ github.event_name != 'pull_request' && format('postgres://{0}:{1}@{2}:{3}/{4}', vars.DATABASE_USER, vars.DATABASE_PASSWORD, vars.DATABASE_HOST, vars.DATABASE_PORT, vars.DATABASE_NAME) || 'sqlite://:memory:' }}
       SECRET_KEY: ${{ vars.SECRET_KEY }}
@@ -93,3 +97,31 @@ jobs:
     - name: Run Tests
       run: |
         python -m pytest --create-db
+
+    - name: Diff coverage report
+      if: github.event_name == 'pull_request'
+      run: |
+        git fetch origin ${{ github.base_ref }} --depth=50
+        diff-cover coverage.xml \
+          --compare-branch=origin/${{ github.base_ref }} \
+          --markdown-report=diff-cover.md \
+          --html-report=diff-cover.html
+      continue-on-error: true  # warn-only
+
+    - name: Post diff coverage as PR comment
+      if: github.event_name == 'pull_request'
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: diff-coverage
+        path: diff-cover.md
+
+    - name: Upload coverage artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: |
+          coverage.xml
+          htmlcov/
+          diff-cover.html
+        retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+diff-cover.md
+diff-cover.html
 
 # Translations
 *.mo

--- a/justfile
+++ b/justfile
@@ -34,6 +34,11 @@ test:
 test-watching folder_or_file:
     git ls-files | entr -c pytest -vv {{folder_or_file}}
 
+# Run tests with coverage and produce a diff-coverage HTML report
+coverage:
+    pytest
+    diff-cover coverage.xml --compare-branch=origin/main --html-report=htmlcov/diff.html || true
+
 
 # Create a release tag (vYY.MM.DD) and push it to trigger production deployment
 release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,43 @@ dev = [
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "gsl.settings_test"
-addopts = "--reuse-db"
+addopts = "--reuse-db --cov --cov-report=xml --cov-report=html --cov-report=term-missing:skip-covered"
+
+[tool.coverage.run]
+branch = true
+source = [
+    "gsl",
+    "gsl_core",
+    "gsl_demarches_simplifiees",
+    "gsl_ds_proxy",
+    "gsl_notification",
+    "gsl_oidc",
+    "gsl_pages",
+    "gsl_programmation",
+    "gsl_projet",
+    "gsl_simulation",
+    "ui",
+]
+omit = [
+    "*/migrations/*",
+    "*/tests/*",
+    "*/test_*.py",
+    "manage.py",
+    "conftest.py",
+    "gsl/settings*.py",
+    "gsl/asgi.py",
+    "gsl/wsgi.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+]
 
 [tool.ruff.lint]
 exclude = ["**/migrations/*.py"]


### PR DESCRIPTION
## 🌮 Objectif

Mesurer la couverture de tests à chaque PR et publier un rapport de couverture du diff en commentaire, en mode avertissement uniquement (sans seuil bloquant).

## 🔍 Liste des modifications

- `pyproject.toml` : ajout de `--cov` aux options par défaut de pytest et configuration de `[tool.coverage.run]` / `[tool.coverage.report]` (branch coverage, sources des apps, exclusion des migrations / tests / settings)
- `.github/workflows/django.yml` :
  - ajout de la permission `pull-requests: write` au job `tests`
  - nouvelle étape `Diff coverage report` (warn-only via `continue-on-error: true`) qui exécute `diff-cover` sur les PR
  - nouvelle étape qui poste le rapport markdown en commentaire « sticky » via `marocchino/sticky-pull-request-comment@v2` (header `diff-coverage`, mis à jour à chaque push)
  - nouvelle étape qui publie `coverage.xml`, `htmlcov/` et `diff-cover.html` en artifact (rétention 14 jours)
- `justfile` : ajout d'une recette `just coverage` pour reproduire localement le rapport CI
- `.gitignore` : ajout de `diff-cover.md` et `diff-cover.html`

## ⚠️ Informations supplémentaires

- `pytest-cov` et `diff-cover` étaient déjà déclarés dans `requirements-dev.txt` ; aucune nouvelle dépendance n'est ajoutée.
- Le seuil de couverture reste **non bloquant** pour le moment : l'objectif est d'obtenir de la visibilité avant de fixer un seuil.
- `--cov` étant désormais activé par défaut, les exécutions locales `pytest <fichier>` produiront elles aussi un rapport de couverture. Pour s'en passer ponctuellement : `pytest --no-cov`.
- Sur les PR, les tests tournent en SQLite en mémoire (comportement existant) ; le rapport reflète donc cet environnement.