### PR TITLE
Correction sur l'affichage de la date de notification 

### DIFF
--- a/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications.html
+++ b/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications.html
@@ -69,7 +69,7 @@
         </h3>
         {% if projet.notified_at %}
             <p class="fr-text-default--success">
-                Message de notification envoyé le {{ programmation_projet.notified_at|date }} sur Démarche Numérique.
+                Message de notification envoyé le {{ projet.notified_at|date }} sur Démarche Numérique.
             </p>
         {% elif not is_instructor %}
             <button class="fr-btn fr-mt-6w fr-icon-edit-line fr-btn--icon-right"


### PR DESCRIPTION
## 🌮 Objectif

On parle de l'onglet "Notifications"

## 🖼️ Images

Avant

<img width="587" height="209" alt="image" src="https://github.com/user-attachments/assets/3a90752d-230f-4eea-b9f9-01ea43517380" />

