### PR TITLE
Réordonner le champ de recherche dans les filtres de listes

### DIFF
--- a/gsl_projet/templates/includes/_projet_list_filters.html
+++ b/gsl_projet/templates/includes/_projet_list_filters.html
@@ -14,9 +14,6 @@
 
     <div class="projets-filters-layout {% if component_included_in_parent %} projet-filters-in-parent{% endif %} fr-container--fluid">
         <div class="filters-flex-row">
-            {% if filter.form.search %}
-                {% include "includes/_filter_search.html" with field=filter.form.search %}
-            {% endif %}
             <div class="fr-col-12 fr-col-md-4 fr-col-lg-3 reinit-filters">
                 <button class="fr-btn fr-btn--tertiary"
                         type="submit"
@@ -25,6 +22,9 @@
                     <span class="fr-icon-arrow-go-back-fill fr-icon--sm"></span> Réinitialiser les filtres
                 </button>
             </div>
+            {% if filter.form.search %}
+                {% include "includes/_filter_search.html" with field=filter.form.search %}
+            {% endif %}
             {% if current_order %}
                 {% active_sort_label columns current_order as sort_label %}
                 {% if sort_label %}


### PR DESCRIPTION
## 🌮 Objectif

Replacer le champ de recherche après le bouton « Réinitialiser les filtres » dans les listes de projets, simulations et programmations.

## 🔍 Liste des modifications

- Inversion, dans `_projet_list_filters.html`, du champ de recherche et du bouton « Réinitialiser les filtres » pour que l'ordre final soit : bouton de réinitialisation → champ de recherche → étiquette de tri → autres filtres.

## ⚠️ Informations supplémentaires

Aucun changement de CSS, JS, vue ou test : simple réordonnancement du gabarit partagé par les trois pages de listes.