### PR TITLE
Création d'une action sur le BO pour récupérer un dossier depuis DN

### DIFF
--- a/gsl_demarches_simplifiees/admin.py
+++ b/gsl_demarches_simplifiees/admin.py
@@ -13,7 +13,8 @@ from gsl.utils.csp import csp_update
 from gsl_core.admin import AllPermsForStaffUser
 from gsl_core.models import Arrondissement
 
-from .forms import RefreshDossiersDepotForm
+from .forms import ImportDossierFromDsForm, RefreshDossiersDepotForm
+from .importer.dossier import import_one_dossier_from_ds
 from .models import (
     CategorieDetr,
     CategorieDsil,
@@ -241,6 +242,7 @@ class ArrondissementFilter(admin.SimpleListFilter):
 
 @admin.register(Dossier)
 class DossierAdmin(AllPermsForStaffUser, admin.ModelAdmin):
+    change_list_template = "admin/gsl_demarches_simplifiees/dossier/change_list.html"
     list_filter = ("ds_state",)
     list_display = (
         "ds_number",
@@ -318,6 +320,46 @@ class DossierAdmin(AllPermsForStaffUser, admin.ModelAdmin):
         "link_to_json",
         "link_to_edit_dossier_data",
     ]
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "import-dossier/",
+                self.admin_site.admin_view(self.import_dossier_view),
+                name="gsl_demarches_simplifiees_dossier_import_dossier",
+            ),
+        ]
+        return custom + urls
+
+    def import_dossier_view(self, request):
+        if request.method == "POST":
+            form = ImportDossierFromDsForm(request.POST)
+            if form.is_valid():
+                dossier_number = form.cleaned_data["dossier_number"]
+                level, message = import_one_dossier_from_ds(dossier_number)
+                self.message_user(request, message, level)
+                return redirect("admin:gsl_demarches_simplifiees_dossier_changelist")
+        else:
+            form = ImportDossierFromDsForm()
+        context = {
+            **self.admin_site.each_context(request),
+            "form": form,
+            "opts": self.model._meta,
+            "title": "Importer un dossier depuis DN",
+        }
+        return render(
+            request,
+            "admin/gsl_demarches_simplifiees/dossier/import_dossier.html",
+            context,
+        )
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context["import_dossier_url"] = reverse(
+            "admin:gsl_demarches_simplifiees_dossier_import_dossier"
+        )
+        return super().changelist_view(request, extra_context)
 
     @admin.action(description="🛢️ Rafraîchir depuis la base de données")
     def refresh_from_db(self, request, queryset):

--- a/gsl_demarches_simplifiees/forms.py
+++ b/gsl_demarches_simplifiees/forms.py
@@ -114,6 +114,19 @@ class DossierReporteSansPieceForm(forms.ModelForm, DsfrBaseForm):
         }
 
 
+class ImportDossierFromDsForm(forms.Form):
+    """Formulaire admin : importer un dossier depuis DN par son numéro."""
+
+    dossier_number = forms.IntegerField(
+        label="Numéro du dossier",
+        help_text=(
+            "Le dossier sera importé uniquement si sa démarche est présente sur Turgot "
+            "et s'il n'existe pas encore."
+        ),
+        min_value=1,
+    )
+
+
 class RefreshDossiersDepotForm(forms.Form):
     """Formulaire admin : rafraîchir les dossiers d'une démarche déposés après une date."""
 

--- a/gsl_demarches_simplifiees/importer/dossier.py
+++ b/gsl_demarches_simplifiees/importer/dossier.py
@@ -130,6 +130,76 @@ def create_or_update_dossier_from_ds_number(ds_number: str):
     )
 
 
+def import_one_dossier_from_ds(dossier_number: int):
+    """
+    Récupère un dossier sur DN et le crée dans Turgot si :
+    - sa démarche est présente dans Turgot
+    - il n'existe pas encore dans Turgot
+
+    Retourne un tuple (level, message) à la manière de save_one_dossier_from_ds.
+    """
+    client = DsClient()
+    try:
+        dossier_data = client.get_one_dossier(dossier_number)
+    except DsServiceException as e:
+        logger.warning(
+            f"Impossible de récupérer le dossier #{dossier_number} depuis Démarches Numériques.",
+            extra={
+                "dossier_ds_number": dossier_number,
+                "error": str(e),
+            },
+        )
+        message = f"Impossible de récupérer le dossier #{dossier_number} depuis Démarches Numériques."
+        if str(e):
+            message += f" Erreur : {str(e)}"
+        return (messages.WARNING, message)
+
+    demarche_number = dossier_data["demarche"]["number"]
+
+    if not Demarche.objects.filter(ds_number=demarche_number).exists():
+        logger.info(
+            "Démarche absente de Turgot, import ignoré",
+            extra={
+                "dossier_ds_number": dossier_number,
+                "demarche_ds_number": demarche_number,
+            },
+        )
+        return (
+            messages.WARNING,
+            f"La démarche n°{demarche_number} n'est pas présente sur Turgot.",
+        )
+
+    if Dossier.objects.filter(ds_number=dossier_number).exists():
+        logger.info(
+            "Dossier déjà présent dans Turgot, import ignoré",
+            extra={"dossier_ds_number": dossier_number},
+        )
+        return (
+            messages.WARNING,
+            f"Le dossier #{dossier_number} existe déjà sur Turgot.",
+        )
+
+    active_departement_insee_codes = _get_active_departement_insee_codes()
+    is_active, departement = _is_dossier_in_active_departement(
+        dossier_data, active_departement_insee_codes
+    )
+    if not is_active:
+        logger.info(
+            "Dossier dans un département inactif, import ignoré",
+            extra={"dossier_ds_number": dossier_number, "departement": departement},
+        )
+        return (
+            messages.WARNING,
+            f"Le dossier #{dossier_number} appartient au département « {departement} » qui n'est pas actif sur Turgot.",
+        )
+
+    _create_or_update_dossier_from_ds_data(dossier_data, active_departement_insee_codes)
+    return (
+        messages.SUCCESS,
+        f"Le dossier #{dossier_number} a été importé avec succès.",
+    )
+
+
 def refresh_dossier_from_saved_data(dossier: Dossier):
     dossier_converter = DossierConverter(dossier.ds_data.raw_data, dossier)
     dossier_converter.fill_unmapped_fields()
@@ -286,27 +356,6 @@ def _get_active_departement_insee_codes():
     return Departement.objects.filter(active=True).values_list("insee_code", flat=True)
 
 
-def _is_dossier_in_active_departement(
-    raw_data: dict, departements_actifs: Iterable[str]
-) -> bool:
-    champs = raw_data.get("champs", [])
-
-    for champ in champs:
-        if champ.get("label") == "Département ou collectivité du demandeur":
-            valeur = champ.get("stringValue", "").strip()
-
-            if not valeur:
-                return False
-
-            # Exemple valeur : "75 - Paris"
-            code_insee = valeur.split("-")[0].strip()
-
-            return code_insee in set(departements_actifs)
-
-    # Champ non trouvé
-    return False
-
-
 def _create_or_update_dossier_from_ds_data(
     dossier_data: dict | None,
     active_departement_insee_codes: Iterable[str],
@@ -319,7 +368,7 @@ def _create_or_update_dossier_from_ds_data(
         demarche_number = dossier_data["demarche"]["number"]
         demarche = Demarche.objects.get(ds_number=demarche_number)
 
-    must_create_or_update_dossier = _is_dossier_in_active_departement(
+    must_create_or_update_dossier, _ = _is_dossier_in_active_departement(
         dossier_data, active_departement_insee_codes
     )
     if not must_create_or_update_dossier:
@@ -349,3 +398,24 @@ def _create_or_update_dossier_from_ds_data(
         refresh_only_if_dossier_has_been_updated=False,
         groupe_index=groupe_index,
     )
+
+
+def _is_dossier_in_active_departement(
+    raw_data: dict, departements_actifs: Iterable[str]
+) -> tuple[bool, str]:
+    champs = raw_data.get("champs", [])
+
+    for champ in champs:
+        if champ.get("label") == "Département ou collectivité du demandeur":
+            valeur = champ.get("stringValue", "").strip()
+
+            if not valeur:
+                return False, valeur
+
+            # Exemple valeur : "75 - Paris"
+            code_insee = valeur.split("-")[0].strip()
+
+            return code_insee in set(departements_actifs), valeur
+
+    # Champ non trouvé
+    return False, "inconnu"

--- a/gsl_demarches_simplifiees/management/commands/ds_import_dossier.py
+++ b/gsl_demarches_simplifiees/management/commands/ds_import_dossier.py
@@ -1,0 +1,27 @@
+from django.core.management.base import BaseCommand
+
+from gsl_demarches_simplifiees.importer.dossier import import_one_dossier_from_ds
+
+
+class Command(BaseCommand):
+    """
+    Usage:
+        python manage.py ds_import_dossier <dossier_number>
+
+    Example:
+        python manage.py ds_import_dossier 123456
+    """
+
+    help = (
+        "Importe un dossier depuis DN si sa démarche est présente sur Turgot "
+        "et s'il n'existe pas déjà"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("dossier_number", type=int, help="Numéro du dossier sur DN")
+
+    def handle(self, *args, **options):
+        dossier_number = options["dossier_number"]
+        self.stdout.write(f"Récupération du dossier #{dossier_number} depuis DN…")
+        import_one_dossier_from_ds(dossier_number)
+        self.stdout.write(self.style.SUCCESS("Terminé."))

--- a/gsl_demarches_simplifiees/templates/admin/gsl_demarches_simplifiees/dossier/change_list.html
+++ b/gsl_demarches_simplifiees/templates/admin/gsl_demarches_simplifiees/dossier/change_list.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+    <li>
+        <a href="{{ import_dossier_url }}" class="addlink">
+            Importer un dossier depuis DN
+        </a>
+    </li>
+    {{ block.super }}
+{% endblock object-tools-items %}

--- a/gsl_demarches_simplifiees/templates/admin/gsl_demarches_simplifiees/dossier/import_dossier.html
+++ b/gsl_demarches_simplifiees/templates/admin/gsl_demarches_simplifiees/dossier/import_dossier.html
@@ -26,9 +26,9 @@
             {% endfor %}
         </div>
         <div class="submit-row">
-            <a href="{% url 'admin:gsl_demarches_simplifiees_demarche_changelist' %}"
+            <a href="{% url 'admin:gsl_demarches_simplifiees_dossier_changelist' %}"
                class="button cancel-link">Annuler</a>
-            <input type="submit" value="Rafraîchir les dossiers" class="default">
+            <input type="submit" value="Importer le dossier" class="default">
         </div>
     </form>
 {% endblock content %}

--- a/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
+++ b/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
@@ -6,10 +6,11 @@ from django.contrib import messages
 from django.utils.timezone import datetime
 
 from gsl_demarches_simplifiees.ds_client import DsClient
-from gsl_demarches_simplifiees.exceptions import DsServiceException
+from gsl_demarches_simplifiees.exceptions import DsConnectionError, DsServiceException
 from gsl_demarches_simplifiees.importer.dossier import (
     _is_dossier_in_active_departement,
     _save_dossier_data_and_refresh_dossier_and_projet_and_co,
+    import_one_dossier_from_ds,
     refresh_dossier_instructeurs,
     save_demarche_dossiers_from_ds,
     save_one_dossier_from_ds,
@@ -410,7 +411,9 @@ def test_is_dossier_in_active_departement_department_found_and_in_active_list():
         ]
     }
     departements_actifs = ["75", "13", "69"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is True
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is True
+    assert label == "75 - Paris"
 
 
 def test_is_dossier_in_active_departement_department_found_but_not_in_active_list():
@@ -424,7 +427,9 @@ def test_is_dossier_in_active_departement_department_found_but_not_in_active_lis
         ]
     }
     departements_actifs = ["13", "69", "92"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is False
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is False
+    assert label == "75 - Paris"
 
 
 def test_is_dossier_in_active_departement_empty_value():
@@ -438,7 +443,9 @@ def test_is_dossier_in_active_departement_empty_value():
         ]
     }
     departements_actifs = ["75", "13", "69"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is False
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is False
+    assert label == ""
 
 
 def test_is_dossier_in_active_departement_whitespace_only_value():
@@ -452,7 +459,9 @@ def test_is_dossier_in_active_departement_whitespace_only_value():
         ]
     }
     departements_actifs = ["75", "13", "69"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is False
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is False
+    assert label == ""
 
 
 def test_is_dossier_in_active_departement_field_not_found():
@@ -463,21 +472,27 @@ def test_is_dossier_in_active_departement_field_not_found():
         ]
     }
     departements_actifs = ["75", "13", "69"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is False
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is False
+    assert label == "inconnu"
 
 
 def test_is_dossier_in_active_departement_no_champs_key():
     """Test when champs key is missing from raw_data."""
     raw_data = {}
     departements_actifs = ["75", "13", "69"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is False
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is False
+    assert label == "inconnu"
 
 
 def test_is_dossier_in_active_departement_empty_champs():
     """Test when champs is an empty list."""
     raw_data = {"champs": []}
     departements_actifs = ["75", "13", "69"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is False
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is False
+    assert label == "inconnu"
 
 
 def test_is_dossier_in_active_departement_with_whitespace_in_code():
@@ -491,7 +506,9 @@ def test_is_dossier_in_active_departement_with_whitespace_in_code():
         ]
     }
     departements_actifs = ["75", "13", "69"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is True
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is True
+    assert label == "75  - Paris"
 
 
 def test_is_dossier_in_active_departement_with_different_format():
@@ -505,7 +522,9 @@ def test_is_dossier_in_active_departement_with_different_format():
         ]
     }
     departements_actifs = ["13", "69"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is True
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is True
+    assert label == "13- Bouches-du-Rhône"
 
 
 def test_is_dossier_in_active_departement_with_list_of_strings():
@@ -519,7 +538,9 @@ def test_is_dossier_in_active_departement_with_list_of_strings():
         ]
     }
     departements_actifs = ["69", "75"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is True
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is True
+    assert label == "69 - Rhône"
 
 
 def test_is_dossier_in_active_departement_with_set():
@@ -533,7 +554,9 @@ def test_is_dossier_in_active_departement_with_set():
         ]
     }
     departements_actifs = {"92", "75", "13"}
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is True
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is True
+    assert label == "92 - Hauts-de-Seine"
 
 
 def test_is_dossier_in_active_departement_no_stringValue_key():
@@ -546,4 +569,128 @@ def test_is_dossier_in_active_departement_no_stringValue_key():
         ]
     }
     departements_actifs = ["75", "13", "69"]
-    assert _is_dossier_in_active_departement(raw_data, departements_actifs) is False
+    is_active, label = _is_dossier_in_active_departement(raw_data, departements_actifs)
+    assert is_active is False
+    assert label == ""
+
+
+# tests import_one_dossier_from_ds
+
+
+def _make_dossier_data(dossier_number, demarche_number, departement_code="75"):
+    return {
+        "id": f"DOSS-{dossier_number}",
+        "number": dossier_number,
+        "demarche": {"number": demarche_number},
+        "champs": [
+            {
+                "label": "Département ou collectivité du demandeur",
+                "stringValue": f"{departement_code} - Département",
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize("exception_class", [DsServiceException, DsConnectionError])
+def test_import_one_dossier_from_ds_erreur_dn(exception_class):
+    with patch(
+        "gsl_demarches_simplifiees.ds_client.DsClient.get_one_dossier",
+        side_effect=exception_class,
+    ):
+        level, message = import_one_dossier_from_ds(20240001)
+
+    assert level == messages.WARNING
+    assert "20240001" in message
+    if exception_class == DsConnectionError:
+        assert (
+            "Erreur : Nous n'arrivons pas à nous connecter à Démarche Numérique."
+            in message
+        )
+
+
+@pytest.mark.django_db
+def test_import_one_dossier_from_ds_demarche_absente(caplog):
+    caplog.set_level(logging.INFO)
+    dossier_number = 20240001
+    dossier_data = _make_dossier_data(dossier_number, demarche_number=9999)
+
+    with patch(
+        "gsl_demarches_simplifiees.ds_client.DsClient.get_one_dossier",
+        return_value=dossier_data,
+    ):
+        level, message = import_one_dossier_from_ds(dossier_number)
+
+    assert Dossier.objects.count() == 0
+    assert level == messages.WARNING
+    assert "9999" in message
+    assert "Démarche absente de Turgot" in caplog.text
+
+
+@pytest.mark.django_db
+def test_import_one_dossier_from_ds_dossier_deja_existant(caplog):
+    caplog.set_level(logging.INFO)
+    demarche = DemarcheFactory()
+    existing_dossier = DossierFactory(ds_number=20240001, ds_demarche=demarche)
+    dossier_data = _make_dossier_data(20240001, demarche.ds_number)
+
+    with patch(
+        "gsl_demarches_simplifiees.ds_client.DsClient.get_one_dossier",
+        return_value=dossier_data,
+    ):
+        level, message = import_one_dossier_from_ds(20240001)
+
+    assert Dossier.objects.count() == 1
+    assert Dossier.objects.filter(pk=existing_dossier.pk).exists()
+    assert level == messages.WARNING
+    assert "20240001" in message
+    assert "Dossier déjà présent dans Turgot" in caplog.text
+
+
+@pytest.mark.django_db
+def test_import_one_dossier_from_ds_departement_inactif(caplog):
+    caplog.set_level(logging.INFO)
+    demarche = DemarcheFactory()
+    dossier_number = 20240001
+    dossier_data = _make_dossier_data(
+        dossier_number, demarche.ds_number, departement_code="99"
+    )
+
+    with patch(
+        "gsl_demarches_simplifiees.ds_client.DsClient.get_one_dossier",
+        return_value=dossier_data,
+    ):
+        with patch(
+            "gsl_demarches_simplifiees.importer.dossier._get_active_departement_insee_codes",
+            return_value=["75"],
+        ):
+            level, message = import_one_dossier_from_ds(dossier_number)
+
+    assert Dossier.objects.count() == 0
+    assert level == messages.WARNING
+    assert "99" in message
+    assert "Dossier dans un département inactif" in caplog.text
+
+
+@pytest.mark.django_db
+def test_import_one_dossier_from_ds_cree_le_dossier():
+    demarche = DemarcheFactory()
+    dossier_number = 20240001
+    dossier_data = _make_dossier_data(dossier_number, demarche.ds_number)
+
+    with patch(
+        "gsl_demarches_simplifiees.ds_client.DsClient.get_one_dossier",
+        return_value=dossier_data,
+    ):
+        with patch(
+            "gsl_demarches_simplifiees.importer.dossier._get_active_departement_insee_codes",
+            return_value=["75"],
+        ):
+            with patch(
+                "gsl_demarches_simplifiees.importer.dossier._save_dossier_data_and_refresh_dossier_and_projet_and_co"
+            ) as mock_refresh:
+                level, message = import_one_dossier_from_ds(dossier_number)
+
+    assert Dossier.objects.filter(ds_number=dossier_number).exists()
+    assert level == messages.SUCCESS
+    assert "20240001" in message
+    mock_refresh.assert_called_once()


### PR DESCRIPTION
## 🌮 Objectif

Permettre aux administrateurs d'importer manuellement un dossier depuis Démarches Numériques (DN) via le back-office ou une commande de gestion.
Comme ça, si on a des dossiers manquants, les non-devs peuvent intervenir.

## 🔍 Liste des modifications

- Ajout de `import_one_dossier_from_ds` dans `importer/dossier.py` : récupère un dossier sur DN et le crée dans Turgot si sa démarche est présente, s'il n'existe pas déjà, et si son département est actif
- Ajout de la commande de gestion `ds_import_dossier` (usage : `python manage.py ds_import_dossier <numéro>`)
- Ajout d'un bouton « Importer un dossier depuis DN » dans la liste des dossiers du BO, avec une vue et un formulaire dédiés (`ImportDossierFromDsForm`)
- Refacto `_is_dossier_in_active_departement` : retourne maintenant `tuple[bool, str]` (actif + libellé du département) au lieu de `bool`, suppression de `_get_departement_label_from_dossier_data`
- Tests pour `import_one_dossier_from_ds` et mise à jour des tests de `_is_dossier_in_active_departement`

## ⚠️ Informations supplémentaires

L'import est silencieux si le dossier existe déjà ou si la démarche est absente — un message d'avertissement est affiché dans le BO dans ces cas.