### PR TITLE
Proxy DS : ignorer les nœuds null et masquer les erreurs partielles dans la liste des dossiers

### DIFF
--- a/gsl_ds_proxy/filters.py
+++ b/gsl_ds_proxy/filters.py
@@ -3,6 +3,8 @@ import copy
 
 def _dossier_is_visible(dossier, allowed_ids):
     """Check if a dossier has at least one instructeur in allowed_ids."""
+    if not dossier:
+        return False
     groupe = dossier.get("groupeInstructeur") or {}
     instructeurs = groupe.get("instructeurs") or []
     instructeurs += dossier.get("instructeurs") or []
@@ -39,6 +41,11 @@ def filter_response(response_data, allowed_instructeur_ids):
         dossiers = demarche.get("dossiers")
         if dossiers and isinstance(dossiers, dict):
             _filter_dossier_nodes(dossiers, allowed_instructeur_ids)
+            # DS reports partial fetch failures (e.g. null nodes) via top-level
+            # errors[]. When at least one dossier comes through, drop them so
+            # callers don't see noise alongside a structurally valid list.
+            if dossiers.get("nodes"):
+                result.pop("errors", None)
 
     # getDossier → data.dossier (single dossier)
     dossier = data.get("dossier")

--- a/gsl_ds_proxy/tests/test_filters.py
+++ b/gsl_ds_proxy/tests/test_filters.py
@@ -77,6 +77,39 @@ class FilterResponseDemarcheTest(TestCase):
         result = filter_response(response, {"inst-a"})
         self.assertEqual(result["data"]["demarche"]["dossiers"]["nodes"], [])
 
+    def test_null_node_is_filtered_out(self):
+        response = self._make_demarche_response(
+            [
+                self._make_dossier(1, ["inst-a"]),
+                None,
+                self._make_dossier(2, ["inst-a"]),
+            ]
+        )
+        result = filter_response(response, {"inst-a"})
+        nodes = result["data"]["demarche"]["dossiers"]["nodes"]
+        self.assertEqual([d["number"] for d in nodes], [1, 2])
+
+    def test_top_level_errors_dropped_when_dossiers_present(self):
+        response = self._make_demarche_response(
+            [
+                self._make_dossier(1, ["inst-a"]),
+                None,
+            ]
+        )
+        response["errors"] = [{"message": "Could not fetch dossier 42"}]
+        result = filter_response(response, {"inst-a"})
+        self.assertNotIn("errors", result)
+
+    def test_top_level_errors_kept_when_filtered_list_is_empty(self):
+        response = self._make_demarche_response(
+            [
+                self._make_dossier(1, ["inst-c"]),
+            ]
+        )
+        response["errors"] = [{"message": "Could not fetch dossier 42"}]
+        result = filter_response(response, {"inst-a"})
+        self.assertEqual(result["errors"], [{"message": "Could not fetch dossier 42"}])
+
 
 class FilterResponseSingleDossierTest(TestCase):
     def test_authorized_dossier_passes_through(self):


### PR DESCRIPTION
## 🌮 Objectif

Corriger le crash « Error in input stream » du proxy DS quand DS renvoie des nœuds `null` dans la liste de dossiers, et nettoyer les erreurs partielles associées.

## 🔍 Liste des modifications

- `_dossier_is_visible` : garde initiale `if not dossier: return False`, pour traiter un nœud `null` comme un dossier non visible (filtré silencieusement, comme tout dossier hors périmètre).
- `filter_response` : quand la liste filtrée `data.demarche.dossiers.nodes` n'est pas vide, on retire le `errors[]` de premier niveau. Ces erreurs DS décrivent typiquement des échecs de récupération de nœuds individuels, qui sont du bruit dès lors qu'on renvoie une liste structurée. Si la liste filtrée est vide, on conserve `errors[]` pour permettre le diagnostic.
- Tests de régression :
  - `test_null_node_is_filtered_out` : mélange dossiers valides et `None`.
  - `test_top_level_errors_dropped_when_dossiers_present` : `errors[]` retiré quand des dossiers visibles sont renvoyés.
  - `test_top_level_errors_kept_when_filtered_list_is_empty` : `errors[]` conservé sinon.

## ⚠️ Informations supplémentaires

Les autres flux (`getDossier`, `data` null/vide, erreurs structurelles GraphQL) continuent de transmettre `errors[]` tels quels — voir tests `test_upstream_errors_forwarded_*` inchangés.