### PR TITLE
Renommage des modèles dans le formulaire de génération de docs en masse

### DIFF
--- a/gsl_notification/models.py
+++ b/gsl_notification/models.py
@@ -91,7 +91,7 @@ class ModeleDocument(models.Model):
         abstract = True
 
     def __str__(self):
-        return f"Modèle d’arrêté {self.id} - {self.name}"
+        return self.name
 
     @property
     def annee(self):
@@ -114,9 +114,6 @@ class ModeleArrete(ModeleDocument):
         verbose_name = "Modèle d’arrêté"
         verbose_name_plural = "Modèles d’arrêté"
 
-    def __str__(self):
-        return f"Modèle d’arrêté {self.id} - {self.name}"
-
     @property
     def type(self):
         return ARRETE
@@ -133,9 +130,6 @@ class ModeleLettreNotification(ModeleDocument):
     class Meta:
         verbose_name = "Modèle de lettre de notification"
         verbose_name_plural = "Modèles de lettre de notification"
-
-    def __str__(self):
-        return f"Modèle de lettre de notification {self.id} - {self.name}"
 
     @property
     def type(self):

--- a/gsl_notification/tests/test_models.py
+++ b/gsl_notification/tests/test_models.py
@@ -272,13 +272,7 @@ def test_modele_properties(factory):
     perimetre = collegue.perimetre
     modele = factory(created_by=collegue, content=file_content, perimetre=perimetre)
 
-    if factory == ModeleArreteFactory:
-        assert str(modele) == f"Modèle d’arrêté {modele.id} - {modele.name}"
-    else:
-        assert (
-            str(modele)
-            == f"Modèle de lettre de notification {modele.id} - {modele.name}"
-        )
+    assert str(modele) == modele.name
 
     assert modele.content == file_content
     assert modele.created_by == collegue


### PR DESCRIPTION
## 🌮 Objectif

Ne plus avoir les ids qui n'ont que peu de sens pour nos utilisateurices

## 🖼️ Images

Avant :
<img width="422" height="410" alt="image" src="https://github.com/user-attachments/assets/34886702-5d41-4c71-b5b5-e943430d5c74" />

Après :
<img width="502" height="289" alt="image" src="https://github.com/user-attachments/assets/d7aac784-9e0e-4063-bcff-0061a4200cb8" />


