### PR TITLE
Corriger l'URL du script HeatmapSessionRecording de Matomo

### DIFF
--- a/gsl_core/static/js/matomo.js
+++ b/gsl_core/static/js/matomo.js
@@ -12,11 +12,11 @@ _paq.push(["enableLinkTracking"]);
   g.async = true;
   g.src = u + "matomo.js";
   s.parentNode.insertBefore(g, s);
-  // Add HeatmapSessionRecording/tracker.min.js cause stats.beta.gouv.fr doesn't
+  // Add plugins/HeatmapSessionRecording/tracker.min.js cause stats.beta.gouv.fr doesn't
   // https://developer.matomo.org/guides/heatmap-session-recording/setup#when-the-matomojs-in-your-piwik-directory-file-is-not-writable
   var heatmapScript = d.createElement("script");
   heatmapScript.async = true;
-  heatmapScript.src = u + "plugin/HeatmapSessionRecording/tracker.min.js";
+  heatmapScript.src = u + "plugins/HeatmapSessionRecording/tracker.min.js";
   s.parentNode.insertBefore(heatmapScript, s);
 })();
 


### PR DESCRIPTION
## 🌮 Objectif

Corriger le chemin du script de heatmap Matomo (renvoyait un 404).

## 🔍 Liste des modifications

- `plugin/HeatmapSessionRecording/tracker.min.js` → `plugins/HeatmapSessionRecording/tracker.min.js` (avec un `s`)
- Mise à jour du commentaire associé

## ⚠️ Informations supplémentaires

Voir la doc Matomo : https://developer.matomo.org/guides/heatmap-session-recording/setup