### PR TITLE
Réparation de la récupération des profils DN en acceptant la modification d'adresse email

### DIFF
--- a/gsl_demarches_simplifiees/importer/demarche.py
+++ b/gsl_demarches_simplifiees/importer/demarche.py
@@ -4,14 +4,16 @@ from django.utils import timezone
 
 from gsl_core.models import Departement
 from gsl_demarches_simplifiees.ds_client import DsClient
-from gsl_demarches_simplifiees.importer.utils import get_departement_from_field_label
+from gsl_demarches_simplifiees.importer.utils import (
+    get_departement_from_field_label,
+    get_or_create_profile,
+)
 from gsl_demarches_simplifiees.models import (
     CategorieDetr,
     CategorieDsil,
     Demarche,
     Dossier,
     FieldMapping,
-    Profile,
 )
 
 logger = getLogger(__name__)
@@ -100,10 +102,8 @@ def update_or_create_demarche(demarche_data):
 def save_groupe_instructeurs(demarche_data, demarche):
     for groupe in demarche_data["groupeInstructeurs"]:
         for instructeur in groupe["instructeurs"]:
-            instructeur, _ = Profile.objects.get_or_create(
-                ds_id=instructeur["id"], ds_email=instructeur["email"]
-            )
-            demarche.ds_instructeurs.add(instructeur)
+            profile = get_or_create_profile(instructeur["id"], instructeur["email"])
+            demarche.ds_instructeurs.add(profile)
 
 
 DN_DEPARTEMENT_FIELD_TO_DJANGO_FIELD_MAP = {

--- a/gsl_demarches_simplifiees/importer/dossier.py
+++ b/gsl_demarches_simplifiees/importer/dossier.py
@@ -8,7 +8,8 @@ from gsl_core.models import Departement
 from gsl_demarches_simplifiees.ds_client import DsClient
 from gsl_demarches_simplifiees.exceptions import DsServiceException
 from gsl_demarches_simplifiees.importer.dossier_converter import DossierConverter
-from gsl_demarches_simplifiees.models import Demarche, Dossier, DossierData, Profile
+from gsl_demarches_simplifiees.importer.utils import get_or_create_profile
+from gsl_demarches_simplifiees.models import Demarche, Dossier, DossierData
 from gsl_projet.services.projet_services import ProjetService
 
 logger = logging.getLogger(__name__)
@@ -202,8 +203,8 @@ def refresh_dossier_instructeurs(
     dossier_instructeurs_ids = [p.ds_id for p in dossier.ds_instructeurs.all()]
     for instructeur_data in instructeurs_data:
         if instructeur_data["id"] not in dossier_instructeurs_ids:
-            instructeur, _ = Profile.objects.get_or_create(
-                ds_id=instructeur_data["id"], ds_email=instructeur_data["email"]
+            instructeur = get_or_create_profile(
+                instructeur_data["id"], instructeur_data["email"]
             )
             dossier.ds_instructeurs.add(instructeur)
 

--- a/gsl_demarches_simplifiees/importer/utils.py
+++ b/gsl_demarches_simplifiees/importer/utils.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from django.utils import timezone
 
 from gsl_core.models import Arrondissement, Departement, Perimetre
-from gsl_demarches_simplifiees.models import CategorieDetr, Demarche, Dossier
+from gsl_demarches_simplifiees.models import CategorieDetr, Demarche, Dossier, Profile
 
 logger = getLogger(__name__)
 
@@ -19,6 +19,16 @@ NOT_HANDLED_TERRITORIES = [
     "988",  # Nouvelle-Calédonie,
     "989",  # île de Clipperton
 ]
+
+
+def get_or_create_profile(ds_id: str, ds_email: str) -> Profile:
+    profile, created = Profile.objects.get_or_create(
+        ds_id=ds_id, defaults={"ds_email": ds_email}
+    )
+    if not created and profile.ds_email != ds_email:
+        profile.ds_email = ds_email
+        profile.save(update_fields=["ds_email"])
+    return profile
 
 
 def get_departement_from_field_label(label: str) -> Departement | None:

--- a/gsl_demarches_simplifiees/tests/importer/test_save_ds_demarche.py
+++ b/gsl_demarches_simplifiees/tests/importer/test_save_ds_demarche.py
@@ -201,6 +201,18 @@ def test_save_groupe_instructeurs_if_already_exists(
     assert Profile.objects.count() == 2
 
 
+def test_save_groupe_instructeurs_updates_email_if_changed(
+    demarche, demarche_data_without_dossier
+):
+    Profile.objects.create(
+        ds_id="TEST_ID_ldXItMTIzNTcx", ds_email="old.email@example.com"
+    )
+    save_groupe_instructeurs(demarche_data_without_dossier, demarche)
+    profile = Profile.objects.get(ds_id="TEST_ID_ldXItMTIzNTcx")
+    assert profile.ds_email == "hubert.lingot@example.com"
+    assert Profile.objects.count() == 2
+
+
 def test_computer_mappings_are_created(demarche, demarche_data_without_dossier):
     assert FieldMapping.objects.count() == 0
 


### PR DESCRIPTION
## 🌮 Objectif

On a eu un cas d'instructrice qui a modifié son adresse mail et qui a fait planter notre mise à jour de démarche

[Erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/277416/?environment=prod&query=is%3Aunresolved&referrer=issue-stream&sort=date)