### PR TITLE
Afficher correctement les documents de l'autre dotation dans l'onglet Programmation

### DIFF
--- a/gsl_programmation/table_columns.py
+++ b/gsl_programmation/table_columns.py
@@ -1,4 +1,4 @@
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 
 from gsl_core.table_columns import (
     COLUMN_ANNOTATIONS_CHAMP_LIBRE_1,
@@ -106,7 +106,7 @@ def _get_other_dotation_documents(context):
     documents = dp.programmation_projet.documents_summary
     if not documents:
         return ""
-    items = "".join(format_html("<li>{}</li>", doc) for doc in documents)
+    items = format_html_join("", "<li>{}</li>", ((doc,) for doc in documents))
     return format_html("<ul>{}</ul>", items)
 
 


### PR DESCRIPTION
## 🖼️ Images
### Avant
<img width="358" height="194" alt="image" src="https://github.com/user-attachments/assets/3cc14e90-3c12-4c36-88e8-fd5211dfe507" />

### Après
<img width="275" height="197" alt="image" src="https://github.com/user-attachments/assets/e11e7bd2-6d6b-4b89-8a5a-fcc5b2ea7049" />
