### PR TITLE
Alléger la requête GraphQL DN pour limiter les timeouts GroupeInstructeur

### DIFF
--- a/gsl_demarches_simplifiees/ds_client.py
+++ b/gsl_demarches_simplifiees/ds_client.py
@@ -96,7 +96,10 @@ class DsClient(DsClientBase):
         return self.launch_graphql_query("getDemarche", variables=variables)
 
     def get_demarche_dossiers(
-        self, demarche_number, updated_since: datetime | None = None
+        self,
+        demarche_number,
+        updated_since: datetime | None = None,
+        page_size: int = 50,
     ) -> Iterator[dict]:
         """
         Get all dossiers from one given demarche
@@ -104,7 +107,7 @@ class DsClient(DsClientBase):
         :return: iterator on all available dossiers of demarche
         """
         for nodes, _cursor in self.iter_demarche_dossiers_pages(
-            demarche_number, updated_since=updated_since
+            demarche_number, updated_since=updated_since, page_size=page_size
         ):
             yield from nodes
 
@@ -113,6 +116,7 @@ class DsClient(DsClientBase):
         demarche_number,
         updated_since: datetime | None = None,
         after_cursor: str | None = None,
+        page_size: int = 50,
     ) -> Iterator[tuple[list[dict], str | None]]:
         """
         Iterate over pages of dossiers from one given demarche, yielding (nodes, end_cursor)
@@ -121,6 +125,7 @@ class DsClient(DsClientBase):
         :param demarche_number:
         :param updated_since: optional datetime filter (updatedSince in the GraphQL query)
         :param after_cursor: optional cursor to resume from a previous run
+        :param page_size: number of dossiers requested per page (GraphQL `first`)
         :return: iterator of (nodes, end_cursor) tuples
         """
         variables = {
@@ -128,6 +133,7 @@ class DsClient(DsClientBase):
             "includeDossiers": True,
             "updatedSince": updated_since.isoformat() if updated_since else None,
             "after": after_cursor,
+            "first": page_size,
         }
         while True:
             result = self.launch_graphql_query("getDemarche", variables=variables)

--- a/gsl_demarches_simplifiees/graphql/ds_queries.gql
+++ b/gsl_demarches_simplifiees/graphql/ds_queries.gql
@@ -28,11 +28,9 @@ query getDemarche(
   $includeService: Boolean = false
   $includeChamps: Boolean = true
   $includeAnotations: Boolean = true
-  $includeTraitements: Boolean = true
   $includeInstructeurs: Boolean = true
+  $includeTraitements: Boolean = false
   $includeAvis: Boolean = false
-  $includeMessages: Boolean = false
-  $includeCorrections: Boolean = false
   $includeGeometry: Boolean = false
 ) {
   demarche(number: $demarcheNumber) {
@@ -136,11 +134,9 @@ query getGroupeInstructeur(
   $includeDeletedDossiers: Boolean = false
   $includeChamps: Boolean = true
   $includeAnotations: Boolean = true
-  $includeTraitements: Boolean = true
   $includeInstructeurs: Boolean = true
+  $includeTraitements: Boolean = false
   $includeAvis: Boolean = false
-  $includeMessages: Boolean = false
-  $includeCorrections: Boolean = false
   $includeGeometry: Boolean = false
 ) {
   groupeInstructeur(number: $groupeInstructeurNumber) {
@@ -209,11 +205,8 @@ query getDossier(
   $includeService: Boolean = false
   $includeChamps: Boolean = true
   $includeAnotations: Boolean = true
-  $includeTraitements: Boolean = true
-  $includeInstructeurs: Boolean = true
+  $includeTraitements: Boolean = false
   $includeAvis: Boolean = false
-  $includeMessages: Boolean = false
-  $includeCorrections: Boolean = false
   $includeGeometry: Boolean = false
 ) {
   dossier(number: $dossierNumber) {
@@ -252,41 +245,17 @@ fragment GroupeInstructeurFragment on GroupeInstructeur {
 }
 
 fragment DossierFragment on Dossier {
-  __typename
   id
   number
-  archived
-  prefilled
   state
   dateDerniereModification
   dateDepot
   datePassageEnConstruction
   datePassageEnInstruction
   dateTraitement
-  dateExpiration
-  dateSuppressionParUsager
-  dateDerniereCorrectionEnAttente @include(if: $includeCorrections)
   dateDerniereModificationChamps
-  dateDerniereModificationAnnotations
-  motivation
-  motivationAttachment {
-    ...FileFragment
-  }
-  attestation {
-    ...FileFragment
-  }
-  pdf {
-    ...FileFragment
-  }
-  usager {
-    email
-  }
-  prenomMandataire
-  nomMandataire
-  deposeParUnTiers
-  connectionUsager
   groupeInstructeur {
-    ...GroupeInstructeurFragment
+    id
   }
   demandeur {
     __typename
@@ -299,16 +268,6 @@ fragment DossierFragment on Dossier {
       id
     }
   }
-  instructeurs @include(if: $includeInstructeurs) {
-    id
-    email
-  }
-  traitements @include(if: $includeTraitements) {
-    state
-    emailAgentTraitant
-    dateTraitement
-    motivation
-  }
   champs @include(if: $includeChamps) {
     ...ChampFragment
     ...RootChampFragment
@@ -317,11 +276,31 @@ fragment DossierFragment on Dossier {
     ...ChampFragment
     ...RootChampFragment
   }
+  traitements @include(if: $includeTraitements) {
+    state
+    emailAgentTraitant
+    dateTraitement
+    motivation
+  }
   avis @include(if: $includeAvis) {
     ...AvisFragment
   }
-  messages @include(if: $includeMessages) {
-    ...MessageFragment
+}
+
+fragment AvisFragment on Avis {
+  id
+  question
+  reponse
+  dateQuestion
+  dateReponse
+  claimant {
+    email
+  }
+  expert {
+    email
+  }
+  attachments {
+    ...FileFragment
   }
 }
 
@@ -406,37 +385,6 @@ fragment ChampDescriptorFragment on ChampDescriptor {
   ... on ExplicationChampDescriptor {
     collapsibleExplanationEnabled
     collapsibleExplanationText
-  }
-}
-
-fragment AvisFragment on Avis {
-  id
-  question
-  reponse
-  dateQuestion
-  dateReponse
-  claimant {
-    email
-  }
-  expert {
-    email
-  }
-  attachments {
-    ...FileFragment
-  }
-}
-
-fragment MessageFragment on Message {
-  id
-  email
-  body
-  createdAt
-  attachments {
-    ...FileFragment
-  }
-  correction @include(if: $includeCorrections) {
-    reason
-    dateResolution
   }
 }
 

--- a/gsl_demarches_simplifiees/importer/dossier.py
+++ b/gsl_demarches_simplifiees/importer/dossier.py
@@ -36,6 +36,14 @@ def save_demarche_dossiers_from_ds(demarche_number):
     active_departement_insee_codes = _get_active_departement_insee_codes()
     dossiers_count = 0
 
+    groupe_index = _build_groupe_index_from_demarche(demarche)
+    if not groupe_index:
+        from gsl_demarches_simplifiees.importer.demarche import save_demarche_from_ds
+
+        save_demarche_from_ds(demarche_number)
+        demarche.refresh_from_db()
+        groupe_index = _build_groupe_index_from_demarche(demarche)
+
     for page_dossiers, end_cursor in client.iter_demarche_dossiers_pages(
         demarche_number, updated_since=api_updated_since, after_cursor=after_cursor
     ):
@@ -55,7 +63,10 @@ def save_demarche_dossiers_from_ds(demarche_number):
 
             try:
                 _create_or_update_dossier_from_ds_data(
-                    dossier_data, active_departement_insee_codes, demarche
+                    dossier_data,
+                    active_departement_insee_codes,
+                    demarche,
+                    groupe_index=groupe_index,
                 )
             except Exception as e:
                 has_error = True
@@ -133,9 +144,20 @@ def refresh_dossier_from_saved_data(dossier: Dossier):
     ProjetService.create_or_update_projet_and_co_from_dossier(dossier.ds_number)
 
 
-def refresh_dossier_instructeurs(dossier_data, dossier: Dossier):
+def refresh_dossier_instructeurs(
+    dossier_data, dossier: Dossier, groupe_index: dict | None = None
+):
     """
     Refreshes the instructeurs associated with a dossier based on data from Démarche Numérique.
+
+    The DN payload only ships ``groupeInstructeur.id`` for the dossier; the list of
+    instructeurs is reconstructed locally from ``Demarche.raw_ds_data`` via
+    ``groupe_index``: ``{groupe_ds_id: [{"id": ..., "email": ...}, ...]}``.
+
+    If ``groupe_index`` is None, it is built from ``dossier.ds_demarche``. If the
+    dossier's groupe id is missing from the mapping (groupe added on DN since the
+    last ``save_demarche_from_ds``), refresh the demarche once and retry; if still
+    unknown, log a warning and leave instructeurs untouched.
 
     Assume ds_instructeur has been prefetch_related on dossier
     Noop if no changes, check only IDs does not check emails.
@@ -143,7 +165,33 @@ def refresh_dossier_instructeurs(dossier_data, dossier: Dossier):
     if "groupeInstructeur" not in dossier_data:
         # Should not happen except in tests
         return
-    instructeurs_data = dossier_data["groupeInstructeur"]["instructeurs"]
+    groupe_id = dossier_data["groupeInstructeur"].get("id")
+    if not groupe_id:
+        return
+
+    if groupe_index is None:
+        groupe_index = _build_groupe_index_from_demarche(dossier.ds_demarche)
+
+    instructeurs_data = groupe_index.get(groupe_id)
+    if instructeurs_data is None:
+        from gsl_demarches_simplifiees.importer.demarche import save_demarche_from_ds
+
+        save_demarche_from_ds(dossier.ds_demarche.ds_number)
+        dossier.ds_demarche.refresh_from_db()
+        refreshed = _build_groupe_index_from_demarche(dossier.ds_demarche)
+        groupe_index.clear()
+        groupe_index.update(refreshed)
+        instructeurs_data = groupe_index.get(groupe_id)
+
+    if instructeurs_data is None:
+        logger.warning(
+            "Unknown groupeInstructeur id when refreshing dossier instructeurs",
+            extra={
+                "dossier_ds_number": dossier.ds_number,
+                "groupe_ds_id": groupe_id,
+            },
+        )
+        return
 
     # Remove instructeurs that are not in the new data
     for profile in dossier.ds_instructeurs.all():
@@ -160,6 +208,24 @@ def refresh_dossier_instructeurs(dossier_data, dossier: Dossier):
             dossier.ds_instructeurs.add(instructeur)
 
 
+def _build_groupe_index_from_demarche(demarche: Demarche) -> dict[str, list[dict]]:
+    """
+    Build ``{groupe_ds_id: [{"id": profile_ds_id, "email": profile_email}, ...]}``
+    from ``demarche.raw_ds_data["groupeInstructeurs"]``. Returns an empty dict if
+    the raw data is missing.
+    """
+    raw = demarche.raw_ds_data or {}
+    groupes = raw.get("groupeInstructeurs") or []
+    return {
+        groupe["id"]: [
+            {"id": instr["id"], "email": instr["email"]}
+            for instr in groupe.get("instructeurs", [])
+        ]
+        for groupe in groupes
+        if "id" in groupe
+    }
+
+
 ### Private methods
 
 
@@ -168,13 +234,14 @@ def _save_dossier_data_and_refresh_dossier_and_projet_and_co(
     dossier_data: dict,
     async_refresh: bool = False,
     refresh_only_if_dossier_has_been_updated: bool = True,
+    groupe_index: dict | None = None,
 ):
     if refresh_only_if_dossier_has_been_updated:
         must_refresh_dossier = _has_dossier_been_updated_on_ds(dossier, dossier_data)
     else:
         must_refresh_dossier = True
 
-    refresh_dossier_instructeurs(dossier_data, dossier)
+    refresh_dossier_instructeurs(dossier_data, dossier, groupe_index=groupe_index)
     if getattr(dossier, "ds_data", None) is None:
         DossierData.objects.create(dossier=dossier, raw_data=dossier_data)
     else:
@@ -244,6 +311,7 @@ def _create_or_update_dossier_from_ds_data(
     dossier_data: dict | None,
     active_departement_insee_codes: Iterable[str],
     demarche: Demarche | None = None,
+    groupe_index: dict | None = None,
 ):
     ds_id = dossier_data["id"]
     ds_dossier_number = dossier_data["number"]
@@ -279,4 +347,5 @@ def _create_or_update_dossier_from_ds_data(
         dossier_data,
         async_refresh=True,
         refresh_only_if_dossier_has_been_updated=False,
+        groupe_index=groupe_index,
     )

--- a/gsl_demarches_simplifiees/tests/ds_client/test_ds_client.py
+++ b/gsl_demarches_simplifiees/tests/ds_client/test_ds_client.py
@@ -73,6 +73,7 @@ def test_get_demarche_dossiers_with_updated_since_calls_graphql_with_iso_format(
         # Verify it's a string in ISO format
         assert isinstance(variables["updatedSince"], str)
         assert "T" in variables["updatedSince"]  # ISO format contains 'T'
+        assert variables["first"] == 50  # default page size
 
 
 def test_get_demarche_dossiers_without_updated_since_passes_none():
@@ -138,11 +139,38 @@ def test_iter_demarche_dossiers_pages_with_after_cursor():
         variables = mock_query.call_args[1]["variables"]
         assert variables["after"] == after_cursor
         assert variables["updatedSince"] is None
+        assert variables["first"] == 50  # default page size
 
         assert len(pages) == 1
         nodes, end_cursor = pages[0]
         assert nodes == [{"id": "DOSS-1", "number": 20240001}]
         assert end_cursor == "xyz789"
+
+
+def test_iter_demarche_dossiers_pages_uses_explicit_page_size():
+    """Caller can override the GraphQL `first` argument via page_size."""
+    client = DsClient()
+    demarche_number = 123
+
+    mock_response = {
+        "data": {
+            "demarche": {
+                "dossiers": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+    }
+
+    with patch.object(
+        client, "launch_graphql_query", return_value=mock_response
+    ) as mock_query:
+        list(client.iter_demarche_dossiers_pages(demarche_number, page_size=20))
+
+        assert mock_query.call_count == 1
+        variables = mock_query.call_args[1]["variables"]
+        assert variables["first"] == 20
 
 
 def test_iter_demarche_dossiers_pages_paginates_until_no_next_page():
@@ -179,9 +207,12 @@ def test_iter_demarche_dossiers_pages_paginates_until_no_next_page():
         pages = list(client.iter_demarche_dossiers_pages(demarche_number))
 
         assert mock_query.call_count == 2
+        first_call_variables = mock_query.call_args_list[0][1]["variables"]
+        assert first_call_variables["first"] == 50
         # Second call should use endCursor from first page
         second_call_variables = mock_query.call_args_list[1][1]["variables"]
         assert second_call_variables["after"] == "cursor_page1"
+        assert second_call_variables["first"] == 50
 
         assert len(pages) == 2
         assert pages[0] == ([{"id": "DOSS-1", "number": 1}], "cursor_page1")

--- a/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
+++ b/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
@@ -25,7 +25,10 @@ from gsl_demarches_simplifiees.tests.factories import (
 @pytest.mark.django_db
 def test_save_demarche_dossiers_from_ds_calls_save_dossier_data_and_refresh_dossier_and_projet_and_co():
     demarche_number = 123
-    DemarcheFactory(ds_number=demarche_number)
+    DemarcheFactory(
+        ds_number=demarche_number,
+        raw_ds_data={"groupeInstructeurs": [{"id": "GROUPE-1", "instructeurs": []}]},
+    )
     ds_dossiers = [
         {
             "id": "DOSS-1",
@@ -76,7 +79,10 @@ def test_save_demarche_dossiers_from_ds_calls_save_dossier_data_and_refresh_doss
 @pytest.mark.django_db
 def test_save_demarche_dossiers_from_ds_update_raw_ds_data_dossiers():
     demarche_number = 123
-    DemarcheFactory(ds_number=demarche_number)
+    DemarcheFactory(
+        ds_number=demarche_number,
+        raw_ds_data={"groupeInstructeurs": [{"id": "GROUPE-1", "instructeurs": []}]},
+    )
     dossier = DossierFactory(
         ds_id="DOSS-1",
         ds_number=20240001,
@@ -119,7 +125,10 @@ def test_save_demarche_dossiers_from_ds_update_raw_ds_data_dossiers():
 def test_save_demarche_dossiers_from_ds_with_one_empty_data(caplog):
     caplog.set_level(logging.INFO)
     demarche_number = 123
-    DemarcheFactory(ds_number=demarche_number)
+    DemarcheFactory(
+        ds_number=demarche_number,
+        raw_ds_data={"groupeInstructeurs": [{"id": "GROUPE-1", "instructeurs": []}]},
+    )
 
     ds_dossiers = [
         {
@@ -164,7 +173,11 @@ def test_save_demarche_dossiers_from_ds_with_one_empty_data(caplog):
 @pytest.mark.django_db
 def test_save_demarche_dossiers_from_ds_update_sync_cursor():
     demarche_number = 123
-    demarche = DemarcheFactory(ds_number=demarche_number, sync_cursor="")
+    demarche = DemarcheFactory(
+        ds_number=demarche_number,
+        sync_cursor="",
+        raw_ds_data={"groupeInstructeurs": [{"id": "GROUPE-1", "instructeurs": []}]},
+    )
     expected_cursor = "abc123cursor=="
 
     with patch(
@@ -237,18 +250,17 @@ def test_refresh_dossier_instructeurs():
     profile_b = Profile.objects.create(ds_id="B-2", ds_email="b@example.com")
     dossier.ds_instructeurs.add(profile_a, profile_b)
 
-    # Incoming DN data contains B (kept) and C (new); A should be removed
-    ds_payload = {
-        "groupeInstructeur": {
-            "instructeurs": [
-                {"id": profile_b.ds_id, "email": profile_b.ds_email},
-                {"id": "C-3", "email": "c@example.com"},
-            ]
-        }
+    # Incoming DN data only ships the groupe id; instructeurs are resolved locally
+    ds_payload = {"groupeInstructeur": {"id": "GROUPE-1"}}
+    groupe_index = {
+        "GROUPE-1": [
+            {"id": profile_b.ds_id, "email": profile_b.ds_email},
+            {"id": "C-3", "email": "c@example.com"},
+        ]
     }
 
     # First refresh: remove A, keep B, add C
-    refresh_dossier_instructeurs(ds_payload, dossier)
+    refresh_dossier_instructeurs(ds_payload, dossier, groupe_index=groupe_index)
 
     current_ids = set(dossier.ds_instructeurs.values_list("ds_id", flat=True))
     assert current_ids == {"B-2", "C-3"}
@@ -258,10 +270,74 @@ def test_refresh_dossier_instructeurs():
     assert c_profile.ds_email == "c@example.com"
 
     # Second refresh with the same payload should be a no-op (no duplicates, same set)
-    refresh_dossier_instructeurs(ds_payload, dossier)
+    refresh_dossier_instructeurs(ds_payload, dossier, groupe_index=groupe_index)
     current_ids_again = set(dossier.ds_instructeurs.values_list("ds_id", flat=True))
     assert current_ids_again == {"B-2", "C-3"}
     assert dossier.ds_instructeurs.count() == 2
+
+
+@pytest.mark.django_db
+def test_refresh_dossier_instructeurs_builds_index_from_demarche_raw_data():
+    """When no groupe_index is passed, it is rebuilt from Demarche.raw_ds_data."""
+    demarche = DemarcheFactory(
+        raw_ds_data={
+            "groupeInstructeurs": [
+                {
+                    "id": "GROUPE-1",
+                    "instructeurs": [
+                        {"id": "A-1", "email": "a@example.com"},
+                        {"id": "B-2", "email": "b@example.com"},
+                    ],
+                },
+                {
+                    "id": "GROUPE-2",
+                    "instructeurs": [
+                        {"id": "Z-9", "email": "z@example.com"},
+                    ],
+                },
+            ]
+        }
+    )
+    dossier = DossierFactory(ds_demarche=demarche)
+
+    ds_payload = {"groupeInstructeur": {"id": "GROUPE-1"}}
+    refresh_dossier_instructeurs(ds_payload, dossier)
+
+    current_ids = set(dossier.ds_instructeurs.values_list("ds_id", flat=True))
+    assert current_ids == {"A-1", "B-2"}
+
+
+@pytest.mark.django_db
+def test_refresh_dossier_instructeurs_unknown_groupe_id_logs_warning(caplog):
+    """If the dossier's groupe id is unknown even after refreshing the demarche,
+    log a warning and leave instructeurs untouched."""
+    demarche = DemarcheFactory(
+        raw_ds_data={
+            "groupeInstructeurs": [
+                {
+                    "id": "GROUPE-1",
+                    "instructeurs": [{"id": "A-1", "email": "a@example.com"}],
+                },
+            ]
+        }
+    )
+    dossier = DossierFactory(ds_demarche=demarche)
+    profile = Profile.objects.create(ds_id="EXISTING", ds_email="x@example.com")
+    dossier.ds_instructeurs.add(profile)
+
+    ds_payload = {"groupeInstructeur": {"id": "GROUPE-UNKNOWN"}}
+
+    # save_demarche_from_ds is stubbed to do nothing, so the id stays unknown.
+    with patch(
+        "gsl_demarches_simplifiees.importer.demarche.save_demarche_from_ds"
+    ) as mock_save_demarche:
+        with caplog.at_level(logging.WARNING):
+            refresh_dossier_instructeurs(ds_payload, dossier, groupe_index={})
+
+    mock_save_demarche.assert_called_once_with(demarche.ds_number)
+    assert "Unknown groupeInstructeur id" in caplog.text
+    # Untouched
+    assert set(dossier.ds_instructeurs.values_list("ds_id", flat=True)) == {"EXISTING"}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 🌮 Objectif

Réduire la fréquence des `Timeout on GroupeInstructeur.id` lors de l'import des dossiers DN.

## 🔍 Liste des modifications

- `iter_demarche_dossiers_pages` envoie désormais `first: 50` (configurable via `page_size`) au lieu de la valeur serveur par défaut (~100 dossiers/page).
- Le `DossierFragment` GraphQL ne demande plus que les champs effectivement consommés par l'importer (`id`, `number`, `state`, les six dates utilisées, `demandeur`, `demarche.revision.id`, `champs`, `annotations`).
- `groupeInstructeur` n'est plus chargé via son fragment complet : seul `groupeInstructeur { id }` est demandé. La liste des instructeurs est reconstruite localement à partir de `Demarche.raw_ds_data["groupeInstructeurs"]`. En cas d'`id` de groupe inconnu (groupe créé côté DN entre l'appel `getDemarche` et la page courante), on rappelle `save_demarche_from_ds` une fois ; s'il reste introuvable, on log un warning et on laisse les instructeurs du dossier intacts.
- Nettoyage des variables et fragments GraphQL devenus orphelins après le trim (`$includeMessages`, `$includeCorrections`, fragment `MessageFragment`). Les variables `$includeTraitements` et `$includeAvis` (avec leurs champs gated) sont conservées avec un défaut `false` pour réactivation rapide quand traçabilité / avis seront branchés.
- Tests : assertions sur la variable `first` (défaut `50`, surcharge `page_size=20`), mise à jour de `test_refresh_dossier_instructeurs` pour le nouveau payload, ajout du test « index reconstruit depuis `Demarche.raw_ds_data` » et du test « id de groupe inconnu → warning, ds_instructeurs intacts ».

## ⚠️ Informations supplémentaires

Effet de bord visible : `view_dossier_json` (page de debug pour les utilisateurs staff) renvoie désormais un `raw_data` plus léger, amputé des champs retirés (`motivation`, `pdf`, `usager`, etc.).

Si Sentry continue à remonter des `Timeout on GroupeInstructeur.id` après déploiement, le levier suivant est de descendre `page_size` à `20` sans toucher au schéma.