### PR TITLE
Persistance du tri en plus des filtres sur la page de simulation

### DIFF
--- a/gsl_simulation/tests/views/test_simulation_detail_view.py
+++ b/gsl_simulation/tests/views/test_simulation_detail_view.py
@@ -545,7 +545,7 @@ class TestFilterPersistence:
         simulation.refresh_from_db()
         assert simulation.filters is None
 
-    def test_order_param_not_saved_as_filter(self, client_logged_in, detr_envelope):
+    def test_order_saved_as_filter(self, client_logged_in, detr_envelope):
         simulation = SimulationFactory(enveloppe=detr_envelope)
         SimulationProjetFactory(
             simulation=simulation,
@@ -556,8 +556,62 @@ class TestFilterPersistence:
             kwargs={"slug": simulation.slug},
         )
 
-        response = client_logged_in.get(url, {"order": "-montant_previsionnel"})
-        assert response.status_code == 200
+        client_logged_in.get(url, {"order": "-montant_previsionnel"})
+
+        simulation.refresh_from_db()
+        assert simulation.filters == {"order": ["-montant_previsionnel"]}
+
+    def test_order_restored_from_simulation(self, client_logged_in, detr_envelope):
+        simulation = SimulationFactory(
+            enveloppe=detr_envelope, filters={"order": ["-cout"]}
+        )
+        SimulationProjetFactory(
+            simulation=simulation,
+            dotation_projet__dotation=DOTATION_DETR,
+        )
+        url = reverse(
+            "gsl_simulation:simulation-detail",
+            kwargs={"slug": simulation.slug},
+        )
+
+        response = client_logged_in.get(url)
+        assert response.status_code == 302
+        assert "order=-cout" in response.url
+
+    def test_filters_and_order_saved_together(self, client_logged_in, detr_envelope):
+        simulation = SimulationFactory(enveloppe=detr_envelope)
+        SimulationProjetFactory(
+            simulation=simulation,
+            dotation_projet__dotation=DOTATION_DETR,
+        )
+        url = reverse(
+            "gsl_simulation:simulation-detail",
+            kwargs={"slug": simulation.slug},
+        )
+
+        client_logged_in.get(url, {"status": "draft", "order": "cout"})
+
+        simulation.refresh_from_db()
+        assert simulation.filters == {
+            "status": ["draft"],
+            "order": ["cout"],
+        }
+
+    def test_reset_clears_order_too(self, client_logged_in, detr_envelope):
+        simulation = SimulationFactory(
+            enveloppe=detr_envelope, filters={"order": ["-cout"]}
+        )
+        SimulationProjetFactory(
+            simulation=simulation,
+            dotation_projet__dotation=DOTATION_DETR,
+        )
+        url = reverse(
+            "gsl_simulation:simulation-detail",
+            kwargs={"slug": simulation.slug},
+        )
+
+        client_logged_in.get(url, {"reset_filters": "1"})
+
         simulation.refresh_from_db()
         assert simulation.filters is None
 

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -80,7 +80,7 @@ class SimulationDetailView(SingleObjectMixin, FilterView):
     template_name = "gsl_simulation/simulation_detail.html"
     paginate_by = 25
 
-    PARAMS_NOT_FILTERS = {"page", "reset_filters", "order"}
+    PARAMS_NOT_FILTERS = {"page", "reset_filters"}
 
     def _get_filter_params(self):
         return {


### PR DESCRIPTION
## 🌮 Objectif

Conserver le tri actif sur la page de détail d'une simulation, au même titre que les filtres déjà persistés.

## 🔍 Liste des modifications

- Retrait de `"order"` de `PARAMS_NOT_FILTERS` dans `SimulationDetailView` : le paramètre `order=` est désormais sauvegardé dans `Simulation.filters` et restauré au retour sur la page.
- Le bouton « Réinitialiser les filtres » efface aussi le tri sauvegardé (comportement attendu de la remise à zéro).
- Tests dans `TestFilterPersistence` :
  - remplacement de `test_order_param_not_saved_as_filter` (assertion désormais inversée) par `test_order_saved_as_filter`,
  - ajout de `test_order_restored_from_simulation`, `test_filters_and_order_saved_together` et `test_reset_clears_order_too`.

## ⚠️ Informations supplémentaires

Aucune migration nécessaire : `Simulation.filters` est un `JSONField` qui acceptait déjà n'importe quelle clé.