### PR TITLE
CI : exécuter les tests lors des push sur les branches hotfix/*

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -2,7 +2,7 @@ name: Django CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "hotfix/*" ]
   pull_request:
     types: [ "opened", "synchronize", "reopened" ]
   merge_group:


### PR DESCRIPTION
## 🌮 Objectif

Permettre la création d'un tag de déploiement production sur une branche `hotfix/*` sans devoir ouvrir une fausse PR.

## 🔍 Liste des modifications

- Ajout de `hotfix/*` à la liste des branches déclenchant le workflow `Django CI` sur `push` (en plus de `main`).

## ⚠️ Informations supplémentaires

La règle de protection des tags GitHub exige un status check de tests réussi sur le commit ciblé avant d'autoriser le push d'un tag `vYY.MM.DD`. Jusqu'ici, les tests ne s'exécutaient que sur les PRs et sur les push vers `main`, ce qui obligeait à ouvrir une PR factice pour qu'un commit de hotfix puisse être taggué. Avec ce changement, un push direct sur une branche nommée `hotfix/*` produit le status check requis.

Convention adoptée : les branches de hotfix destinées à être taguées en production doivent être nommées `hotfix/<nom>` (et non plus `<id>/hotfix-<nom>`).