### PR TITLE
Proxy DN : restriction des champs Demarche et filtrage des dossiers supprimés

### DIFF
--- a/gsl_ds_proxy/filters.py
+++ b/gsl_ds_proxy/filters.py
@@ -41,11 +41,11 @@ def filter_response(response_data, allowed_instructeur_ids):
         dossiers = demarche.get("dossiers")
         if dossiers and isinstance(dossiers, dict):
             _filter_dossier_nodes(dossiers, allowed_instructeur_ids)
-            # DS reports partial fetch failures (e.g. null nodes) via top-level
-            # errors[]. When at least one dossier comes through, drop them so
-            # callers don't see noise alongside a structurally valid list.
-            if dossiers.get("nodes"):
-                result.pop("errors", None)
+
+        for connection_field in ("pendingDeletedDossiers", "deletedDossiers"):
+            connection = demarche.get(connection_field)
+            if connection and isinstance(connection, dict):
+                _filter_dossier_nodes(connection, allowed_instructeur_ids)
 
     # getDossier → data.dossier (single dossier)
     dossier = data.get("dossier")

--- a/gsl_ds_proxy/query_guard.py
+++ b/gsl_ds_proxy/query_guard.py
@@ -1,0 +1,118 @@
+"""Field-level allow-list for the `Demarche` GraphQL type.
+
+The DN proxy hands a token holder a single démarche; the dossier-level
+filter trims the dossiers they may see, but DS will happily expose the
+full `Demarche` shape (e.g. `groupeInstructeurs.instructeurs`) if asked.
+This module walks the parsed query AST and rejects any selection on the
+`Demarche` type that is not in `ALLOWED_DEMARCHE_FIELDS`.
+"""
+
+from graphql.language.ast import (
+    FieldNode,
+    FragmentDefinitionNode,
+    FragmentSpreadNode,
+    InlineFragmentNode,
+)
+
+ALLOWED_DEMARCHE_FIELDS = frozenset(
+    {
+        "number",
+        "title",
+        "state",
+        "dateCreation",
+        "dateFermeture",
+        "activeRevision",
+        "revision",
+        "dossiers",
+        "pendingDeletedDossiers",
+        "deletedDossiers",
+        # GraphQL meta-fields are always allowed.
+        "__typename",
+        "__schema",
+        "__type",
+    }
+)
+
+
+def _fragments_by_name(doc):
+    return {
+        d.name.value: d
+        for d in doc.definitions
+        if isinstance(d, FragmentDefinitionNode)
+    }
+
+
+def _resolve_spread(sel, fragments, seen_fragments):
+    """Yield (selection_set, new_seen) for a spread, or None if cycle/missing."""
+    frag_name = sel.name.value
+    if frag_name in seen_fragments:
+        return None
+    fragment = fragments.get(frag_name)
+    if fragment is None:
+        return None
+    return fragment.selection_set, seen_fragments | {frag_name}
+
+
+def _check_demarche_selection_set(selection_set, fragments, seen_fragments):
+    """Validate the direct selection set of a `Demarche` (aliases ignored)."""
+    if selection_set is None:
+        return None
+    for sel in selection_set.selections:
+        if isinstance(sel, FieldNode):
+            if sel.name.value not in ALLOWED_DEMARCHE_FIELDS:
+                return sel.name.value
+            continue
+        if isinstance(sel, InlineFragmentNode):
+            sub = sel.selection_set
+            new_seen = seen_fragments
+        elif isinstance(sel, FragmentSpreadNode):
+            resolved = _resolve_spread(sel, fragments, seen_fragments)
+            if resolved is None:
+                continue
+            sub, new_seen = resolved
+        else:
+            continue
+        offender = _check_demarche_selection_set(sub, fragments, new_seen)
+        if offender is not None:
+            return offender
+    return None
+
+
+def _walk_for_demarche(selection_set, fragments, seen_fragments):
+    """Find every `demarche` field in the AST and apply the Demarche guard.
+
+    Whenever we hit a field literally named `demarche`, we apply the
+    allow-list to its selection set. We also keep descending so that a
+    `demarche` nested under e.g. `dossier` or `demarche.dossiers.nodes`
+    is still caught.
+    """
+    if selection_set is None:
+        return None
+    for sel in selection_set.selections:
+        if isinstance(sel, FieldNode):
+            if sel.name.value == "demarche":
+                offender = _check_demarche_selection_set(
+                    sel.selection_set, fragments, set()
+                )
+                if offender is not None:
+                    return offender
+            sub, new_seen = sel.selection_set, seen_fragments
+        elif isinstance(sel, InlineFragmentNode):
+            sub, new_seen = sel.selection_set, seen_fragments
+        elif isinstance(sel, FragmentSpreadNode):
+            resolved = _resolve_spread(sel, fragments, seen_fragments)
+            if resolved is None:
+                continue
+            sub, new_seen = resolved
+        else:
+            continue
+        offender = _walk_for_demarche(sub, fragments, new_seen)
+        if offender is not None:
+            return offender
+    return None
+
+
+def validate_demarche_selections(doc, operation):
+    """Return the offending field name, or None if every `Demarche` selection is allowed."""
+    fragments = _fragments_by_name(doc)
+    return _walk_for_demarche(operation.selection_set, fragments, set())

--- a/gsl_ds_proxy/tests/test_filters.py
+++ b/gsl_ds_proxy/tests/test_filters.py
@@ -89,17 +89,6 @@ class FilterResponseDemarcheTest(TestCase):
         nodes = result["data"]["demarche"]["dossiers"]["nodes"]
         self.assertEqual([d["number"] for d in nodes], [1, 2])
 
-    def test_top_level_errors_dropped_when_dossiers_present(self):
-        response = self._make_demarche_response(
-            [
-                self._make_dossier(1, ["inst-a"]),
-                None,
-            ]
-        )
-        response["errors"] = [{"message": "Could not fetch dossier 42"}]
-        result = filter_response(response, {"inst-a"})
-        self.assertNotIn("errors", result)
-
     def test_top_level_errors_kept_when_filtered_list_is_empty(self):
         response = self._make_demarche_response(
             [
@@ -109,6 +98,119 @@ class FilterResponseDemarcheTest(TestCase):
         response["errors"] = [{"message": "Could not fetch dossier 42"}]
         result = filter_response(response, {"inst-a"})
         self.assertEqual(result["errors"], [{"message": "Could not fetch dossier 42"}])
+
+
+class FilterResponseDeletedDossiersTest(TestCase):
+    def _make_dossier(self, number, instructeur_ids):
+        return {
+            "number": number,
+            "groupeInstructeur": {
+                "instructeurs": [
+                    {"id": iid, "email": f"{iid}@test.fr"} for iid in instructeur_ids
+                ]
+            },
+            "instructeurs": [],
+        }
+
+    def _wrap(self, connection_field, dossiers):
+        return {
+            "data": {
+                "demarche": {
+                    connection_field: {
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": "abc",
+                        },
+                        "nodes": dossiers,
+                    }
+                }
+            }
+        }
+
+    def test_pending_deleted_dossiers_filters_unauthorized(self):
+        for connection_field in ("pendingDeletedDossiers", "deletedDossiers"):
+            with self.subTest(connection_field=connection_field):
+                response = self._wrap(
+                    connection_field,
+                    [
+                        self._make_dossier(1, ["inst-a", "inst-b"]),
+                        self._make_dossier(2, ["inst-c"]),
+                        self._make_dossier(3, ["inst-a"]),
+                    ],
+                )
+                result = filter_response(response, {"inst-a"})
+                nodes = result["data"]["demarche"][connection_field]["nodes"]
+                self.assertEqual([d["number"] for d in nodes], [1, 3])
+
+    def test_deleted_connections_preserve_page_info(self):
+        for connection_field in ("pendingDeletedDossiers", "deletedDossiers"):
+            with self.subTest(connection_field=connection_field):
+                response = self._wrap(
+                    connection_field,
+                    [self._make_dossier(1, ["inst-c"])],
+                )
+                result = filter_response(response, {"inst-a"})
+                page_info = result["data"]["demarche"][connection_field]["pageInfo"]
+                self.assertEqual(page_info["endCursor"], "abc")
+
+    def test_deleted_connections_empty_nodes_pass_through(self):
+        for connection_field in ("pendingDeletedDossiers", "deletedDossiers"):
+            with self.subTest(connection_field=connection_field):
+                response = self._wrap(connection_field, [])
+                result = filter_response(response, {"inst-a"})
+                self.assertEqual(
+                    result["data"]["demarche"][connection_field]["nodes"], []
+                )
+
+    def test_deleted_dossier_without_groupe_instructeur_is_dropped(self):
+        for connection_field in ("pendingDeletedDossiers", "deletedDossiers"):
+            with self.subTest(connection_field=connection_field):
+                response = self._wrap(
+                    connection_field,
+                    [{"number": 1}, {"number": 2, "groupeInstructeur": {}}],
+                )
+                result = filter_response(response, {"inst-a"})
+                self.assertEqual(
+                    result["data"]["demarche"][connection_field]["nodes"], []
+                )
+
+    def test_mixed_connections_filtered_independently(self):
+        response = {
+            "data": {
+                "demarche": {
+                    "dossiers": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "a"},
+                        "nodes": [
+                            self._make_dossier(1, ["inst-a"]),
+                            self._make_dossier(2, ["inst-c"]),
+                        ],
+                    },
+                    "pendingDeletedDossiers": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "b"},
+                        "nodes": [
+                            self._make_dossier(10, ["inst-c"]),
+                            self._make_dossier(11, ["inst-a"]),
+                        ],
+                    },
+                    "deletedDossiers": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "c"},
+                        "nodes": [
+                            self._make_dossier(20, ["inst-a"]),
+                            self._make_dossier(21, ["inst-b"]),
+                        ],
+                    },
+                }
+            }
+        }
+        result = filter_response(response, {"inst-a"})
+        demarche = result["data"]["demarche"]
+        self.assertEqual([d["number"] for d in demarche["dossiers"]["nodes"]], [1])
+        self.assertEqual(
+            [d["number"] for d in demarche["pendingDeletedDossiers"]["nodes"]], [11]
+        )
+        self.assertEqual(
+            [d["number"] for d in demarche["deletedDossiers"]["nodes"]], [20]
+        )
 
 
 class FilterResponseSingleDossierTest(TestCase):

--- a/gsl_ds_proxy/tests/test_query_guard.py
+++ b/gsl_ds_proxy/tests/test_query_guard.py
@@ -1,0 +1,117 @@
+from graphql import parse
+from graphql.language.ast import OperationDefinitionNode
+
+from gsl_ds_proxy.query_guard import validate_demarche_selections
+
+
+def _validate(query, operation_name=None):
+    doc = parse(query)
+    operations = [d for d in doc.definitions if isinstance(d, OperationDefinitionNode)]
+    if operation_name:
+        operation = next(
+            o for o in operations if o.name and o.name.value == operation_name
+        )
+    else:
+        operation = operations[0]
+    return validate_demarche_selections(doc, operation)
+
+
+def test_top_level_demarche_with_allowed_field_returns_none():
+    assert _validate("query getDemarche { demarche { number } }") is None
+
+
+def test_top_level_demarche_with_all_allowed_fields_returns_none():
+    query = (
+        "query getDemarche { demarche { "
+        "number title state dateCreation dateFermeture "
+        "activeRevision { id } "
+        "dossiers { nodes { number } } "
+        "} }"
+    )
+    assert _validate(query) is None
+
+
+def test_top_level_demarche_with_groupeInstructeurs_rejected():
+    query = "query getDemarche { demarche { groupeInstructeurs { id } } }"
+    assert _validate(query) == "groupeInstructeurs"
+
+
+def test_nested_dossier_demarche_with_groupeInstructeurs_rejected():
+    query = "query getDossier { dossier { demarche { groupeInstructeurs { id } } } }"
+    assert _validate(query) == "groupeInstructeurs"
+
+
+def test_dossiers_subselection_in_demarche_is_out_of_scope():
+    query = (
+        "query getDemarche { demarche { dossiers { nodes "
+        "{ number groupeInstructeur { instructeurs { id } } } } } }"
+    )
+    assert _validate(query) is None
+
+
+def test_inline_fragment_with_forbidden_field_rejected():
+    query = "query getDemarche { demarche { ... on Demarche { revisions { id } } } }"
+    assert _validate(query) == "revisions"
+
+
+def test_inline_fragment_with_allowed_field_accepted():
+    query = "query getDemarche { demarche { ... on Demarche { number title } } }"
+    assert _validate(query) is None
+
+
+def test_fragment_spread_with_forbidden_field_rejected():
+    query = (
+        "query getDemarche { demarche { ...D } } "
+        "fragment D on Demarche { service { nom } }"
+    )
+    assert _validate(query) == "service"
+
+
+def test_fragment_spread_with_allowed_field_accepted():
+    query = (
+        "query getDemarche { demarche { ...D } } "
+        "fragment D on Demarche { number title }"
+    )
+    assert _validate(query) is None
+
+
+def test_aliased_forbidden_field_rejected():
+    query = "query getDemarche { demarche { x: groupeInstructeurs { id } } }"
+    assert _validate(query) == "groupeInstructeurs"
+
+
+def test_typename_inside_demarche_allowed():
+    query = "query getDemarche { demarche { __typename number } }"
+    assert _validate(query) is None
+
+
+def test_getDossier_without_demarche_selection_passes_guard():
+    query = "query getDossier { dossier { number } }"
+    assert _validate(query) is None
+
+
+def test_demarche_inside_dossiers_nodes_caught():
+    query = (
+        "query getDemarche { demarche { dossiers { nodes "
+        "{ demarche { groupeInstructeurs { id } } } } } }"
+    )
+    assert _validate(query) == "groupeInstructeurs"
+
+
+def test_pending_deleted_dossiers_allowed():
+    query = (
+        "query getDemarche { demarche { pendingDeletedDossiers { nodes { number } } } }"
+    )
+    assert _validate(query) is None
+
+
+def test_deleted_dossiers_allowed():
+    query = "query getDemarche { demarche { deletedDossiers { nodes { number } } } }"
+    assert _validate(query) is None
+
+
+def test_self_referencing_fragment_does_not_loop():
+    query = (
+        "query getDemarche { demarche { ...D } } fragment D on Demarche { number ...D }"
+    )
+    assert _validate(query) is None

--- a/gsl_ds_proxy/tests/test_views.py
+++ b/gsl_ds_proxy/tests/test_views.py
@@ -472,6 +472,80 @@ class GraphqlProxyViewTest(TestCase):
         response = self._post({"query": "{ demarche { title } }"})
         self.assertEqual(response.status_code, 403)
 
+    @patch("gsl_ds_proxy.views.requests.post")
+    def test_getDemarche_groupeInstructeurs_field_rejected(self, mock_post):
+        response = self._post(
+            {
+                "query": (
+                    "query getDemarche { demarche "
+                    "{ groupeInstructeurs { instructeurs { id } } } }"
+                ),
+                "operationName": "getDemarche",
+                "variables": {"demarcheNumber": self.demarche.ds_number},
+            }
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(mock_post.called)
+        body = json.loads(response.content)
+        self.assertEqual(
+            body["errors"][0]["message"],
+            "Champ démarche non autorisé : `groupeInstructeurs`.",
+        )
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    def test_getDossier_demarche_groupeInstructeurs_field_rejected(self, mock_post):
+        response = self._post(
+            {
+                "query": (
+                    "query getDossier { dossier { number demarche "
+                    "{ groupeInstructeurs { id } } } }"
+                ),
+                "operationName": "getDossier",
+                "variables": {"dossierNumber": 42},
+            }
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(mock_post.called)
+        body = json.loads(response.content)
+        self.assertEqual(
+            body["errors"][0]["message"],
+            "Champ démarche non autorisé : `groupeInstructeurs`.",
+        )
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    def test_getDemarche_allowed_fields_pass(self, mock_post):
+        ds_response_data = {
+            "data": {
+                "demarche": {
+                    "number": self.demarche.ds_number,
+                    "title": "Une démarche",
+                    "state": "publiee",
+                    "dateCreation": "2025-01-01T00:00:00Z",
+                    "dateFermeture": None,
+                    "dossiers": {"nodes": []},
+                }
+            }
+        }
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_post.return_value.json.return_value = ds_response_data
+
+        response = self._post(
+            {
+                "query": (
+                    "query getDemarche { demarche "
+                    "{ number title state dateCreation dateFermeture "
+                    "dossiers { nodes { number } } } }"
+                ),
+                "operationName": "getDemarche",
+                "variables": {"demarcheNumber": self.demarche.ds_number},
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+        data = _parse_stream(response)
+        self.assertTrue(mock_post.called)
+        self.assertEqual(data["data"]["demarche"]["title"], "Une démarche")
+
     def test_operationName_not_in_document_rejected(self):
         response = self._post(
             {

--- a/gsl_ds_proxy/views.py
+++ b/gsl_ds_proxy/views.py
@@ -11,6 +11,7 @@ from graphql.language.ast import OperationDefinitionNode
 
 from gsl_ds_proxy.filters import filter_response
 from gsl_ds_proxy.models import ProxyToken
+from gsl_ds_proxy.query_guard import validate_demarche_selections
 
 logger = logging.getLogger(__name__)
 
@@ -195,6 +196,12 @@ def graphql_proxy(request):
     error = _check_operation_allowed(proxy_token, operation_name, variables)
     if error is not None:
         return error
+
+    forbidden_field = validate_demarche_selections(doc, operation)
+    if forbidden_field is not None:
+        return _error_response(
+            f"Champ démarche non autorisé : `{forbidden_field}`.", 403
+        )
 
     allowed_ids = set(proxy_token.instructeurs.values_list("ds_id", flat=True))
     stream = _stream_ds_response(


### PR DESCRIPTION
## 🌮 Objectif

Renforcer le proxy DN en limitant les champs exposés sur `Demarche` et en filtrant les connexions de dossiers supprimés par instructeur.

## 🔍 Liste des modifications

- Nouveau garde-fou `gsl_ds_proxy/query_guard.py` qui valide chaque sélection sur le type `Demarche` contre une allow-list (`number`, `title`, `state`, `dateCreation`, `dateFermeture`, `activeRevision`, `revision`, `dossiers`, `pendingDeletedDossiers`, `deletedDossiers`).
- Toute requête GraphQL sélectionnant un champ hors allow-list (ex. `groupeInstructeurs`, `service`, `revisions`) est rejetée par le proxy avec un 403 `Champ démarche non autorisé : \`<champ>\``.
- Le garde-fou gère les inline fragments, les fragment spreads (avec détection de cycle), les alias et les `demarche` imbriqués sous `dossier` ou `dossiers.nodes`.
- `filter_response` filtre désormais aussi les connexions `pendingDeletedDossiers` et `deletedDossiers` selon les `instructeurs.id` autorisés du token, en plus de `dossiers`.
- Suppression du nettoyage des `errors[]` de premier niveau lorsqu'au moins un dossier passait le filtre.
- Tests : nouveau `test_query_guard.py`, nouvelles classes `FilterResponseDeletedDossiersTest` et tests de rejet/pass-through `getDemarche` / `getDossier` dans `test_views.py`.

## ⚠️ Informations supplémentaires

Suppression volontaire du `result.pop("errors", None)` dans `filter_response` : les `errors[]` de premier niveau renvoyés par DS sont désormais transmis au client du proxy même quand des `nodes` valides passent le filtre.