### PR TITLE
Permettre de fermer la modale « Vous ne faites pas partie du groupe d'instructeurs »

### DIFF
--- a/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications.html
+++ b/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications.html
@@ -73,7 +73,7 @@
             </p>
         {% elif not is_instructor %}
             <button class="fr-btn fr-mt-6w fr-icon-edit-line fr-btn--icon-right"
-                    aria-controls="refuse-confirmation-modal"
+                    aria-controls="not-instructeur-modal"
                     data-fr-opened="false">
                 Rédiger le message de notification
             </button>
@@ -113,8 +113,8 @@
 {% endblock extra_js %}
 
 {% block modal %}
-    <div id="refuse-confirmation-modal" class="fr-modal" aria-hidden="true">
-        {% include "includes/_not_instructeur_modal.html" %}
+    <div id="not-instructeur-modal" class="fr-modal" aria-hidden="true">
+        {% include "includes/_not_instructeur_modal.html" with modal_id="not-instructeur-modal" %}
     </div>
     {% ui_confirmation_modal modal_id="delete-document-confirmation-modal" title=arrete_modal_title text="Êtes-vous sûr(e) de vouloir supprimer cet arrêté ?<br>Cette action est irréversible." form="delete-document-form" action_text="Supprimer" %}
     <form method="post" id="delete-document-form">


### PR DESCRIPTION
## 🌮 Objectif

Permettre de fermer la modale « Vous ne faites pas partie du groupe d'instructeurs » qui s'ouvre depuis l'onglet de notification d'un projet de simulation lorsque l'utilisateur n'est pas instructeur du dossier.

## 🔍 Liste des modifications

- Passer `modal_id` à l'include `_not_instructeur_modal.html` pour que les boutons « × » et « Compris » aient le bon `aria-controls` (auparavant vide), et que le `<h1>` ait un `id` valide.
- Renommer l'id de la modale `refuse-confirmation-modal` en `not-instructeur-modal` — le nom précédent était trompeur (vestige de copier-coller, cette modale n'a aucun rapport avec un refus).

## ⚠️ Informations supplémentaires

Aucun nouveau test : le bug est un argument de template manquant et il n'y a pas de couche d'interaction JS à tester.