### PR TITLE
Ouverture du dropdown de statut sans casser les colonnes stickies

### DIFF
--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -333,10 +333,6 @@ ul.no-list-style li {
     z-index: 12;
 }
 
-.gsl-projet-table .fr-table__container:has([aria-expanded="true"]) {
-    overflow: visible;
-}
-
 /* Custom properties for sticky offsets – adjusted by :has() rules when columns hide.
    --sticky-checkbox-width reserves room for the sticky checkbox column when present. */
 #projet-table-wrapper {

--- a/gsl_core/static/js/gsl.js
+++ b/gsl_core/static/js/gsl.js
@@ -1,3 +1,44 @@
+// Close any open status menu when the page (or any scrollable ancestor)
+// scrolls — the menu is position:fixed and would otherwise stay in place
+// while its trigger scrolls away.
+document.addEventListener(
+  'scroll',
+  () => {
+    document
+      .querySelectorAll(
+        '.gsl-projet-table__status-select .fr-collapse--expanded'
+      )
+      .forEach((menu) => dsfr(menu).collapse.conceal())
+  },
+  { capture: true, passive: true }
+)
+
+// Pin status menus to their trigger with `position: fixed` so they escape
+// the table container's overflow:auto.
+new window.MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    const menu = mutation.target
+    if (!menu.classList.contains('fr-collapse')) continue
+    if (!menu.closest('.gsl-projet-table__status-select')) continue
+    if (menu.classList.contains('fr-collapse--expanded')) {
+      const trigger = document.querySelector(`[aria-controls="${menu.id}"]`)
+      if (!trigger) continue
+      const rect = trigger.getBoundingClientRect()
+      menu.style.position = 'fixed'
+      menu.style.top = `${rect.bottom}px`
+      menu.style.left = `${rect.left}px`
+    } else {
+      menu.style.position = ''
+      menu.style.top = ''
+      menu.style.left = ''
+    }
+  }
+}).observe(document.body, {
+  attributes: true,
+  attributeFilter: ['class'],
+  subtree: true
+})
+
 // Make notice closable again
 document.querySelectorAll('.fr-notice button.fr-btn--close').forEach((elt) => {
   elt.addEventListener('click', (evt) => {

--- a/gsl_simulation/static/css/simulation_detail.css
+++ b/gsl_simulation/static/css/simulation_detail.css
@@ -137,6 +137,13 @@
   gap: 0.5rem;
 }
 
+/* Status menu is position: fixed (set by JS in gsl.js) while expanded, so the
+   DSFR collapse slide-in/out looks out of place in viewport space. Skip it. */
+.gsl-projet-table__status-select .fr-collapse,
+.gsl-projet-table__status-select .fr-collapse::before {
+  transition: none;
+}
+
 /* text inputs */
 
 .gsl-projet-table__input--valid {

--- a/gsl_simulation/templates/includes/_status_dropdown_buttons.html
+++ b/gsl_simulation/templates/includes/_status_dropdown_buttons.html
@@ -1,7 +1,6 @@
 {% load simulation_filters %}
-<div class="fr-nav fr-translate gsl-projet-table__status-select gsl-projet-table__status-select--{{ simu.status }}"
-     id="status-dropdown-{{ simu.pk }}">
-    <div class="fr-nav__item{% if table %}fr-nav__item--align-right{% endif %}">
+<div class="fr-nav fr-translate gsl-projet-table__status-select gsl-projet-table__status-select--{{ simu.status }}">
+    <div class="fr-nav__item{% if table %} fr-nav__item--align-right{% endif %}">
         <button class="fr-select fr-btn--{% if table %}sm{% else %}lg{% endif %} fr-dropdown__button"
                 aria-expanded="false"
                 aria-controls="status-dropdown-{{ simu.pk }}"


### PR DESCRIPTION
## 🌮 Objectif

Permettre d'ouvrir le menu déroulant de statut (listes projets, programmation, simulation) sans casser les colonnes stickies de droite (Statut, Notification).

## 🔍 Liste des modifications

- Suppression du `overflow: visible` posé sur `.fr-table__container` quand un dropdown était ouvert : ce hack retirait le contexte de défilement dont les colonnes stickies ont besoin (les cellules sticky-right tombaient sur le bord du viewport et un scrollbar horizontal apparaissait au niveau de la page).
- Positionnement du menu avec `position: fixed`, posé en JS à partir du `getBoundingClientRect()` du bouton déclencheur. Le menu peut ainsi s'échapper du conteneur en `overflow: auto` sans qu'on touche au conteneur lui-même.
- Fermeture du menu au scroll (page ou conteneur de table), sinon il resterait flottant à l'ancienne position de son bouton.
- Désactivation de la transition de fermeture DSFR (`fr-collapse`) pour ce menu : dans l'espace viewport, le slide-out semble déplacé.
- Suppression de l'`id` dupliqué sur le wrapper du dropdown (les deux `div` portaient le même `status-dropdown-{pk}`) et ajout d'un espace manquant dans la classe conditionnelle `fr-nav__item--align-right`.

## ⚠️ Informations supplémentaires

À tester sur les listes projet, programmation et simulation : ouvrir un dropdown de statut sur une ligne après scroll horizontal, vérifier que les colonnes stickies restent en place et qu'aucun scrollbar horizontal n'apparaît au niveau de la page. Vérifier aussi sur la carte de décision côté détail projet (`_status_and_notification_status_card.html`) qui utilise le même partial.