### PR TITLE
Proxy DN : autoriser les champs datePublication et dateDerniereModification sur Demarche

### DIFF
--- a/gsl_ds_proxy/query_guard.py
+++ b/gsl_ds_proxy/query_guard.py
@@ -20,6 +20,8 @@ ALLOWED_DEMARCHE_FIELDS = frozenset(
         "title",
         "state",
         "dateCreation",
+        "datePublication",
+        "dateDerniereModification",
         "dateFermeture",
         "activeRevision",
         "revision",


### PR DESCRIPTION
## 🌮 Objectif

Étendre l'allow-list des champs `Demarche` du proxy DN pour exposer les dates de publication et de dernière modification.

## 🔍 Liste des modifications

- Ajout de `datePublication` et `dateDerniereModification` dans `ALLOWED_DEMARCHE_FIELDS` (`gsl_ds_proxy/query_guard.py`)