### PR TITLE
Mise à jour des dépendances vulnérables signalées par Dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1245,11 +1245,10 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1507,11 +1506,10 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2755,9 +2753,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -2768,8 +2766,7 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -2850,11 +2847,10 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true,
-      "license": "ISC"
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3820,11 +3816,10 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4044,10 +4039,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-      "license": "MIT",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -4132,11 +4126,10 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4501,11 +4494,10 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -4614,9 +4606,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -4632,7 +4624,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5840,11 +5831,10 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -72,7 +72,7 @@ coverage[toml]==7.13.5
     # via pytest-cov
 cron-descriptor==1.4.5
     # via django-celery-beat
-cryptography==46.0.5
+cryptography==46.0.7
     # via mozilla-django-oidc
 cssbeautifier==1.15.4
     # via djlint
@@ -92,7 +92,7 @@ distlib==0.4.0
     # via virtualenv
 dj-database-url==3.1.2
     # via gsl (pyproject.toml)
-django==6.0.3
+django==6.0.5
     # via
     #   dj-database-url
     #   django-axes
@@ -216,7 +216,7 @@ json5==0.13.0
     # via djlint
 kombu==5.6.2
     # via celery
-lxml==6.0.2
+lxml==6.1.0
     # via pikepdf
 markupsafe==3.0.3
     # via jinja2
@@ -251,7 +251,7 @@ pikepdf==10.5.0
     # via
     #   gsl (pyproject.toml)
     #   img2pdf
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   img2pdf
     #   pikepdf
@@ -289,7 +289,7 @@ pydantic-core==2.41.5
     # via pydantic
 pydyf==0.12.1
     # via weasyprint
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   diff-cover
     #   ipython
@@ -305,7 +305,7 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pyproject-toml==0.1.0
     # via gsl (pyproject.toml)
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   gsl (pyproject.toml)
     #   pytest-cov
@@ -340,7 +340,7 @@ redis==7.3.0
     # via gsl (pyproject.toml)
 regex==2026.2.28
     # via djlint
-requests==2.32.5
+requests==2.34.0
     # via
     #   django-dsfr
     #   gsl (pyproject.toml)
@@ -404,7 +404,7 @@ tzdata==2025.3
     #   kombu
 tzlocal==5.3.1
     # via celery
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ click-repl==0.3.0
     # via celery
 cron-descriptor==1.4.5
     # via django-celery-beat
-cryptography==46.0.5
+cryptography==46.0.7
     # via mozilla-django-oidc
 cssselect2==0.9.0
     # via weasyprint
@@ -72,7 +72,7 @@ diff-match-patch==20241021
     # via django-import-export
 dj-database-url==3.1.2
     # via gsl (pyproject.toml)
-django==6.0.3
+django==6.0.5
     # via
     #   dj-database-url
     #   django-axes
@@ -161,7 +161,7 @@ jmespath==1.1.0
     #   botocore
 kombu==5.6.2
     # via celery
-lxml==6.0.2
+lxml==6.1.0
     # via pikepdf
 matplotlib-inline==0.2.1
     # via ipython
@@ -186,7 +186,7 @@ pikepdf==10.5.0
     # via
     #   gsl (pyproject.toml)
     #   img2pdf
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   img2pdf
     #   pikepdf
@@ -207,7 +207,7 @@ pycparser==3.0
     # via cffi
 pydyf==0.12.1
     # via weasyprint
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   ipython
     #   ipython-pygments-lexers
@@ -225,7 +225,7 @@ python-dotenv==1.2.2
     # via gsl (pyproject.toml)
 redis==7.3.0
     # via gsl (pyproject.toml)
-requests==2.32.5
+requests==2.34.0
     # via
     #   django-dsfr
     #   gsl (pyproject.toml)
@@ -268,7 +268,7 @@ tzdata==2025.3
     #   kombu
 tzlocal==5.3.1
     # via celery
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
## 🌮 Objectif

Résoudre les alertes Dependabot ouvertes (Python + npm) sans introduire de mise à jour majeure.

## 🔍 Liste des modifications

Python (`pip-compile -P` sur `pyproject.toml`) :
- cryptography 46.0.5 → 46.0.7
- django 6.0.3 → 6.0.5
- lxml 6.0.2 → 6.1.0
- pillow 12.1.1 → 12.2.0
- pygments 2.19.2 → 2.20.0
- pytest 9.0.2 → 9.0.3 (dev)
- requests 2.32.5 → 2.34.0
- urllib3 2.6.3 → 2.7.0

npm (`npm audit fix`) : correctifs transitifs sur `ajv`, `brace-expansion`, `fast-uri`, `flatted`, `js-yaml`, `markdown-it`, `minimatch`, `picomatch`, `postcss`.

## ⚠️ Informations supplémentaires

`cryptography` est volontairement contraint à `<47` dans la commande `pip-compile` pour rester sur la branche 46 et éviter le saut majeur 46 → 48 (au-delà de la version corrective réclamée par Dependabot, 46.0.7).

`npm audit` retourne désormais `found 0 vulnerabilities`.