### PR TITLE
Garder les titres de colonnes visibles au scroll dans les listes

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -699,4 +699,20 @@ ul.no-list-style li {
     margin-top: 0.25rem;
 }
 
+/* Sticky table headers: the <thead> of `.gsl-projet-table` is translated by
+   JS to track the viewport top. It must paint above body rows that scroll
+   underneath it. Existing sticky-header cells live at z-index 3; lifting the
+   thead block itself to 4 ensures its background covers the rows below. */
+.gsl-projet-table .fr-table__content > table > thead {
+    position: relative;
+    z-index: 4;
+    background: var(--background-default-grey);
+    will-change: transform;
+}
+
+@media print {
+    .gsl-projet-table .fr-table__content > table > thead {
+        transform: none !important;
+    }
+}
 

--- a/gsl_core/static/js/sticky_table_headers.js
+++ b/gsl_core/static/js/sticky_table_headers.js
@@ -1,0 +1,67 @@
+// Sticky table headers: keep the <thead> of `.gsl-projet-table` glued to the
+// viewport top while the user scrolls the page vertically. The DSFR
+// `fr-table__container` is itself a horizontal scroll context (overflow-x:
+// auto), which would normally bound `position: sticky`. Instead, we translate
+// the real <thead> with a rAF-coalesced window scroll listener so it tracks
+// the viewport without leaving its own overflow box.
+
+const bindings = new WeakMap()
+
+function initStickyTables (root) {
+  const scope = root || document
+  const tables = scope.querySelectorAll
+    ? scope.querySelectorAll('.gsl-projet-table')
+    : []
+  tables.forEach((el) => {
+    const realTable = el.querySelector('.fr-table__content > table')
+    const realThead = realTable && realTable.querySelector('thead')
+    if (!realTable || !realThead) return
+
+    const previous = bindings.get(el)
+    if (previous) previous.disconnect()
+
+    let raf = 0
+    const update = () => {
+      const rect = realTable.getBoundingClientRect()
+      const theadHeight = realThead.getBoundingClientRect().height
+      const offset = -rect.top
+      const maxOffset = Math.max(0, rect.height - theadHeight)
+      const clamped = Math.max(0, Math.min(offset, maxOffset))
+      realThead.style.transform = `translateY(${clamped}px)`
+    }
+
+    const schedule = () => {
+      if (raf) return
+      raf = window.requestAnimationFrame(() => {
+        raf = 0
+        update()
+      })
+    }
+
+    window.addEventListener('scroll', schedule, { passive: true })
+    window.addEventListener('resize', schedule, { passive: true })
+    const ro = new window.ResizeObserver(schedule)
+    ro.observe(realTable)
+
+    const disconnect = () => {
+      window.removeEventListener('scroll', schedule)
+      window.removeEventListener('resize', schedule)
+      ro.disconnect()
+      if (raf) {
+        window.cancelAnimationFrame(raf)
+        raf = 0
+      }
+      realThead.style.transform = ''
+    }
+
+    bindings.set(el, { disconnect })
+    update()
+  })
+}
+
+document.body.addEventListener('htmx:afterSwap', (e) => {
+  const scope = e.target.closest('.gsl-projet-table') || e.target
+  initStickyTables(scope)
+})
+
+initStickyTables()

--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -119,6 +119,7 @@
         {% endblock modal %}
 
         <script src="{% static "js/gsl.js" %}" defer></script>
+        <script src="{% static "js/sticky_table_headers.js" %}" defer></script>
         <script type="module" nonce="{{ csp_nonce }}">
             import { Application } from "stimulus"
             import { DoubleDotation } from "doubleDotation"


### PR DESCRIPTION
## 🌮 Objectif

Garder les titres de colonnes visibles en haut de l'écran pendant qu'on scrolle dans les listes longues : projets, programmation, et détail de simulation.

## 🔍 Liste des modifications

- Nouveau module `gsl_core/static/js/sticky_table_headers.js` : pour chaque `.gsl-projet-table`, un listener `scroll` sur `window` (passif, coalescé par `requestAnimationFrame`) translate le `<thead>` réel via `transform: translateY(...)` pour qu'il colle au haut du viewport. La translation est bornée à la hauteur de la table pour que le `<thead>` se détache naturellement en fin de tableau. Idempotent (re-init sur `htmx:afterSwap` via un `WeakMap` de teardowns). Un `ResizeObserver` couvre les changements de largeur (toggle de colonnes, pagination).
- `gsl_core/static/css/gsl.css` : `position: relative; z-index: 4; background; will-change: transform` sur le `<thead>` des `.gsl-projet-table` pour qu'il peigne au-dessus des lignes du `<tbody>` quand il est translaté. Reset `transform: none !important` en `@media print`.
- `gsl_core/templates/base.html` : chargement du nouveau script `defer` juste après `gsl.js`.

## ⚠️ Informations supplémentaires

- Pure CSS `position: sticky` ne marche pas ici : `fr-table__container` a `overflow-x: auto`, qui crée un contexte de scroll bornant la stickyness sur les deux axes.
- Aucun changement de gabarit DSFR, aucun clone, aucune synchro de largeur : le `<thead>` reste dans la table d'origine donc les largeurs intrinsèques sont préservées.
- Les colonnes sticky existantes (gauche/droite) et le dropdown de statut continuent de fonctionner — z-index : sticky-body 2 < sticky-header 3 < thead translaté 4 < cadre DSFR 11 < dropdown statut 12.