### PR TITLE
Cibler le commit du tag plutôt que main lors de la création de la release

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create GitHub release with notes
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" --generate-notes --target main
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes
 
   deploy:
     needs: tests


### PR DESCRIPTION
## 🌮 Objectif

Faire en sorte que les notes de release auto-générées reflètent réellement le contenu du tag, y compris pour des tags posés sur une branche de hotfix.

## 🔍 Liste des modifications

- `.github/workflows/deploy-prod.yml` : suppression de `--target main` sur `gh release create`. Le workflow se déclenche sur push d'un tag, donc le tag existe déjà au moment de l'appel : `--target` est alors ignoré pour la création du tag, mais il influence la plage des notes générées. Avec `--target main`, un tag posé sur une branche autre que main générait des notes pour la plage `v(precedent)..main` (toutes les PR mergées dans main depuis le dernier tag), au lieu de la plage `v(precedent)..commit_du_tag`.

## ⚠️ Informations supplémentaires

Cette correction prépare le terrain pour la PR de hotfix proxy DS, qui pose un tag sur une branche dérivée de v26.04.21 plutôt que de main.