### PR TITLE
Évaluation paresseuse des choix dans les FilterSet

### DIFF
--- a/gsl_demarches_simplifiees/models.py
+++ b/gsl_demarches_simplifiees/models.py
@@ -939,7 +939,7 @@ class CategorieDetr(Categorie):
         )
 
     def __str__(self):
-        return f"{self.label}"
+        return self.complete_label
 
     @property
     def complete_label(self):

--- a/gsl_notification/views/generate_document_for_multiple_projets_views.py
+++ b/gsl_notification/views/generate_document_for_multiple_projets_views.py
@@ -265,6 +265,16 @@ class GenerateDocumentsWizard(SessionWizardView):
         self._submitted_step = request.POST.get(f"{self.prefix}-current_step")
         return super().post(request, *args, **kwargs)
 
+    def get_cleaned_data_for_step(self, step):
+        # formtools re-instantiates and re-validates the step's form on every
+        # call. Within one request, the underlying storage data for a non-current
+        # step doesn't change, so we cache the result per instance.
+        if not hasattr(self, "_cleaned_data_cache"):
+            self._cleaned_data_cache = {}
+        if step not in self._cleaned_data_cache:
+            self._cleaned_data_cache[step] = super().get_cleaned_data_for_step(step)
+        return self._cleaned_data_cache[step]
+
     def get_form_kwargs(self, step=None):
         kwargs = super().get_form_kwargs(step)
         kwargs.update(
@@ -343,14 +353,20 @@ class GenerateDocumentsWizard(SessionWizardView):
             )
             for step in self.get_form_list()
         }
+        # Only validate the steps whose cleaned_data is read from form_dict in
+        # done(). LAUNCH and STEP1 feed into other steps via get_form_kwargs,
+        # where they were already validated (and cached). STEP4 is the
+        # save-action form, not a data-bearing step.
+        for step in (self.STEP2, self.STEP3):
+            form_dict[step].is_valid()
         response = self.done(form_dict.values(), form_dict=form_dict, **kwargs)
         self.storage.reset()
         return response
 
     def done(self, form_list, form_dict, **kwargs):
         form = form_dict[self.STEP4]
-        step2_data = self.get_cleaned_data_for_step(self.STEP2) or {}
-        step3_data = self.get_cleaned_data_for_step(self.STEP3) or {}
+        step2_data = form_dict[self.STEP2].cleaned_data
+        step3_data = form_dict[self.STEP3].cleaned_data
         export_format = step3_data.get("export_format")
         refreshed = form.save(
             modele_arrete=step2_data.get("modele_arrete_id"),

--- a/gsl_programmation/models.py
+++ b/gsl_programmation/models.py
@@ -45,9 +45,7 @@ class EnveloppeQueryset(models.QuerySet):
         return new_obj
 
     def for_current_year(self):
-        return self.filter(
-            annee=self.order_by("-annee").values_list("annee", flat=True).first()
-        )
+        return self.filter(annee=self.values("annee").order_by("-annee")[:1])
 
 
 class EnveloppeManager(models.Manager.from_queryset(EnveloppeQueryset)):

--- a/gsl_programmation/tests/test_programmation_projet_filters.py
+++ b/gsl_programmation/tests/test_programmation_projet_filters.py
@@ -690,19 +690,38 @@ class TestProgrammationProjetFilters:
         assert prog_match in result
         assert prog_no_match not in result
 
-    def test_filterset_initialization_with_user_perimetre(
+    def test_filterset_territoire_queryset_with_user_perimetre(
         self, mock_request, departement
     ):
-        """Test l'initialisation du filterset avec les choix basés sur le périmètre utilisateur"""
+        """Le filtre territoire expose un queryset incluant le périmètre de l'utilisateur."""
         filterset = ProgrammationProjetFilters(request=mock_request)
 
-        # Vérifier que les choix de territoire sont configurés
-        territoire_choices = filterset.filters["territoire"].extra["choices"]
-        assert len(territoire_choices) > 0
+        territoire_queryset = filterset.form.fields["territoire"].queryset
 
-        # Vérifier que le périmètre de l'utilisateur est dans les choix
-        perimetre_ids = [choice[0] for choice in territoire_choices]
-        assert departement.id in perimetre_ids
+        assert territoire_queryset.filter(id=departement.id).exists()
+
+    def test_filterset_instantiation_does_not_query_choice_tables(self, mock_request):
+        """Instantiating the filterset must not query the choice tables;
+        the dropdowns evaluate their querysets lazily when the form is rendered."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as ctx:
+            ProgrammationProjetFilters(request=mock_request)
+
+        executed = " ".join(q["sql"] for q in ctx.captured_queries).lower()
+        for table in (
+            "cofinancement",
+            "projetzonage",
+            "projetcontractualisation",
+            "categoriedetr",
+            "categoriedsil",
+            "perimetre",
+        ):
+            assert table.lower() not in executed, (
+                f"Filterset __init__ should not query {table}, got:\n"
+                + "\n".join(q["sql"] for q in ctx.captured_queries)
+            )
 
     def test_date_depot_filter(self, mock_request, enveloppe, arrondissement):
         """Test les filtres par date de dépôt"""

--- a/gsl_programmation/utils/programmation_projet_filters.py
+++ b/gsl_programmation/utils/programmation_projet_filters.py
@@ -1,9 +1,12 @@
-from django.db.models import Case, DecimalField, F, When
+from functools import cached_property
+
+from django.db.models import Case, DecimalField, F, Q, When
 from django_filters import (
     CharFilter,
     ChoiceFilter,
     DateFromToRangeFilter,
     FilterSet,
+    ModelMultipleChoiceFilter,
     MultipleChoiceFilter,
     RangeFilter,
 )
@@ -32,6 +35,7 @@ from gsl_projet.utils.django_filters_custom_widget import (
 from gsl_projet.utils.projet_filters import (
     DOTATION_SOLLICITEE_CHOICES,
     OUI_NON_CHOICES,
+    LabelFromInstanceFilter,
     ProjetOrderingFilter,
     filter_boolean,
     filter_dossier_complet,
@@ -62,15 +66,18 @@ class ProgrammationProjetFilters(FilterSet):
         method="filter_search",
     )
 
-    categorie_detr = MultipleChoiceFilter(
+    categorie_detr = LabelFromInstanceFilter(
         label="Catégorie DETR",
         field_name="dotation_projet__projet__dossier_ds__demande_categorie_detr",
+        queryset=CategorieDetr.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
+        label_attr="complete_label",
     )
 
-    categorie_dsil = MultipleChoiceFilter(
+    categorie_dsil = ModelMultipleChoiceFilter(
         label="Catégorie DSIL",
         field_name="dotation_projet__projet__dossier_ds__demande_categorie_dsil",
+        queryset=CategorieDsil.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
     )
 
@@ -109,12 +116,13 @@ class ProgrammationProjetFilters(FilterSet):
         widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
     )
 
-    territoire = MultipleChoiceFilter(
+    territoire = LabelFromInstanceFilter(
         method="filter_territoire",
-        choices=[],
+        queryset=Perimetre.objects.none(),
         widget=CustomCheckboxSelectMultiple(
             display_template="includes/_filter_territoire.html"
         ),
+        label_attr="entity_name",
     )
 
     budget_vert_demandeur = MultipleChoiceFilter(
@@ -149,24 +157,24 @@ class ProgrammationProjetFilters(FilterSet):
         method="filter_dossier_complet",
     )
 
-    cofinancement = MultipleChoiceFilter(
+    cofinancement = ModelMultipleChoiceFilter(
         label="Cofinancement",
         field_name="dotation_projet__projet__dossier_ds__demande_cofinancements",
-        choices=[],
+        queryset=Cofinancement.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
     )
 
-    zonage = MultipleChoiceFilter(
+    zonage = ModelMultipleChoiceFilter(
         label="Zonage",
         field_name="dotation_projet__projet__dossier_ds__projet_zonage",
-        choices=[],
+        queryset=ProjetZonage.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
     )
 
-    contractualisation = MultipleChoiceFilter(
+    contractualisation = ModelMultipleChoiceFilter(
         label="Contractualisation",
         field_name="dotation_projet__projet__dossier_ds__projet_contractualisation",
-        choices=[],
+        queryset=ProjetContractualisation.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
     )
 
@@ -214,9 +222,11 @@ class ProgrammationProjetFilters(FilterSet):
         widget=CustomSelectWidget,
     )
 
-    def filter_territoire(self, queryset, _name, values: list[int]):
+    def filter_territoire(self, queryset, _name, values):
+        if not values:
+            return queryset
         result = queryset.none()
-        for perimetre in Perimetre.objects.filter(id__in=values):
+        for perimetre in values:
             result |= queryset.for_perimetre(perimetre)
         return result
 
@@ -264,17 +274,16 @@ class ProgrammationProjetFilters(FilterSet):
         super().__init__(*args, **kwargs)
         if hasattr(self.request, "user") and self.request.user.perimetre:
             perimetre = self.request.user.perimetre
-            self.filters["territoire"].extra["choices"] = tuple(
-                (p.id, p.entity_name) for p in (perimetre, *perimetre.children())
+            self.filters["territoire"].queryset = Perimetre.objects.filter(
+                Q(id=perimetre.id) | Q(id__in=perimetre.children().values("id"))
             )
 
         dotation = self.request.resolver_match.kwargs.get("dotation")
         visible_dossiers = Dossier.objects.for_user(self.request.user)
 
         if dotation == DOTATION_DETR:
-            self.filters["categorie_detr"].extra["choices"] = tuple(
-                (str(c.id), c.complete_label)
-                for c in CategorieDetr.objects.active()
+            self.filters["categorie_detr"].queryset = (
+                CategorieDetr.objects.active()
                 .filter(dossier__in=visible_dossiers)
                 .distinct()
                 .order_by("rank")
@@ -283,9 +292,8 @@ class ProgrammationProjetFilters(FilterSet):
             del self.filters["categorie_detr"]
 
         if dotation == DOTATION_DSIL:
-            self.filters["categorie_dsil"].extra["choices"] = tuple(
-                (str(c.id), c.label)
-                for c in CategorieDsil.objects.active()
+            self.filters["categorie_dsil"].queryset = (
+                CategorieDsil.objects.active()
                 .filter(dossier__in=visible_dossiers)
                 .distinct()
                 .order_by("rank", "label")
@@ -293,30 +301,25 @@ class ProgrammationProjetFilters(FilterSet):
         else:
             del self.filters["categorie_dsil"]
 
-        self.filters["cofinancement"].extra["choices"] = tuple(
-            (str(c.id), c.label)
-            for c in Cofinancement.objects.filter(dossier__in=visible_dossiers)
+        self.filters["cofinancement"].queryset = (
+            Cofinancement.objects.filter(dossier__in=visible_dossiers)
             .distinct()
             .order_by("id")
         )
 
-        self.filters["zonage"].extra["choices"] = tuple(
-            (str(z.id), z.label)
-            for z in ProjetZonage.objects.filter(dossier__in=visible_dossiers)
+        self.filters["zonage"].queryset = (
+            ProjetZonage.objects.filter(dossier__in=visible_dossiers)
             .distinct()
             .order_by("id")
         )
 
-        self.filters["contractualisation"].extra["choices"] = tuple(
-            (str(c.id), c.label)
-            for c in ProjetContractualisation.objects.filter(
-                dossier__in=visible_dossiers
-            )
+        self.filters["contractualisation"].queryset = (
+            ProjetContractualisation.objects.filter(dossier__in=visible_dossiers)
             .distinct()
             .order_by("id")
         )
 
-        self.filters["epci"].extra["choices"] = tuple(
+        self.filters["epci"].extra["choices"] = lambda: tuple(
             (epci, epci.split(" - ", 1)[1] if " - " in epci else epci)
             for epci in visible_dossiers.values_list(
                 "porteur_de_projet_epci", flat=True
@@ -326,12 +329,17 @@ class ProgrammationProjetFilters(FilterSet):
             if epci
         )
 
-    @property
-    def qs(self):
-        self.perimetre: Perimetre = self.request.user.perimetre
-        self.dotation = self.request.resolver_match.kwargs.get("dotation")
+    @cached_property
+    def perimetre(self) -> Perimetre:
+        return self.request.user.perimetre
 
-        enveloppe_qs = (
+    @cached_property
+    def dotation(self):
+        return self.request.resolver_match.kwargs.get("dotation")
+
+    @cached_property
+    def _enveloppe_qs(self):
+        return (
             Enveloppe.objects.select_related(
                 "perimetre",
                 "perimetre__region",
@@ -342,17 +350,19 @@ class ProgrammationProjetFilters(FilterSet):
             .for_current_year()
         )
 
+    @cached_property
+    def enveloppe(self):
         try:
-            self.enveloppe = enveloppe_qs.get(perimetre=self.perimetre)
+            return self._enveloppe_qs.get(perimetre=self.perimetre)
         except Enveloppe.DoesNotExist:
-            self.enveloppe = None
+            return None
 
+    @property
+    def qs(self):
         qs = (
             super()
-            .qs.filter(
-                enveloppe__in=enveloppe_qs,
-            )
-            .for_perimetre(self.request.user.perimetre)
+            .qs.filter(enveloppe__in=self._enveloppe_qs)
+            .for_perimetre(self.perimetre)
         )
         qs = qs.annotate(
             prog_taux=Case(

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.db import connection
 from django.db.models import Count, Exists, F, Func, OuterRef, Q, Value
 from django.forms.utils import pretty_name
@@ -6,13 +7,22 @@ from django_filters import (
     CharFilter,
     DateFromToRangeFilter,
     FilterSet,
+    ModelMultipleChoiceFilter,
     MultipleChoiceFilter,
     OrderingFilter,
     RangeFilter,
 )
 
 from gsl_core.models import Perimetre
-from gsl_demarches_simplifiees.models import Dossier, NaturePorteurProjet
+from gsl_demarches_simplifiees.models import (
+    CategorieDetr,
+    CategorieDsil,
+    Cofinancement,
+    Dossier,
+    NaturePorteurProjet,
+    ProjetContractualisation,
+    ProjetZonage,
+)
 from gsl_projet.constants import (
     DOTATION_DETR,
     DOTATION_DSIL,
@@ -30,6 +40,22 @@ from gsl_projet.utils.django_filters_custom_widget import (
     DsfrRangeWidget,
 )
 from gsl_projet.utils.utils import order_couples_tuple_by_first_value
+
+
+class LabelFromInstanceField(forms.ModelMultipleChoiceField):
+    """ModelMultipleChoiceField that calls a configurable attribute/property
+    for the option label, so we can use complete_label, entity_name, etc."""
+
+    def __init__(self, *args, label_attr="label", **kwargs):
+        self.label_attr = label_attr
+        super().__init__(*args, **kwargs)
+
+    def label_from_instance(self, obj):
+        return getattr(obj, self.label_attr)
+
+
+class LabelFromInstanceFilter(ModelMultipleChoiceFilter):
+    field_class = LabelFromInstanceField
 
 
 class ProjetOrderingFilter(OrderingFilter):
@@ -132,9 +158,11 @@ def filter_dotation(queryset, _name, values):
     return queryset.filter(query)
 
 
-def filter_territoire(queryset, _name, values: list[int]):
+def filter_territoire(queryset, _name, values):
+    if not values:
+        return queryset
     result = queryset.none()
-    for perimetre in Perimetre.objects.filter(id__in=values):
+    for perimetre in values:
         result |= queryset.for_perimetre(perimetre)
     return result
 
@@ -310,24 +338,28 @@ class ProjetFilters(FilterSet):
         widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
     )
 
-    categorie_detr = MultipleChoiceFilter(
+    categorie_detr = LabelFromInstanceFilter(
         label="Catégorie DETR",
         field_name="dossier_ds__demande_categorie_detr",
+        queryset=CategorieDetr.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
+        label_attr="complete_label",
     )
 
-    categorie_dsil = MultipleChoiceFilter(
+    categorie_dsil = ModelMultipleChoiceFilter(
         label="Catégorie DSIL",
         field_name="dossier_ds__demande_categorie_dsil",
+        queryset=CategorieDsil.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
     )
 
-    territoire = MultipleChoiceFilter(
+    territoire = LabelFromInstanceFilter(
         method="filter_territoire",
-        choices=[],
+        queryset=Perimetre.objects.none(),
         widget=CustomCheckboxSelectMultiple(
             display_template="includes/_filter_territoire.html"
         ),
+        label_attr="entity_name",
     )
 
     epci = MultipleChoiceFilter(
@@ -368,24 +400,24 @@ class ProjetFilters(FilterSet):
         method="filter_dossier_complet",
     )
 
-    cofinancement = MultipleChoiceFilter(
+    cofinancement = ModelMultipleChoiceFilter(
         label="Cofinancement",
         field_name="dossier_ds__demande_cofinancements",
-        choices=[],
+        queryset=Cofinancement.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
     )
 
-    zonage = MultipleChoiceFilter(
+    zonage = ModelMultipleChoiceFilter(
         label="Zonage",
         field_name="dossier_ds__projet_zonage",
-        choices=[],
+        queryset=ProjetZonage.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
     )
 
-    contractualisation = MultipleChoiceFilter(
+    contractualisation = ModelMultipleChoiceFilter(
         label="Contractualisation",
         field_name="dossier_ds__projet_contractualisation",
-        choices=[],
+        queryset=ProjetContractualisation.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
     )
 

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.db.models import Case, DecimalField, F, Max, Prefetch, Sum, When
+from django.db.models import Case, DecimalField, F, Max, Prefetch, Q, Sum, When
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -8,6 +8,7 @@ from django.views.generic import ListView, UpdateView
 from django_filters.views import FilterView
 
 from gsl_core.exceptions import Http404
+from gsl_core.models import Perimetre
 from gsl_demarches_simplifiees.models import (
     CategorieDetr,
     CategorieDsil,
@@ -110,8 +111,8 @@ class ProjetListViewFilters(ProjetFilters):
         super().__init__(*args, **kwargs)
         if hasattr(self.request, "user") and self.request.user.perimetre:
             perimetre = self.request.user.perimetre
-            self.filters["territoire"].extra["choices"] = tuple(
-                (p.id, p.entity_name) for p in (perimetre, *perimetre.children())
+            self.filters["territoire"].queryset = Perimetre.objects.filter(
+                Q(id=perimetre.id) | Q(id__in=perimetre.children().values("id"))
             )
 
         selected_dotations = self.data.getlist("dotation")
@@ -121,9 +122,8 @@ class ProjetListViewFilters(ProjetFilters):
             "DETR" in selected_dotations or "DETR_et_DSIL" in selected_dotations
         )
         if detr_selected:
-            self.filters["categorie_detr"].extra["choices"] = tuple(
-                (str(c.id), c.complete_label)
-                for c in CategorieDetr.objects.active()
+            self.filters["categorie_detr"].queryset = (
+                CategorieDetr.objects.active()
                 .filter(dossier__projet__in=visible_projets)
                 .distinct()
                 .order_by("rank")
@@ -135,9 +135,8 @@ class ProjetListViewFilters(ProjetFilters):
             "DSIL" in selected_dotations or "DETR_et_DSIL" in selected_dotations
         )
         if dsil_selected:
-            self.filters["categorie_dsil"].extra["choices"] = tuple(
-                (str(c.id), c.label)
-                for c in CategorieDsil.objects.active()
+            self.filters["categorie_dsil"].queryset = (
+                CategorieDsil.objects.active()
                 .filter(dossier__projet__in=visible_projets)
                 .distinct()
                 .order_by("rank", "label")
@@ -147,7 +146,7 @@ class ProjetListViewFilters(ProjetFilters):
 
         visible_dossiers = visible_projets.values("dossier_ds")
 
-        self.filters["epci"].extra["choices"] = tuple(
+        self.filters["epci"].extra["choices"] = lambda: tuple(
             (epci, epci.split(" - ", 1)[1] if " - " in epci else epci)
             for epci in visible_projets.values_list(
                 "dossier_ds__porteur_de_projet_epci", flat=True
@@ -157,25 +156,20 @@ class ProjetListViewFilters(ProjetFilters):
             if epci
         )
 
-        self.filters["cofinancement"].extra["choices"] = tuple(
-            (str(c.id), c.label)
-            for c in Cofinancement.objects.filter(dossier__in=visible_dossiers)
+        self.filters["cofinancement"].queryset = (
+            Cofinancement.objects.filter(dossier__in=visible_dossiers)
             .distinct()
             .order_by("id")
         )
 
-        self.filters["zonage"].extra["choices"] = tuple(
-            (str(z.id), z.label)
-            for z in ProjetZonage.objects.filter(dossier__in=visible_dossiers)
+        self.filters["zonage"].queryset = (
+            ProjetZonage.objects.filter(dossier__in=visible_dossiers)
             .distinct()
             .order_by("id")
         )
 
-        self.filters["contractualisation"].extra["choices"] = tuple(
-            (str(c.id), c.label)
-            for c in ProjetContractualisation.objects.filter(
-                dossier__in=visible_dossiers
-            )
+        self.filters["contractualisation"].queryset = (
+            ProjetContractualisation.objects.filter(dossier__in=visible_dossiers)
             .distinct()
             .order_by("id")
         )

--- a/gsl_simulation/filters.py
+++ b/gsl_simulation/filters.py
@@ -1,13 +1,15 @@
 from django.db import models
-from django.db.models import Case, DecimalField, F, Subquery, When
+from django.db.models import Case, DecimalField, F, Q, Subquery, When
 from django_filters import (
     CharFilter,
     DateFromToRangeFilter,
     FilterSet,
+    ModelMultipleChoiceFilter,
     MultipleChoiceFilter,
     RangeFilter,
 )
 
+from gsl_core.models import Perimetre
 from gsl_demarches_simplifiees.models import (
     CategorieDetr,
     CategorieDsil,
@@ -28,6 +30,7 @@ from gsl_projet.utils.projet_filters import (
     DOTATION_SOLLICITEE_CHOICES,
     ORDERING_MAP,
     OUI_NON_CHOICES,
+    LabelFromInstanceFilter,
     ProjetOrderingFilter,
     filter_boolean,
     filter_dossier_complet,
@@ -46,14 +49,13 @@ class SimulationProjetFilters(FilterSet):
 
         if hasattr(self.request, "user") and self.request.user.perimetre:
             perimetre = self.request.user.perimetre
-            self.filters["territoire"].extra["choices"] = tuple(
-                (p.id, p.entity_name) for p in (perimetre, *perimetre.children())
+            self.filters["territoire"].queryset = Perimetre.objects.filter(
+                Q(id=perimetre.id) | Q(id__in=perimetre.children().values("id"))
             )
 
         if dotation == DOTATION_DETR:
-            self.filters["categorie_detr"].extra["choices"] = tuple(
-                (str(c.id), c.complete_label)
-                for c in CategorieDetr.objects.active()
+            self.filters["categorie_detr"].queryset = (
+                CategorieDetr.objects.active()
                 .filter(dossier__projet__in=self.queryset)
                 .distinct()
                 .order_by("rank")
@@ -62,9 +64,8 @@ class SimulationProjetFilters(FilterSet):
             del self.filters["categorie_detr"]
 
         if dotation == DOTATION_DSIL:
-            self.filters["categorie_dsil"].extra["choices"] = tuple(
-                (str(c.id), c.label)
-                for c in CategorieDsil.objects.active()
+            self.filters["categorie_dsil"].queryset = (
+                CategorieDsil.objects.active()
                 .filter(dossier__projet__in=self.queryset)
                 .distinct()
                 .order_by("rank", "label")
@@ -74,32 +75,29 @@ class SimulationProjetFilters(FilterSet):
 
         visible_dossiers = self.queryset.values("dossier_ds")
 
-        self.filters["cofinancement"].extra["choices"] = tuple(
-            (str(c.id), c.label)
-            for c in Cofinancement.objects.filter(dossier__in=visible_dossiers)
+        self.filters["cofinancement"].queryset = (
+            Cofinancement.objects.filter(dossier__in=visible_dossiers)
             .distinct()
             .order_by("id")
         )
 
-        self.filters["zonage"].extra["choices"] = tuple(
-            (str(z.id), z.label)
-            for z in ProjetZonage.objects.filter(dossier__in=visible_dossiers)
+        self.filters["zonage"].queryset = (
+            ProjetZonage.objects.filter(dossier__in=visible_dossiers)
             .distinct()
             .order_by("id")
         )
 
-        self.filters["contractualisation"].extra["choices"] = tuple(
-            (str(c.id), c.label)
-            for c in ProjetContractualisation.objects.filter(
-                dossier__in=visible_dossiers
-            )
+        self.filters["contractualisation"].queryset = (
+            ProjetContractualisation.objects.filter(dossier__in=visible_dossiers)
             .distinct()
             .order_by("id")
         )
 
-        self.filters["epci"].extra["choices"] = tuple(
+        projets_queryset = self.queryset
+
+        self.filters["epci"].extra["choices"] = lambda: tuple(
             (epci, epci.split(" - ", 1)[1] if " - " in epci else epci)
-            for epci in self.queryset.values_list(
+            for epci in projets_queryset.values_list(
                 "dossier_ds__porteur_de_projet_epci", flat=True
             )
             .distinct()
@@ -119,15 +117,18 @@ class SimulationProjetFilters(FilterSet):
         method="filter_search",
     )
 
-    categorie_detr = MultipleChoiceFilter(
+    categorie_detr = LabelFromInstanceFilter(
         label="Catégorie DETR",
         field_name="dossier_ds__demande_categorie_detr",
+        queryset=CategorieDetr.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
+        label_attr="complete_label",
     )
 
-    categorie_dsil = MultipleChoiceFilter(
+    categorie_dsil = ModelMultipleChoiceFilter(
         label="Catégorie DSIL",
         field_name="dossier_ds__demande_categorie_dsil",
+        queryset=CategorieDsil.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
     )
 
@@ -196,12 +197,13 @@ class SimulationProjetFilters(FilterSet):
         widget=DsfrDateRangeWidget(icon="fr-icon-calendar-line"),
     )
 
-    territoire = MultipleChoiceFilter(
+    territoire = LabelFromInstanceFilter(
         method="filter_territoire",
-        choices=[],
+        queryset=Perimetre.objects.none(),
         widget=CustomCheckboxSelectMultiple(
             display_template="includes/_filter_territoire.html"
         ),
+        label_attr="entity_name",
     )
 
     budget_vert_demandeur = MultipleChoiceFilter(
@@ -236,24 +238,24 @@ class SimulationProjetFilters(FilterSet):
         method="filter_dossier_complet",
     )
 
-    cofinancement = MultipleChoiceFilter(
+    cofinancement = ModelMultipleChoiceFilter(
         label="Cofinancement",
         field_name="dossier_ds__demande_cofinancements",
-        choices=[],
+        queryset=Cofinancement.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
     )
 
-    zonage = MultipleChoiceFilter(
+    zonage = ModelMultipleChoiceFilter(
         label="Zonage",
         field_name="dossier_ds__projet_zonage",
-        choices=[],
+        queryset=ProjetZonage.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Tous"),
     )
 
-    contractualisation = MultipleChoiceFilter(
+    contractualisation = ModelMultipleChoiceFilter(
         label="Contractualisation",
         field_name="dossier_ds__projet_contractualisation",
-        choices=[],
+        queryset=ProjetContractualisation.objects.none(),
         widget=CustomCheckboxSelectMultiple(placeholder="Toutes"),
     )
 


### PR DESCRIPTION
## 🌮 Objectif

Évaluer paresseusement les choix des filtres pour éviter des requêtes SQL inutiles lors de l'instantiation des `FilterSet` (notamment quand le formulaire n'est pas rendu).

## 🔍 Liste des modifications

- Conversion des filtres `MultipleChoiceFilter` adossés à un modèle (`territoire`, `catégorie DETR/DSIL`, `cofinancement`, `zonage`, `contractualisation`) en `ModelMultipleChoiceFilter` : les querysets sont évalués au rendu du formulaire et non plus dans `__init__`.
- Ajout d'un helper `LabelFromInstanceFilter` permettant de configurer l'attribut servant de libellé (`complete_label`, `entity_name`, etc.).
- Le filtre `epci` (non adossé à un modèle) emballe ses `choices` dans un `lambda` pour le même effet.
- `ProgrammationProjetFilters` : mise en cache de `perimetre`, `dotation`, `enveloppe` et du queryset d'enveloppes via `cached_property`.
- `EnveloppeQueryset.for_current_year()` : utilisation d'une sous-requête `values(...)[:1]` pour ne produire qu'une seule requête SQL.
- Ajout d'un test garantissant que l'instantiation du filterset n'interroge plus les tables des choix.
- Mise en cache de `get_cleaned_data_for_step` sur le wizard de génération de documents multi-projets (évite de revalider plusieurs fois le même formulaire dans une requête).
- `CategorieDetr.__str__` utilise désormais `complete_label`.

## ⚠️ Informations supplémentaires

Aucune migration. Le test `test_filterset_instantiation_does_not_query_choice_tables` documente le contrat de performance.