### PR TITLE
Supprimer les logs verbeux de fontTools en production

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -315,6 +315,11 @@ LOGGING = {
             "level": LIBRARIES_LOGGING_LEVEL,
             "propagate": False,
         },
+        "fontTools": {
+            "handlers": ["console"],
+            "level": LIBRARIES_LOGGING_LEVEL,
+            "propagate": False,
+        },
     },
 }
 


### PR DESCRIPTION
## 🌮 Objectif

Éliminer les centaines de logs INFO produits par `fontTools.subset` lors de la génération de PDFs (WeasyPrint utilise fontTools en interne pour le subsetting des polices).

## 🔍 Liste des modifications

- Ajout d'un logger `fontTools` dans `LOGGING` avec le niveau `LIBRARIES_LOGGING_LEVEL` (ERROR par défaut en prod) et `propagate: False`

## ⚠️ Informations supplémentaires

Ces logs apparaissaient dans Sentry avec le logger `fontTools.subset` et la fonction `_log_glyphs`, générés à chaque export PDF.