### PR TITLE
Ajout d'un loader au niveau du téléchargement des docs générés

### DIFF
--- a/gsl_core/static/js/controllers/formUtils.js
+++ b/gsl_core/static/js/controllers/formUtils.js
@@ -5,13 +5,61 @@ export class FormUtils extends Controller {
 
   disableButtons (evt) {
     const container = this.hasContainerTarget ? this.containerTarget : evt.target
-    const buttons = container.querySelectorAll('button')
-    buttons.forEach(btn => {
+    this._disableAllButtons(container)
+  }
+
+  async download (evt) {
+    evt.preventDefault()
+    const url = evt.currentTarget.getAttribute('href')
+    const container = this.hasContainerTarget ? this.containerTarget : evt.currentTarget
+    this._disableAllButtons(container)
+
+    try {
+      const response = await fetch(url)
+      const blob = await response.blob()
+      const blobUrl = URL.createObjectURL(blob)
+
+      const filename = this._extractFilename(response)
+      const a = document.createElement('a')
+      a.href = blobUrl
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(blobUrl)
+    } finally {
+      this._enableAllButtons(container)
+    }
+  }
+
+  _disableAllButtons (container) {
+    container.querySelectorAll('button').forEach(btn => {
       if (btn.type === 'submit') {
         this._disableButtonAndAddALoader(btn)
       } else {
         btn.setAttribute('disabled', '1')
       }
+    })
+    container.querySelectorAll('a.fr-btn').forEach(link => {
+      link.dataset.formUtilsHref = link.getAttribute('href')
+      link.removeAttribute('href')
+      link.setAttribute('aria-disabled', 'true')
+      link.classList.add('fr-icon-loader', 'fr-icon-spin')
+    })
+  }
+
+  _enableAllButtons (container) {
+    container.querySelectorAll('button[disabled]').forEach(btn => {
+      btn.removeAttribute('disabled')
+      btn.classList.remove('fr-icon-loader', 'fr-icon-spin')
+    })
+    container.querySelectorAll('a.fr-btn[aria-disabled]').forEach(link => {
+      if (link.dataset.formUtilsHref) {
+        link.setAttribute('href', link.dataset.formUtilsHref)
+        delete link.dataset.formUtilsHref
+      }
+      link.removeAttribute('aria-disabled')
+      link.classList.remove('fr-icon-loader', 'fr-icon-spin')
     })
   }
 
@@ -19,5 +67,14 @@ export class FormUtils extends Controller {
     btn.classList.add('fr-icon-loader')
     btn.classList.add('fr-icon-spin')
     btn.setAttribute('disabled', '1')
+  }
+
+  _extractFilename (response) {
+    const disposition = response.headers.get('Content-Disposition')
+    if (disposition) {
+      const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/)
+      if (match) return match[1].replace(/['"]/g, '')
+    }
+    return 'download'
   }
 }

--- a/gsl_notification/templates/gsl_notification/generated_document/multiple/modal_success_body.html
+++ b/gsl_notification/templates/gsl_notification/generated_document/multiple/modal_success_body.html
@@ -30,7 +30,8 @@
 {% block footer_buttons %}
     <li>
         <a class="fr-btn fr-icon-download-line fr-icon--sm"
-           href="{{ download_url }}">
+           href="{{ download_url }}"
+           data-action="click->form-utils#download">
             Télécharger
         </a>
     </li>

--- a/gsl_programmation/templates/gsl_programmation/programmation_projet_list.html
+++ b/gsl_programmation/templates/gsl_programmation/programmation_projet_list.html
@@ -58,7 +58,9 @@
             </button>
             <dialog class="fr-modal"
                     id="generate-multiple-modal"
-                    aria-labelledby="generate-multiple-modal-title">
+                    aria-labelledby="generate-multiple-modal-title"
+                    data-controller="form-utils"
+                    data-form-utils-target="container">
                 <div class="fr-container fr-container--fluid fr-container-md">
                     <div class="fr-grid-row fr-grid-row--center">
                         <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">


### PR DESCRIPTION
## 🌮 Objectif

ça peut être long (10-20 sec voire + si beaucoup de docs), et sans informer l'utilisateur, c'est dommage, voire, ça l'incite à recliquer sur "Télécharger" et a partir dans un scénario catastrophe !
Je propose donc de désactiver les boutons + de rajouter un loader à ce moment-là.

## 🖼️ Images


https://github.com/user-attachments/assets/621d4cea-7c52-4574-8846-76b64260c2ca




