### PR TITLE
Ajouter un filtre de recherche sur les listes de projets, simulations et programmations

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "mozilla_django_oidc",
     "django.contrib.contenttypes",
+    "django.contrib.postgres",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",

--- a/gsl_demarches_simplifiees/migrations/0057_pg_trgm_search.py
+++ b/gsl_demarches_simplifiees/migrations/0057_pg_trgm_search.py
@@ -1,0 +1,51 @@
+from django.contrib.postgres.operations import TrigramExtension, UnaccentExtension
+from django.db import migrations
+
+
+class PostgresOnlyRunSQL(migrations.RunSQL):
+    """RunSQL variant that no-ops on non-PostgreSQL backends (e.g. test SQLite)."""
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        if schema_editor.connection.vendor != "postgresql":
+            return
+        super().database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        if schema_editor.connection.vendor != "postgresql":
+            return
+        super().database_backwards(app_label, schema_editor, from_state, to_state)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("gsl_demarches_simplifiees", "0056_merge_20260427_1223"),
+    ]
+
+    operations = [
+        UnaccentExtension(),
+        TrigramExtension(),
+        PostgresOnlyRunSQL(
+            sql=(
+                "CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text "
+                "AS $$ SELECT public.unaccent('public.unaccent', $1) $$ "
+                "LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;"
+            ),
+            reverse_sql="DROP FUNCTION IF EXISTS f_unaccent(text);",
+        ),
+        PostgresOnlyRunSQL(
+            sql=(
+                "CREATE INDEX dossier_intitule_trgm_idx "
+                "ON gsl_demarches_simplifiees_dossier "
+                "USING gin (f_unaccent(projet_intitule) gin_trgm_ops);"
+            ),
+            reverse_sql="DROP INDEX IF EXISTS dossier_intitule_trgm_idx;",
+        ),
+        PostgresOnlyRunSQL(
+            sql=(
+                "CREATE INDEX personnemorale_rs_trgm_idx "
+                "ON gsl_demarches_simplifiees_personnemorale "
+                "USING gin (f_unaccent(raison_sociale) gin_trgm_ops);"
+            ),
+            reverse_sql="DROP INDEX IF EXISTS personnemorale_rs_trgm_idx;",
+        ),
+    ]

--- a/gsl_programmation/tests/test_programmation_projet_filters.py
+++ b/gsl_programmation/tests/test_programmation_projet_filters.py
@@ -829,6 +829,59 @@ class TestProgrammationProjetFilters:
         assert prog_tot in result
         assert prog_tard not in result
 
+    def test_search_filter(self, mock_request, enveloppe, arrondissement):
+        """Test le filtre de recherche par intitulé, demandeur et n° dossier."""
+        demandeur_quimper = PersonneMoraleFactory(raison_sociale="Commune de Quimper")
+        demandeur_brest = PersonneMoraleFactory(raison_sociale="Commune de Brest")
+
+        dossier_ecole = DossierFactory(
+            projet_intitule="Rénovation école",
+            ds_demandeur=demandeur_quimper,
+            ds_number=9000001,
+            perimetre=arrondissement,
+        )
+        dossier_mairie = DossierFactory(
+            projet_intitule="Construction mairie",
+            ds_demandeur=demandeur_brest,
+            ds_number=9000002,
+            perimetre=arrondissement,
+        )
+
+        dotation_ecole = DotationProjetFactory(
+            projet=ProjetFactory(dossier_ds=dossier_ecole), dotation=DOTATION_DETR
+        )
+        dotation_mairie = DotationProjetFactory(
+            projet=ProjetFactory(dossier_ds=dossier_mairie), dotation=DOTATION_DETR
+        )
+
+        prog_ecole = ProgrammationProjetFactory(
+            dotation_projet=dotation_ecole, enveloppe=enveloppe
+        )
+        prog_mairie = ProgrammationProjetFactory(
+            dotation_projet=dotation_mairie, enveloppe=enveloppe
+        )
+
+        filterset = ProgrammationProjetFilters(
+            data={"search": "école"}, request=mock_request
+        )
+        result = list(filterset.qs)
+        assert prog_ecole in result
+        assert prog_mairie not in result
+
+        filterset = ProgrammationProjetFilters(
+            data={"search": "Brest"}, request=mock_request
+        )
+        result = list(filterset.qs)
+        assert prog_ecole not in result
+        assert prog_mairie in result
+
+        filterset = ProgrammationProjetFilters(
+            data={"search": "9000002"}, request=mock_request
+        )
+        result = list(filterset.qs)
+        assert prog_ecole not in result
+        assert prog_mairie in result
+
     def test_empty_filters(self, mock_request, enveloppe, arrondissement):
         """Test que sans filtres, tous les projets de l'enveloppe sont retournés"""
         projet1 = ProjetFactory(dossier_ds__perimetre=arrondissement)

--- a/gsl_programmation/utils/programmation_projet_filters.py
+++ b/gsl_programmation/utils/programmation_projet_filters.py
@@ -1,5 +1,6 @@
 from django.db.models import Case, DecimalField, F, When
 from django_filters import (
+    CharFilter,
     ChoiceFilter,
     DateFromToRangeFilter,
     FilterSet,
@@ -35,6 +36,7 @@ from gsl_projet.utils.projet_filters import (
     filter_boolean,
     filter_dossier_complet,
     filter_dotation_sollicitee,
+    make_filter_search,
 )
 
 PROGRAMMATION_ORDERING_MAP = {
@@ -55,6 +57,11 @@ PROGRAMMATION_ORDERING_MAP = {
 
 
 class ProgrammationProjetFilters(FilterSet):
+    search = CharFilter(
+        label="Recherche",
+        method="filter_search",
+    )
+
     categorie_detr = MultipleChoiceFilter(
         label="Catégorie DETR",
         field_name="dotation_projet__projet__dossier_ds__demande_categorie_detr",
@@ -173,6 +180,13 @@ class ProgrammationProjetFilters(FilterSet):
     filter_boolean = staticmethod(filter_boolean)
     filter_dotation_sollicitee = staticmethod(filter_dotation_sollicitee)
     filter_dossier_complet = staticmethod(filter_dossier_complet)
+    filter_search = staticmethod(
+        make_filter_search(
+            intitule_field="dotation_projet__projet__dossier_ds__projet_intitule",
+            raison_sociale_field="dotation_projet__projet__dossier_ds__ds_demandeur__raison_sociale",
+            ds_number_field="dotation_projet__projet__dossier_ds__ds_number",
+        )
+    )
 
     date_depot = DateFromToRangeFilter(
         label="Date de dépôt",
@@ -223,6 +237,7 @@ class ProgrammationProjetFilters(FilterSet):
     class Meta:
         model = ProgrammationProjet
         fields = (
+            "search",
             "territoire",
             "epci",
             "categorie_detr",

--- a/gsl_projet/static/css/projet_list_filters.css
+++ b/gsl_projet/static/css/projet_list_filters.css
@@ -203,6 +203,16 @@
   max-width: 270px;
 }
 
+.filters-flex-row > .filter-field--search {
+  flex: 1 1 280px;
+  min-width: 280px;
+  max-width: 360px;
+}
+
+.filter-field--search .fr-search-bar {
+  width: 100%;
+}
+
 #filter-categorie_detr > div {
   max-height: 400px;
   scroll-behavior: auto;

--- a/gsl_projet/templates/includes/_filter_search.html
+++ b/gsl_projet/templates/includes/_filter_search.html
@@ -1,0 +1,15 @@
+<div class="filter-field filter-field--search" role="search">
+    <label class="fr-label" for="{{ field.id_for_label }}">
+        {{ field.label }}
+    </label>
+    <div class="fr-search-bar" id="search-{{ field.name }}">
+        <input type="search"
+               class="fr-input"
+               name="{{ field.name }}"
+               id="{{ field.id_for_label }}"
+               value="{{ field.value|default_if_none:'' }}">
+        <button class="fr-btn" type="submit" aria-label="Lancer la recherche">
+            Rechercher
+        </button>
+    </div>
+</div>

--- a/gsl_projet/templates/includes/_projet_list_filters.html
+++ b/gsl_projet/templates/includes/_projet_list_filters.html
@@ -14,6 +14,9 @@
 
     <div class="projets-filters-layout {% if component_included_in_parent %} projet-filters-in-parent{% endif %} fr-container--fluid">
         <div class="filters-flex-row">
+            {% if filter.form.search %}
+                {% include "includes/_filter_search.html" with field=filter.form.search %}
+            {% endif %}
             <div class="fr-col-12 fr-col-md-4 fr-col-lg-3 reinit-filters">
                 <button class="fr-btn fr-btn--tertiary"
                         type="submit"
@@ -43,7 +46,7 @@
                 {% endif %}
             {% endif %}
             {% for field in filter.form %}
-                {% if field.name != "order" %}
+                {% if field.name != "order" and field.name != "search" %}
                     {% include field.field.widget.display_template with field=field %}
                 {% endif %}
             {% endfor %}

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -2,6 +2,7 @@ from datetime import UTC
 from decimal import Decimal
 
 import pytest
+from django.db import connection
 from django.db.models import Count, F, Q
 from django.urls import reverse
 from django.utils import timezone
@@ -35,6 +36,11 @@ from gsl_projet.views import (
 )
 
 pytestmark = pytest.mark.django_db
+
+requires_postgres = pytest.mark.skipif(
+    connection.vendor != "postgresql",
+    reason="diacritic-insensitive search requires PostgreSQL (unaccent + pg_trgm)",
+)
 
 
 @pytest.fixture
@@ -841,6 +847,98 @@ def test_filter_territoire_with_two_arrondissements_gives_only_these_arrondissem
 
     assert qs.count() == 2
     assert qs.first().perimetre in [perimetre_quimper, perimetre_brest]
+
+
+### Tests du filtre de recherche
+
+
+@pytest.fixture
+def searchable_projets() -> dict[str, Projet]:
+    return {
+        "ecole": ProjetFactory(
+            dossier_ds__projet_intitule="Rénovation de l'école Jules Ferry",
+            dossier_ds__ds_demandeur__raison_sociale="Commune de Brest",
+            dossier_ds__ds_number=1234567,
+        ),
+        "mairie": ProjetFactory(
+            dossier_ds__projet_intitule="Construction d'une nouvelle mairie",
+            dossier_ds__ds_demandeur__raison_sociale="Commune de Quimper",
+            dossier_ds__ds_number=2345678,
+        ),
+        "voirie": ProjetFactory(
+            dossier_ds__projet_intitule="Réfection de la voirie communale",
+            dossier_ds__ds_demandeur__raison_sociale="EPCI Pays de Morlaix",
+            dossier_ds__ds_number=3456789,
+        ),
+        "numerisation": ProjetFactory(
+            dossier_ds__projet_intitule="Numérisation des écoles",
+            dossier_ds__ds_demandeur__raison_sociale="Commune de Rennes",
+            dossier_ds__ds_number=4567890,
+        ),
+    }
+
+
+def test_filter_search_matches_projet_intitule(req, view, searchable_projets):
+    request = req.get("/", data={"search": "Jules Ferry"})
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+    assert list(qs) == [searchable_projets["ecole"]]
+
+
+def test_filter_search_matches_raison_sociale(req, view, searchable_projets):
+    request = req.get("/", data={"search": "Quimper"})
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+    assert list(qs) == [searchable_projets["mairie"]]
+
+
+def test_filter_search_matches_ds_number_exactly(req, view, searchable_projets):
+    request = req.get("/", data={"search": "3456789"})
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+    assert list(qs) == [searchable_projets["voirie"]]
+
+
+def test_filter_search_empty_returns_all(req, view, searchable_projets):
+    request = req.get("/", data={"search": ""})
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+    assert qs.count() == len(searchable_projets)
+
+
+def test_filter_search_no_match_returns_empty(req, view, searchable_projets):
+    request = req.get("/", data={"search": "zzzzzNonExistent"})
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+    assert qs.count() == 0
+
+
+@requires_postgres
+def test_filter_search_matches_ignoring_diacritics_in_query(
+    req, view, searchable_projets
+):
+    request = req.get("/", data={"search": "Numerisation"})
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+    assert list(qs) == [searchable_projets["numerisation"]]
+
+
+@requires_postgres
+def test_filter_search_matches_with_diacritics_in_query(req, view, searchable_projets):
+    request = req.get("/", data={"search": "Numérisation"})
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+    assert list(qs) == [searchable_projets["numerisation"]]
+
+
+@requires_postgres
+def test_filter_search_matches_ignoring_diacritics_in_stored_value(
+    req, view, searchable_projets
+):
+    request = req.get("/", data={"search": "ecoles"})
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+    assert searchable_projets["numerisation"] in qs
 
 
 def test_view_has_correct_territoire_choices():

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -1,7 +1,9 @@
-from django.db.models import Count, Exists, F, OuterRef, Q
+from django.db import connection
+from django.db.models import Count, Exists, F, Func, OuterRef, Q, Value
 from django.forms.utils import pretty_name
 from django.utils.translation import gettext_lazy as _
 from django_filters import (
+    CharFilter,
     DateFromToRangeFilter,
     FilterSet,
     MultipleChoiceFilter,
@@ -176,6 +178,44 @@ def filter_dotation_sollicitee(queryset, name, values):
     return queryset.filter(q)
 
 
+def make_filter_search(intitule_field, raison_sociale_field, ds_number_field):
+    """Build a CharFilter `method` that searches across project title, applicant
+    name and dossier number. Uses trigram similarity on PostgreSQL, icontains
+    on other backends (test sandbox uses SQLite)."""
+
+    def filter_search(queryset, _name, value):
+        value = (value or "").strip()
+        if not value:
+            return queryset
+
+        if connection.vendor == "postgresql":
+            from django.contrib.postgres.search import TrigramWordSimilarity
+
+            def _unaccent(expr):
+                return Func(expr, function="f_unaccent")
+
+            queryset = queryset.annotate(
+                _search_sim_intitule=TrigramWordSimilarity(
+                    _unaccent(Value(value)), _unaccent(F(intitule_field))
+                ),
+                _search_sim_demandeur=TrigramWordSimilarity(
+                    _unaccent(Value(value)), _unaccent(F(raison_sociale_field))
+                ),
+            )
+            q = Q(_search_sim_intitule__gte=0.6) | Q(_search_sim_demandeur__gte=0.6)
+        else:
+            q = Q(**{f"{intitule_field}__icontains": value}) | Q(
+                **{f"{raison_sociale_field}__icontains": value}
+            )
+
+        if value.isdigit():
+            q |= Q(**{ds_number_field: int(value)})
+
+        return queryset.filter(q).distinct()
+
+    return filter_search
+
+
 def filter_dossier_complet(queryset, name, values):
     if not values:
         return queryset
@@ -194,6 +234,11 @@ class ProjetFilters(FilterSet):
         fields=ORDERING_MAP,
         empty_label="Tri",
         widget=CustomSelectWidget,
+    )
+
+    search = CharFilter(
+        label="Recherche",
+        method="filter_search",
     )
 
     dotation = MultipleChoiceFilter(
@@ -349,6 +394,13 @@ class ProjetFilters(FilterSet):
     filter_boolean = staticmethod(filter_boolean)
     filter_dotation_sollicitee = staticmethod(filter_dotation_sollicitee)
     filter_dossier_complet = staticmethod(filter_dossier_complet)
+    filter_search = staticmethod(
+        make_filter_search(
+            intitule_field="dossier_ds__projet_intitule",
+            raison_sociale_field="dossier_ds__ds_demandeur__raison_sociale",
+            ds_number_field="dossier_ds__ds_number",
+        )
+    )
 
     def filter_montant_retenu(self, queryset, _name, value):
         dotation_qs = DotationProjet.objects.filter(projet=OuterRef("pk"))
@@ -368,6 +420,7 @@ class ProjetFilters(FilterSet):
     class Meta:
         model = Projet
         fields = (
+            "search",
             "territoire",
             "epci",
             "dotation",

--- a/gsl_simulation/filters.py
+++ b/gsl_simulation/filters.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.db.models import Case, DecimalField, F, Subquery, When
 from django_filters import (
+    CharFilter,
     DateFromToRangeFilter,
     FilterSet,
     MultipleChoiceFilter,
@@ -32,6 +33,7 @@ from gsl_projet.utils.projet_filters import (
     filter_dossier_complet,
     filter_dotation_sollicitee,
     filter_territoire,
+    make_filter_search,
 )
 from gsl_projet.utils.utils import order_couples_tuple_by_first_value
 from gsl_simulation.models import SimulationProjet
@@ -111,6 +113,11 @@ class SimulationProjetFilters(FilterSet):
         "simu_assiette": "assiette",
         "simu_taux": "taux",
     }
+
+    search = CharFilter(
+        label="Recherche",
+        method="filter_search",
+    )
 
     categorie_detr = MultipleChoiceFilter(
         label="Catégorie DETR",
@@ -267,6 +274,13 @@ class SimulationProjetFilters(FilterSet):
     filter_boolean = staticmethod(filter_boolean)
     filter_dotation_sollicitee = staticmethod(filter_dotation_sollicitee)
     filter_dossier_complet = staticmethod(filter_dossier_complet)
+    filter_search = staticmethod(
+        make_filter_search(
+            intitule_field="dossier_ds__projet_intitule",
+            raison_sociale_field="dossier_ds__ds_demandeur__raison_sociale",
+            ds_number_field="dossier_ds__ds_number",
+        )
+    )
 
     def filter_status(self, queryset, name, value):
         return queryset.filter(
@@ -292,6 +306,7 @@ class SimulationProjetFilters(FilterSet):
     class Meta:
         model = Projet
         fields = (
+            "search",
             "territoire",
             "epci",
             "categorie_detr",

--- a/gsl_simulation/tests/views/test_filters.py
+++ b/gsl_simulation/tests/views/test_filters.py
@@ -357,6 +357,32 @@ def test_view_with_multiple_simulations(req, perimetre_departemental):
     assert projets.count() == 0
 
 
+def test_view_with_search_filter(req, simulation, create_simulation_projets):
+    """Le filtre de recherche cible l'intitulé, la raison sociale et le n° dossier."""
+    # On modifie un projet existant pour qu'il porte une chaîne unique
+    target = simulation.simulationprojet_set.first()
+    target_dossier = target.projet.dossier_ds
+    target_dossier.projet_intitule = "Mon Projet Unique XYZW"
+    target_dossier.ds_demandeur.raison_sociale = "Demandeur Unique XYZW"
+    target_dossier.ds_demandeur.save()
+    target_dossier.ds_number = 8888888
+    target_dossier.save()
+
+    projets = _get_filtered_projets(req, simulation, {"search": "XYZW"})
+    assert list(projets) == [target.projet]
+
+    projets = _get_filtered_projets(req, simulation, {"search": "8888888"})
+    assert list(projets) == [target.projet]
+
+    projets = _get_filtered_projets(req, simulation, {"search": ""})
+    assert projets.count() == 7
+
+    projets = _get_filtered_projets(
+        req, simulation, {"search": "ZZZ_ChaineQuiNeMatcheRien"}
+    )
+    assert projets.count() == 0
+
+
 def test_view_with_cout_total_filter(req, simulation, create_simulation_projets):
     filter_params = {
         "cout_min": 2_000_000,


### PR DESCRIPTION
## 🌮 Objectif

Permettre la recherche d'un projet par intitulé, demandeur ou numéro de dossier sur les listes de projets, simulations et programmations.

## 🔍 Liste des modifications

- Ajout du filtre `search` sur `ProjetFilters`, `SimulationProjetFilters` et `ProgrammationProjetFilters` (intitulé, raison sociale, n° de dossier exact si numérique)
- Recherche par similarité trigramme avec `unaccent` sur PostgreSQL (tolérante aux fautes et aux accents), repli `icontains` sur SQLite pour les tests
- Migration : extensions `pg_trgm` et `unaccent`, fonction immutable `f_unaccent`, index GIN trigramme sur `dossier.projet_intitule` et `personnemorale.raison_sociale`
- Ajout de `django.contrib.postgres` à `INSTALLED_APPS`
- Template `_filter_search.html` rendant la barre de recherche DSFR en tête de la rangée de filtres

## ⚠️ Informations supplémentaires

La migration crée deux index GIN trigramme sur les tables `dossier` et `personnemorale` — quelques secondes de création en production.

## 🖼️ Images

_à compléter_