### PR TITLE
Génération de l'export de documents en fin d'assistant et téléchargement via le stockage

### DIFF
--- a/gsl/settings_test.py
+++ b/gsl/settings_test.py
@@ -13,7 +13,7 @@ BYPASS_ANTIVIRUS = True
 
 STORAGES = {
     "default": {
-        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "BACKEND": "django.core.files.storage.InMemoryStorage",
     },
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",

--- a/gsl_notification/exports.py
+++ b/gsl_notification/exports.py
@@ -1,0 +1,153 @@
+import io
+import logging
+import uuid
+import zipfile
+
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.utils import timezone
+from django.utils.text import slugify
+from pikepdf import Pdf
+
+from gsl_notification.forms import (
+    ARRETE_ET_LETTRE,
+    EXPORT_FORMAT_ONE_PDF_ALL,
+    EXPORT_FORMAT_ONE_PDF_ALL_GROUPED,
+    EXPORT_FORMAT_ONE_PDF_PER_PROJECT,
+)
+from gsl_notification.utils import generate_pdf_for_generated_document
+from gsl_projet.constants import ARRETE
+
+logger = logging.getLogger(__name__)
+
+EXPORT_PREFIX = "tmp/notifications/exports"
+EXPORT_URL_TTL = 900  # 15 minutes
+
+
+def build_export(
+    programmation_projets, attrs, export_format, document_type
+) -> tuple[str, str, bytes]:
+    if export_format == EXPORT_FORMAT_ONE_PDF_ALL:
+        return _build_single_merged_pdf(programmation_projets, attrs, document_type)
+    if export_format == EXPORT_FORMAT_ONE_PDF_PER_PROJECT:
+        return _build_one_pdf_per_project(programmation_projets, attrs)
+    if export_format == EXPORT_FORMAT_ONE_PDF_ALL_GROUPED:
+        return _build_grouped_merged_pdf(programmation_projets, attrs)
+    return _build_one_pdf_per_doc(programmation_projets, attrs)
+
+
+def _build_one_pdf_per_doc(programmation_projets, attrs) -> tuple[str, str, bytes]:
+    documents = [
+        doc
+        for attr in attrs
+        for doc in (getattr(pp, attr) for pp in programmation_projets)
+    ]
+
+    if len(documents) == 1:
+        document = documents[0]
+        pdf_content = generate_pdf_for_generated_document(document)
+        logger.info(f"#1 {document} généré")
+        return document.name, "application/pdf", pdf_content
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as zip_file:
+        for i, document in enumerate(documents, start=1):
+            pdf_content = generate_pdf_for_generated_document(document)
+            zip_file.writestr(f"{document.name}", pdf_content)
+            logger.info(f"#{i} {document} généré")
+    date_str = timezone.now().strftime("%d-%m-%Y")
+    return f"export turgot {date_str}.zip", "application/zip", zip_buffer.getvalue()
+
+
+def _build_single_merged_pdf(
+    programmation_projets, attrs, document_type
+) -> tuple[str, str, bytes]:
+    pdf_bytes_list = []
+    for pp in programmation_projets:
+        for attr in attrs:
+            pdf_bytes_list.append(
+                generate_pdf_for_generated_document(getattr(pp, attr))
+            )
+    merged = _merge_pdfs_bytes(pdf_bytes_list)
+    date_str = timezone.now().strftime("%d-%m-%Y")
+    if document_type == ARRETE:
+        doc_type_fr = "arrêté"
+    elif document_type == ARRETE_ET_LETTRE:
+        doc_type_fr = "lettres et arrêtés"
+    else:
+        doc_type_fr = "lettre"
+    filename = f"export {doc_type_fr} turgot {date_str}.pdf"
+    return filename, "application/pdf", merged
+
+
+def _build_one_pdf_per_project(programmation_projets, attrs) -> tuple[str, str, bytes]:
+    if len(programmation_projets) == 1:
+        pp = programmation_projets[0]
+        pdf_bytes_list = [
+            generate_pdf_for_generated_document(getattr(pp, attr)) for attr in attrs
+        ]
+        merged = _merge_pdfs_bytes(pdf_bytes_list)
+        date_str = timezone.now().strftime("%d-%m-%Y")
+        ds_number = pp.dossier.ds_number
+        raison_sociale = slugify(pp.dossier.ds_demandeur.raison_sociale)
+        filename = f"lettre et arrêté - {ds_number} - {raison_sociale} - {date_str}.pdf"
+        return filename, "application/pdf", merged
+
+    date_str = timezone.now().strftime("%d-%m-%Y")
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as zip_file:
+        for pp in programmation_projets:
+            project_pdfs = [
+                generate_pdf_for_generated_document(getattr(pp, attr)) for attr in attrs
+            ]
+            merged = _merge_pdfs_bytes(project_pdfs)
+            ds_number = pp.dossier.ds_number
+            raison_sociale = slugify(pp.dossier.ds_demandeur.raison_sociale)
+            filename = f"lettre et arrêté - {ds_number} - {raison_sociale}.pdf"
+            zip_file.writestr(filename, merged)
+    return (
+        f"export turgot {date_str}.zip",
+        "application/zip",
+        zip_buffer.getvalue(),
+    )
+
+
+def _build_grouped_merged_pdf(programmation_projets, attrs) -> tuple[str, str, bytes]:
+    pdf_bytes_list = []
+    for pp in programmation_projets:
+        for attr in attrs:
+            pdf_bytes_list.append(
+                generate_pdf_for_generated_document(getattr(pp, attr))
+            )
+    merged = _merge_pdfs_bytes(pdf_bytes_list)
+    date_str = timezone.now().strftime("%d-%m-%Y")
+    filename = f"export turgot {date_str}.pdf"
+    return filename, "application/pdf", merged
+
+
+def _merge_pdfs_bytes(pdf_bytes_list: list[bytes]) -> bytes:
+    pdf = Pdf.new()
+    for pdf_bytes in pdf_bytes_list:
+        src = Pdf.open(io.BytesIO(pdf_bytes))
+        pdf.pages.extend(src.pages)
+    output = io.BytesIO()
+    pdf.save(output)
+    return output.getvalue()
+
+
+def upload_export_and_get_url(filename: str, content_type: str, body: bytes) -> str:
+    key = f"{EXPORT_PREFIX}/{uuid.uuid4().hex}/{filename}"
+    default_storage.save(key, ContentFile(body))
+    try:
+        return default_storage.url(
+            key,
+            parameters={
+                "ResponseContentDisposition": f'attachment; filename="{filename}"',
+                "ResponseContentType": content_type,
+            },
+            expire=EXPORT_URL_TTL,
+        )
+    except TypeError:
+        # Non-S3 backends (e.g. InMemoryStorage in tests) don't accept the
+        # presign kwargs; fall back to the plain url.
+        return default_storage.url(key)

--- a/gsl_notification/tests/views/test_generate_document_for_multiple_projets_views.py
+++ b/gsl_notification/tests/views/test_generate_document_for_multiple_projets_views.py
@@ -1,12 +1,13 @@
 import io
+import os
 import zipfile
-from datetime import UTC, datetime
 from html import unescape
 from unittest.mock import patch
 
 import pytest
-from django.test import Client, override_settings
-from django.urls import reverse
+from django.core.files.storage import default_storage
+from django.test import override_settings
+from django.utils.text import slugify
 from freezegun import freeze_time
 
 from gsl_core.tests.factories import (
@@ -17,18 +18,20 @@ from gsl_core.tests.factories import (
 from gsl_notification.forms import (
     ARRETE_ET_LETTRE,
     EXPORT_FORMAT_ONE_PDF_ALL,
+    EXPORT_FORMAT_ONE_PDF_ALL_GROUPED,
+    EXPORT_FORMAT_ONE_PDF_PER_DOC,
+    EXPORT_FORMAT_ONE_PDF_PER_PROJECT,
     GenerateDocumentsStep2Form,
 )
 from gsl_notification.models import LettreNotification
 from gsl_notification.tests.factories import (
-    ArreteFactory,
     LettreNotificationFactory,
     ModeleArreteFactory,
     ModeleLettreNotificationFactory,
 )
 from gsl_programmation.models import ProgrammationProjet
 from gsl_programmation.tests.factories import ProgrammationProjetFactory
-from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL, LETTRE
+from gsl_projet.constants import DOTATION_DETR, LETTRE
 
 pytestmark = pytest.mark.django_db
 
@@ -68,264 +71,19 @@ def client(perimetre):
     return ClientWithLoggedUserFactory(user)
 
 
-## download_documents
-
-
-def test_download_documents_method_allowed(client):
-    url = reverse(
-        "notification:download-documents",
-        kwargs={
-            "dotation": DOTATION_DETR,
-            "document_type": LETTRE,
-        },
-    )
-    assert url == f"/notification/{DOTATION_DETR}/telechargement/lettre"
-    response = client.post(url)
-    assert response.status_code == 405
-
-
-@override_settings(DEBUG=False)
-def test_download_documents_with_wrong_dotation(client):
-    url = reverse("notification:download-documents", args=["raté", LETTRE])
-    response = client.get(url)
-    assert response.status_code == 404
-    assert "Dotation inconnue" in unescape(response.content.decode("utf-8"))
-
-
-@override_settings(DEBUG=False)
-def test_download_documents_with_wrong_document_type(client):
-    url = reverse(
-        "notification:download-documents",
-        args=[DOTATION_DETR, "raté"],
-    )
-    response = client.get(url)
-    assert response.status_code == 404
-    assert "Type de document inconnu" in unescape(response.content.decode("utf-8"))
-
-
-@freeze_time("2026-05-03")
-def test_download_documents_no_id(client):
-    pps = []
-    # Must be selected (good perimetre, status and notified_at)
-    pps += ProgrammationProjetFactory.create_batch(
-        3,
-        dotation_projet__dotation=DOTATION_DETR,
-        dotation_projet__projet__dossier_ds__perimetre=client.user.perimetre,
-        status=ProgrammationProjet.STATUS_ACCEPTED,
-        notified_at=None,
-    )
-
-    # Must not be selected
-    pps += ProgrammationProjetFactory.create_batch(
-        5,
-        status=ProgrammationProjet.STATUS_ACCEPTED,
-        notified_at=None,
-    )
-
-    pps += ProgrammationProjetFactory.create_batch(
-        4,
-        dotation_projet__projet__dossier_ds__perimetre=client.user.perimetre,
-        status=ProgrammationProjet.STATUS_ACCEPTED,
-        notified_at=datetime.now(UTC),
-    )
-
-    for pp in pps:
-        LettreNotificationFactory(programmation_projet=pp)
-
-    url = reverse(
-        "notification:download-documents",
-        args=[DOTATION_DETR, LETTRE],
-    )
+@pytest.fixture(autouse=True)
+def _mock_logo_base64():
+    """Step 4 of the wizard renders every PDF synchronously, which fetches the
+    modele logo via HTTP. Mock it so tests don't hit the network."""
     with patch(
         "gsl_notification.utils.get_logo_base64",
         return_value="mocked_base64",
     ):
-        response = client.get(url)
-
-    assert response.status_code == 200
-    assert (
-        response["Content-Disposition"]
-        == 'attachment; filename="export turgot 03-05-2026.zip"'
-    )
-
-    with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
-        assert len(zf.namelist()) == 3
+        yield
 
 
-@freeze_time("2026-05-03")
-def test_download_documents_no_id_with_filters(client):
-    data = {"montant_demande_min": "100000"}
+## Helpers
 
-    pps = []
-    for amount in [50_000, 100_000, 150_000]:
-        pps.append(
-            ProgrammationProjetFactory(
-                dotation_projet__dotation=DOTATION_DETR,
-                dotation_projet__projet__dossier_ds__perimetre=client.user.perimetre,
-                dotation_projet__projet__dossier_ds__demande_montant=amount,
-                status=ProgrammationProjet.STATUS_ACCEPTED,
-                notified_at=None,
-            )
-        )
-
-    for pp in pps:
-        LettreNotificationFactory(programmation_projet=pp)
-
-    url = reverse(
-        "notification:download-documents",
-        args=[DOTATION_DETR, LETTRE],
-    )
-    with patch(
-        "gsl_notification.utils.get_logo_base64",
-        return_value="mocked_base64",
-    ):
-        response = client.get(url, data)
-
-    assert response.status_code == 200
-    assert (
-        response["Content-Disposition"]
-        == 'attachment; filename="export turgot 03-05-2026.zip"'
-    )
-
-    with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
-        assert len(zf.namelist()) == 2
-
-
-def _bad_wrong_perimetre():
-    return ProgrammationProjetFactory(dotation_projet__dotation=DOTATION_DETR)
-
-
-def _bad_wrong_dotation():
-    return ProgrammationProjetFactory(dotation_projet__dotation=DOTATION_DSIL)
-
-
-def _bad_already_notified():
-    return ProgrammationProjetFactory(notified_at=datetime.now(UTC))
-
-
-def _bad_refused():
-    return ProgrammationProjetFactory(status=ProgrammationProjet.STATUS_REFUSED)
-
-
-@pytest.mark.parametrize(
-    "make_bad_pp, duplicate_id",
-    [
-        pytest.param(_bad_wrong_perimetre, False, id="wrong_perimetre"),
-        pytest.param(_bad_wrong_dotation, False, id="wrong_dotation"),
-        pytest.param(_bad_already_notified, False, id="already_notified"),
-        pytest.param(_bad_refused, False, id="refused"),
-        # missing_doc: append a PP that won't pass the dotation filter and
-        # also has no LettreNotification — exercises both rejection paths
-        # in a single parameter.
-        pytest.param(_bad_wrong_dotation, False, id="missing_doc"),
-        pytest.param(None, True, id="duplicate_id"),
-    ],
-)
-def test_download_documents_rejects_invalid_pp(
-    client, programmation_projets, make_bad_pp, duplicate_id
-):
-    for pp in programmation_projets:
-        LettreNotificationFactory(programmation_projet=pp)
-
-    if make_bad_pp is not None:
-        programmation_projets.append(make_bad_pp())
-
-    ids = ",".join([str(pp.id) for pp in programmation_projets])
-    if duplicate_id:
-        ids += f",{str(programmation_projets[0].id)}"
-    url = (
-        reverse(
-            "notification:download-documents",
-            args=[DOTATION_DETR, LETTRE],
-        )
-        + f"?ids={ids}"
-    )
-    response = client.get(url)
-    assert response.status_code == 404
-    assert (
-        "Un ou plusieurs des projets n'est pas disponible pour une des raisons (identifiant inconnu, identifiant en double, projet déjà notifié ou refusé, projet associé à une autre dotation, ou hors de votre périmètre)."
-        in unescape(response.content.decode("utf-8"))
-    )
-
-
-@freeze_time("2026-05-03")
-def test_download_documents_correctly(client, programmation_projets):
-    for pp in programmation_projets:
-        LettreNotificationFactory(programmation_projet=pp)
-    pp_ids = [str(pp.id) for pp in programmation_projets]
-    ids = ",".join(pp_ids)
-    url = (
-        reverse(
-            "notification:download-documents",
-            args=[DOTATION_DETR, LETTRE],
-        )
-        + f"?ids={ids}"
-    )
-    with patch(
-        "gsl_notification.utils.get_logo_base64",
-        return_value="mocked_base64",
-    ):
-        response = client.get(url)
-
-    assert response.status_code == 200
-    assert (
-        response["Content-Disposition"]
-        == 'attachment; filename="export turgot 03-05-2026.zip"'
-    )
-
-    with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
-        assert len(zf.namelist()) == 3
-
-
-@freeze_time("2026-05-03")
-def test_download_documents_arrete_et_lettre_one_pdf_all_filename(
-    client, programmation_projets
-):
-    for pp in programmation_projets:
-        LettreNotificationFactory(programmation_projet=pp)
-        ArreteFactory(programmation_projet=pp)
-    ids = ",".join([str(pp.id) for pp in programmation_projets])
-    url = (
-        reverse(
-            "notification:download-documents",
-            args=[DOTATION_DETR, ARRETE_ET_LETTRE],
-        )
-        + f"?ids={ids}&export_format={EXPORT_FORMAT_ONE_PDF_ALL}"
-    )
-    with patch(
-        "gsl_notification.utils.get_logo_base64",
-        return_value="mocked_base64",
-    ):
-        response = client.get(url)
-
-    assert response.status_code == 200
-    assert response["Content-Type"] == "application/pdf"
-    assert response["Content-Disposition"].startswith(
-        'attachment; filename="export lettres et arrêtés turgot'
-    )
-
-
-def test_download_documents_single_doc_returns_pdf(client):
-    pp = ProgrammationProjetFactory(
-        dotation_projet__projet__dossier_ds__perimetre=client.user.perimetre,
-        dotation_projet__dotation=DOTATION_DETR,
-        status=ProgrammationProjet.STATUS_ACCEPTED,
-        notified_at=None,
-    )
-    LettreNotificationFactory(programmation_projet=pp)
-    url = (
-        reverse("notification:download-documents", args=[DOTATION_DETR, LETTRE])
-        + f"?ids={pp.id}"
-    )
-    with patch("gsl_notification.utils.get_logo_base64", return_value="mocked_base64"):
-        response = client.get(url)
-
-    assert response.status_code == 200
-    assert response["Content-Type"] == "application/pdf"
-    assert response.content[:4] == b"%PDF"
-
-
-## Modal HTMX views
 
 HTMX_HEADERS = {"HTTP_HX_REQUEST": "true"}
 
@@ -333,6 +91,8 @@ WIZARD_PREFIX_DETR = f"generate_documents_wizard_{DOTATION_DETR}"
 
 
 def _wizard_url(dotation=DOTATION_DETR):
+    from django.urls import reverse
+
     return reverse("gsl_notification:generate-documents-modal", args=[dotation])
 
 
@@ -356,6 +116,28 @@ def _post_launch(client, ids=None, dotation=DOTATION_DETR):
         ),
         **HTMX_HEADERS,
     )
+
+
+def _storage_key_from_url(url):
+    """InMemoryStorage returns '/media/<key>' — strip the media prefix.
+    The url is URL-encoded; decode it back to the on-disk key."""
+    from urllib.parse import unquote
+
+    return unquote(url.removeprefix("/media/"))
+
+
+def _read_storage_body(url):
+    key = _storage_key_from_url(url)
+    assert default_storage.exists(key)
+    with default_storage.open(key) as f:
+        return key, f.read()
+
+
+def _template_names(response):
+    # Step 4 renders PDFs via render_to_string before rendering the success
+    # template, so the success template is not always at index 0. Compare
+    # against the full set.
+    return {t.name for t in response.templates}
 
 
 ## Launch step (PRG entry) and wizard GET (dialog rendering)
@@ -582,6 +364,7 @@ def _drive_through_step3(
     *,
     document_type=LETTRE,
     step2_fields,
+    export_format=EXPORT_FORMAT_ONE_PDF_PER_DOC,
     dotation=DOTATION_DETR,
 ):
     """Walk the wizard from launch through a step3 submit.
@@ -611,7 +394,7 @@ def _drive_through_step3(
         _wizard_url(dotation),
         _wizard_step_data(
             "step3",
-            {"export_format": "un_pdf_par_document"},
+            {"export_format": export_format},
             prefix=f"generate_documents_wizard_{dotation}",
         ),
         **HTMX_HEADERS,
@@ -655,8 +438,9 @@ def test_wizard_step4_creates_documents_and_returns_success(
     )
     response = _post_step4(client)
     assert response.status_code == 200
-    assert response.templates[0].name == (
+    assert (
         "gsl_notification/generated_document/multiple/modal_success_body.html"
+        in _template_names(response)
     )
     assert response.context["doc_count"] == 3
     assert len(list(response.context["refreshed_programmation_projets"])) == 3
@@ -665,6 +449,9 @@ def test_wizard_step4_creates_documents_and_returns_success(
         assert hasattr(pp, "lettre_notification")
         assert pp.lettre_notification.modele == detr_lettre_modele
         assert pp.lettre_notification.created_by == client.user
+
+    _, body = _read_storage_body(response.context["download_url"])
+    assert body[:2] == b"PK"  # ZIP (3 docs)
 
 
 def test_wizard_step4_replaces_existing_doc(
@@ -681,9 +468,12 @@ def test_wizard_step4_replaces_existing_doc(
             "overwrite_strategy": GenerateDocumentsStep2Form.STRATEGY_REMPLACER,
         },
     )
-    _post_step4(client)
+    response = _post_step4(client)
     pp.refresh_from_db()
     assert pp.lettre_notification.id != old_lettre.id
+
+    _, body = _read_storage_body(response.context["download_url"])
+    assert body[:2] == b"PK"
 
 
 def test_wizard_step2_conserver_when_all_covered_advances_to_step3(
@@ -735,8 +525,9 @@ def test_wizard_step4_conserver_creates_only_missing_documents(
     )
     response = _post_step4(client)
     assert response.status_code == 200
-    assert response.templates[0].name == (
+    assert (
         "gsl_notification/generated_document/multiple/modal_success_body.html"
+        in _template_names(response)
     )
 
     pp_with_existing.refresh_from_db()
@@ -745,6 +536,9 @@ def test_wizard_step4_conserver_creates_only_missing_documents(
         pp.refresh_from_db()
         assert hasattr(pp, "lettre_notification")
         assert pp.lettre_notification.modele == detr_lettre_modele
+
+    _, body = _read_storage_body(response.context["download_url"])
+    assert body[:2] == b"PK"
 
 
 def test_wizard_step4_remplacer_when_all_covered_replaces_all(
@@ -764,13 +558,17 @@ def test_wizard_step4_remplacer_when_all_covered_replaces_all(
     )
     response = _post_step4(client)
     assert response.status_code == 200
-    assert response.templates[0].name == (
+    assert (
         "gsl_notification/generated_document/multiple/modal_success_body.html"
+        in _template_names(response)
     )
     for pp, old_id in zip(programmation_projets, old_ids, strict=True):
         pp.refresh_from_db()
         assert pp.lettre_notification.id != old_id
         assert pp.lettre_notification.modele == detr_lettre_modele
+
+    _, body = _read_storage_body(response.context["download_url"])
+    assert body[:2] == b"PK"
 
 
 def test_wizard_step4_conserver_full_coverage_with_empty_ids_reaches_success(
@@ -802,15 +600,19 @@ def test_wizard_step4_conserver_full_coverage_with_empty_ids_reaches_success(
     )
     client.post(
         _wizard_url(),
-        _wizard_step_data("step3", {"export_format": "un_pdf_par_document"}),
+        _wizard_step_data("step3", {"export_format": EXPORT_FORMAT_ONE_PDF_PER_DOC}),
         **HTMX_HEADERS,
     )
     response = _post_step4(client)
     assert response.status_code == 200
-    assert response.templates[0].name == (
+    assert (
         "gsl_notification/generated_document/multiple/modal_success_body.html"
+        in _template_names(response)
     )
     assert LettreNotification.objects.count() == 3
+
+    _, body = _read_storage_body(response.context["download_url"])
+    assert body[:2] == b"PK"
 
 
 def test_wizard_step4_both_creates_arrete_and_lettre(
@@ -827,8 +629,9 @@ def test_wizard_step4_both_creates_arrete_and_lettre(
     )
     response = _post_step4(client)
     assert response.status_code == 200
-    assert response.templates[0].name == (
+    assert (
         "gsl_notification/generated_document/multiple/modal_success_body.html"
+        in _template_names(response)
     )
     form = response.context["form"]
     assert form.document_type == ARRETE_ET_LETTRE
@@ -842,15 +645,157 @@ def test_wizard_step4_both_creates_arrete_and_lettre(
         assert hasattr(pp, "lettre_notification")
         assert pp.lettre_notification.modele == detr_lettre_modele
 
+    key, body = _read_storage_body(response.context["download_url"])
+    assert body[:2] == b"PK"  # ZIP (6 docs)
+    with zipfile.ZipFile(io.BytesIO(body)) as zf:
+        assert len(zf.namelist()) == 6
 
-## Authentication
+
+## Export-format coverage — end-to-end through the wizard
 
 
-def test_download_documents_requires_authentication():
-    anonymous_client = Client()
-    url = reverse(
-        "notification:download-documents",
-        args=[DOTATION_DETR, LETTRE],
+@freeze_time("2026-05-03")
+def test_export_one_pdf_per_doc_single_returns_named_pdf(perimetre, detr_lettre_modele):
+    """One projet × LETTRE → single PDF named after the document."""
+    user = CollegueFactory(perimetre=perimetre)
+    client = ClientWithLoggedUserFactory(user)
+    pps = [
+        ProgrammationProjetFactory(
+            dotation_projet__projet__dossier_ds__perimetre=perimetre,
+            dotation_projet__dotation=DOTATION_DETR,
+            status=ProgrammationProjet.STATUS_ACCEPTED,
+            notified_at=None,
+        )
+    ]
+    _drive_through_step3(
+        client,
+        pps,
+        step2_fields={"modele_lettre_id": str(detr_lettre_modele.id)},
+        export_format=EXPORT_FORMAT_ONE_PDF_PER_DOC,
     )
-    response = anonymous_client.get(url)
-    assert response.status_code == 302
+    response = _post_step4(client)
+    assert response.status_code == 200
+
+    key, body = _read_storage_body(response.context["download_url"])
+    filename = os.path.basename(key)
+    assert filename == pps[0].lettre_notification.name
+    assert body[:4] == b"%PDF"
+
+
+@freeze_time("2026-05-03")
+def test_export_one_pdf_per_doc_multi_returns_zip(
+    client, programmation_projets, detr_lettre_modele
+):
+    _drive_through_step3(
+        client,
+        programmation_projets,
+        step2_fields={"modele_lettre_id": str(detr_lettre_modele.id)},
+        export_format=EXPORT_FORMAT_ONE_PDF_PER_DOC,
+    )
+    response = _post_step4(client)
+    assert response.status_code == 200
+
+    key, body = _read_storage_body(response.context["download_url"])
+    assert os.path.basename(key) == "export turgot 03-05-2026.zip"
+    assert body[:2] == b"PK"
+    with zipfile.ZipFile(io.BytesIO(body)) as zf:
+        assert len(zf.namelist()) == 3
+
+
+@freeze_time("2026-05-03")
+def test_export_one_pdf_all_merges_into_single_pdf(
+    client, programmation_projets, detr_lettre_modele
+):
+    """One_PDF_ALL is only offered for a single document type (lettre xor arrêté)."""
+    _drive_through_step3(
+        client,
+        programmation_projets,
+        step2_fields={"modele_lettre_id": str(detr_lettre_modele.id)},
+        export_format=EXPORT_FORMAT_ONE_PDF_ALL,
+    )
+    response = _post_step4(client)
+    assert response.status_code == 200
+
+    key, body = _read_storage_body(response.context["download_url"])
+    assert os.path.basename(key) == "export lettre turgot 03-05-2026.pdf"
+    assert body[:4] == b"%PDF"
+
+
+@freeze_time("2026-05-03")
+def test_export_one_pdf_per_project_single_returns_named_pdf(
+    perimetre, detr_arrete_modele, detr_lettre_modele
+):
+    user = CollegueFactory(perimetre=perimetre)
+    client = ClientWithLoggedUserFactory(user)
+    pp = ProgrammationProjetFactory(
+        dotation_projet__projet__dossier_ds__perimetre=perimetre,
+        dotation_projet__dotation=DOTATION_DETR,
+        status=ProgrammationProjet.STATUS_ACCEPTED,
+        notified_at=None,
+    )
+    _drive_through_step3(
+        client,
+        [pp],
+        document_type=ARRETE_ET_LETTRE,
+        step2_fields={
+            "modele_arrete_id": str(detr_arrete_modele.id),
+            "modele_lettre_id": str(detr_lettre_modele.id),
+        },
+        export_format=EXPORT_FORMAT_ONE_PDF_PER_PROJECT,
+    )
+    response = _post_step4(client)
+    assert response.status_code == 200
+
+    key, body = _read_storage_body(response.context["download_url"])
+    ds_number = pp.dossier.ds_number
+    raison_sociale = slugify(pp.dossier.ds_demandeur.raison_sociale)
+    expected = f"lettre et arrêté - {ds_number} - {raison_sociale} - 03-05-2026.pdf"
+    assert os.path.basename(key) == expected
+    assert body[:4] == b"%PDF"
+
+
+@freeze_time("2026-05-03")
+def test_export_one_pdf_per_project_multi_returns_zip(
+    client, programmation_projets, detr_arrete_modele, detr_lettre_modele
+):
+    _drive_through_step3(
+        client,
+        programmation_projets,
+        document_type=ARRETE_ET_LETTRE,
+        step2_fields={
+            "modele_arrete_id": str(detr_arrete_modele.id),
+            "modele_lettre_id": str(detr_lettre_modele.id),
+        },
+        export_format=EXPORT_FORMAT_ONE_PDF_PER_PROJECT,
+    )
+    response = _post_step4(client)
+    assert response.status_code == 200
+
+    key, body = _read_storage_body(response.context["download_url"])
+    assert os.path.basename(key) == "export turgot 03-05-2026.zip"
+    assert body[:2] == b"PK"
+    with zipfile.ZipFile(io.BytesIO(body)) as zf:
+        # One merged PDF per project.
+        assert len(zf.namelist()) == 3
+
+
+@freeze_time("2026-05-03")
+def test_export_one_pdf_all_grouped_merges_into_single_pdf(
+    client, programmation_projets, detr_arrete_modele, detr_lettre_modele
+):
+    _drive_through_step3(
+        client,
+        programmation_projets,
+        document_type=ARRETE_ET_LETTRE,
+        step2_fields={
+            "modele_arrete_id": str(detr_arrete_modele.id),
+            "modele_lettre_id": str(detr_lettre_modele.id),
+        },
+        export_format=EXPORT_FORMAT_ONE_PDF_ALL_GROUPED,
+    )
+    response = _post_step4(client)
+    assert response.status_code == 200
+
+    key, body = _read_storage_body(response.context["download_url"])
+    assert os.path.basename(key) == "export turgot 03-05-2026.pdf"
+    assert body[:4] == b"%PDF"

--- a/gsl_notification/urls.py
+++ b/gsl_notification/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from gsl_notification.views.generate_document_for_multiple_projets_views import (
     GenerateDocumentsWizard,
-    download_documents,
 )
 from gsl_notification.views.modele_views import (
     ChooseModeleDocumentType,
@@ -83,11 +82,6 @@ urlpatterns = [
         "<str:dotation>/generer/",
         GenerateDocumentsWizard.as_view(),
         name="generate-documents-modal",
-    ),
-    path(
-        "<str:dotation>/telechargement/<str:document_type>",
-        download_documents,
-        name="download-documents",
     ),
     # Uploaded files
     path(

--- a/gsl_notification/views/generate_document_for_multiple_projets_views.py
+++ b/gsl_notification/views/generate_document_for_multiple_projets_views.py
@@ -1,25 +1,16 @@
-import io
 import logging
-import zipfile
 
-from django.http import HttpResponse
-from django.shortcuts import get_list_or_404, render
-from django.urls import reverse
-from django.utils import timezone
+from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from django.utils.text import slugify
-from django.views.decorators.http import require_GET
 from django_htmx.http import trigger_client_event
 from formtools.wizard.views import SessionWizardView
-from pikepdf import Pdf
 
 from gsl_core.decorators import htmx_only
 from gsl_core.exceptions import Http404
+from gsl_notification.exports import build_export, upload_export_and_get_url
 from gsl_notification.forms import (
-    ARRETE_ET_LETTRE,
     EXPORT_FORMAT_ONE_PDF_ALL,
     EXPORT_FORMAT_ONE_PDF_ALL_GROUPED,
-    EXPORT_FORMAT_ONE_PDF_PER_DOC,
     EXPORT_FORMAT_ONE_PDF_PER_PROJECT,
     SELECTED_TYPES_BY_CHOICE,
     GenerateDocumentsCreateForm,
@@ -28,192 +19,10 @@ from gsl_notification.forms import (
     GenerateDocumentsStep2Form,
     GenerateDocumentsStep3Form,
 )
-from gsl_notification.utils import (
-    generate_pdf_for_generated_document,
-    get_programmation_projet_attribute,
-)
-from gsl_programmation.models import ProgrammationProjet
-from gsl_programmation.utils.programmation_projet_filters import (
-    ProgrammationProjetFilters,
-)
-from gsl_projet.constants import (
-    ARRETE,
-    DOTATIONS,
-    LETTRE,
-)
+from gsl_notification.utils import get_programmation_projet_attribute
+from gsl_projet.constants import DOTATIONS
 
 logger = logging.getLogger(__name__)
-
-
-@require_GET
-def download_documents(request, dotation, document_type):
-    if dotation not in DOTATIONS:
-        raise Http404(user_message="Dotation inconnue")
-    selected_types = SELECTED_TYPES_BY_CHOICE.get(document_type)
-    if selected_types is None:
-        raise Http404(user_message="Type de document inconnu")
-
-    types = [t for t in (LETTRE, ARRETE) if t in selected_types]
-    attrs = [get_programmation_projet_attribute(t) for t in types]
-    attr_select_related = [
-        "dotation_projet",
-        "dotation_projet__projet",
-        "dotation_projet__projet__dossier_ds",
-        "dotation_projet__projet__dossier_ds__ds_demandeur",
-        *attrs,
-        *(f"{a}__modele" for a in attrs),
-    ]
-
-    ids_str = request.GET.get("ids", "")
-    ids = [int(i) for i in ids_str.split(",") if i.strip().isdigit()]
-    if ids:
-        programmation_projets = get_list_or_404(
-            ProgrammationProjet.objects.visible_to_user(request.user).select_related(
-                *attr_select_related
-            ),
-            id__in=ids,
-            dotation_projet__dotation=dotation,
-            status=ProgrammationProjet.STATUS_ACCEPTED,
-            dotation_projet__projet__notified_at=None,
-        )
-        if len(programmation_projets) < len(ids):
-            raise Http404(
-                user_message="Un ou plusieurs des projets n'est pas disponible pour une des raisons (identifiant inconnu, identifiant en double, projet déjà notifié ou refusé, projet associé à une autre dotation, ou hors de votre périmètre)."
-            )
-    else:
-        filterset = ProgrammationProjetFilters(data=request.GET, request=request)
-        programmation_projets = filterset.qs.can_generate_documents().select_related(
-            *attr_select_related
-        )
-
-    export_format = request.GET.get("export_format", EXPORT_FORMAT_ONE_PDF_PER_DOC)
-
-    if export_format == EXPORT_FORMAT_ONE_PDF_ALL:
-        return _download_single_merged_pdf(programmation_projets, attrs, document_type)
-    if export_format == EXPORT_FORMAT_ONE_PDF_PER_PROJECT:
-        return _download_one_pdf_per_project(programmation_projets, attrs)
-    if export_format == EXPORT_FORMAT_ONE_PDF_ALL_GROUPED:
-        return _download_grouped_merged_pdf(programmation_projets, attrs)
-
-    return _download_one_pdf_per_doc(programmation_projets, attrs)
-
-
-def _download_one_pdf_per_doc(programmation_projets, attrs):
-    try:
-        documents = [
-            doc
-            for attr in attrs
-            for doc in (getattr(pp, attr) for pp in programmation_projets)
-        ]
-    except (
-        ProgrammationProjet.lettre_notification.RelatedObjectDoesNotExist,
-        ProgrammationProjet.arrete.RelatedObjectDoesNotExist,
-    ):
-        raise Http404(user_message="Un des projets n'a pas le document demandé.")
-
-    if len(documents) == 1:
-        document = documents[0]
-        pdf_content = generate_pdf_for_generated_document(document)
-        logger.info(f"#1 {document} généré")
-        response = HttpResponse(pdf_content, content_type="application/pdf")
-        response["Content-Disposition"] = f'attachment; filename="{document.name}"'
-        return response
-
-    zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, "w") as zip_file:
-        for i, document in enumerate(documents, start=1):
-            pdf_content = generate_pdf_for_generated_document(document)
-            zip_file.writestr(f"{document.name}", pdf_content)
-            logger.info(f"#{i} {document} généré")
-    zip_buffer.seek(0)
-    date_str = timezone.now().strftime("%d-%m-%Y")
-    zip_filename = f"export turgot {date_str}.zip"
-    response = HttpResponse(zip_buffer, content_type="application/zip")
-    response["Content-Disposition"] = f'attachment; filename="{zip_filename}"'
-    return response
-
-
-def _download_single_merged_pdf(programmation_projets, attrs, document_type):
-    pdf_bytes_list = []
-    for pp in programmation_projets:
-        for attr in attrs:
-            pdf_bytes_list.append(
-                generate_pdf_for_generated_document(getattr(pp, attr))
-            )
-    merged = _merge_pdfs_bytes(pdf_bytes_list)
-    date_str = timezone.now().strftime("%d-%m-%Y")
-    if document_type == ARRETE:
-        doc_type_fr = "arrêté"
-    elif document_type == ARRETE_ET_LETTRE:
-        doc_type_fr = "lettres et arrêtés"
-    else:
-        doc_type_fr = "lettre"
-    filename = f"export {doc_type_fr} turgot {date_str}.pdf"
-    response = HttpResponse(merged, content_type="application/pdf")
-    response["Content-Disposition"] = f'attachment; filename="{filename}"'
-    return response
-
-
-def _download_one_pdf_per_project(programmation_projets, attrs):
-    if len(programmation_projets) == 1:
-        pp = programmation_projets[0]
-        pdf_bytes_list = []
-        for attr in attrs:
-            pdf_bytes_list.append(
-                generate_pdf_for_generated_document(getattr(pp, attr))
-            )
-        merged = _merge_pdfs_bytes(pdf_bytes_list)
-        date_str = timezone.now().strftime("%d-%m-%Y")
-        ds_number = pp.dossier.ds_number
-        raison_sociale = slugify(pp.dossier.ds_demandeur.raison_sociale)
-        filename = f"lettre et arrêté - {ds_number} - {raison_sociale} - {date_str}.pdf"
-        response = HttpResponse(merged, content_type="application/pdf")
-        response["Content-Disposition"] = f'attachment; filename="{filename}"'
-        return response
-
-    date_str = timezone.now().strftime("%d-%m-%Y")
-    zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, "w") as zip_file:
-        for pp in programmation_projets:
-            project_pdfs = [
-                generate_pdf_for_generated_document(getattr(pp, attr)) for attr in attrs
-            ]
-            merged = _merge_pdfs_bytes(project_pdfs)
-            ds_number = pp.dossier.ds_number
-            raison_sociale = slugify(pp.dossier.ds_demandeur.raison_sociale)
-            filename = f"lettre et arrêté - {ds_number} - {raison_sociale}.pdf"
-            zip_file.writestr(filename, merged)
-    zip_buffer.seek(0)
-    zip_filename = f"export turgot {date_str}.zip"
-    response = HttpResponse(zip_buffer, content_type="application/zip")
-    response["Content-Disposition"] = f'attachment; filename="{zip_filename}"'
-    return response
-
-
-def _download_grouped_merged_pdf(programmation_projets, attrs):
-    pdf_bytes_list = []
-    for pp in programmation_projets:
-        for attr in attrs:
-            pdf_bytes_list.append(
-                generate_pdf_for_generated_document(getattr(pp, attr))
-            )
-    merged = _merge_pdfs_bytes(pdf_bytes_list)
-    date_str = timezone.now().strftime("%d-%m-%Y")
-    filename = f"export turgot {date_str}.pdf"
-    response = HttpResponse(merged, content_type="application/pdf")
-    response["Content-Disposition"] = f'attachment; filename="{filename}"'
-    return response
-
-
-def _merge_pdfs_bytes(pdf_bytes_list: list[bytes]) -> bytes:
-    pdf = Pdf.new()
-    for pdf_bytes in pdf_bytes_list:
-        src = Pdf.open(io.BytesIO(pdf_bytes))
-        pdf.pages.extend(src.pages)
-    output = io.BytesIO()
-    pdf.save(output)
-    output.seek(0)
-    return output.read()
 
 
 @method_decorator(htmx_only, name="dispatch")
@@ -368,22 +177,19 @@ class GenerateDocumentsWizard(SessionWizardView):
         step2_data = form_dict[self.STEP2].cleaned_data
         step3_data = form_dict[self.STEP3].cleaned_data
         export_format = step3_data.get("export_format")
+
         refreshed = form.save(
             modele_arrete=step2_data.get("modele_arrete_id"),
             modele_lettre=step2_data.get("modele_lettre_id"),
             overwrite_strategy=step2_data.get("overwrite_strategy"),
         )
-        download_url = reverse(
-            "gsl_notification:download-documents",
-            kwargs={
-                "dotation": self.kwargs["dotation"],
-                "document_type": form.document_type,
-            },
-            query={
-                "ids": ",".join(str(pp.id) for pp in form.programmation_projets),
-                "export_format": export_format,
-            },
+
+        attrs = [get_programmation_projet_attribute(t) for t in form.selected_types]
+        filename, content_type, body = build_export(
+            refreshed, attrs, export_format, form.document_type
         )
+        download_url = upload_export_and_get_url(filename, content_type, body)
+
         context = {
             "modal_id": self.modal_id,
             "dotation": self.kwargs["dotation"],


### PR DESCRIPTION
## 🌮 Objectif

Construire l'export de documents directement à la fin de l'assistant de génération, et fournir une URL vers le stockage plutôt qu'un endpoint dédié.

## 🔍 Liste des modifications

- Nouveau module `gsl_notification/exports.py` qui regroupe la construction du PDF / ZIP exporté (`build_export`) et un helper `upload_export_and_get_url` qui dépose le fichier sur `default_storage` et renvoie une URL pré-signée (S3) ou directe (fallback).
- L'étape 4 (`done()`) de `GenerateDocumentsWizard` construit l'export depuis les `ProgrammationProjet` rafraîchis et passe l'URL générée au template de succès.
- Suppression de la vue `download_documents` et de la route `notification:download-documents`, ainsi que de toute la logique de re-sélection / re-validation des projets côté téléchargement.
- Tests : retrait des tests ciblant `download_documents` ; ajout d'une couverture end-to-end qui pilote l'assistant et relit l'export depuis `default_storage`.
- `settings_test.py` bascule le `default` storage sur `InMemoryStorage` pour permettre la relecture du fichier exporté dans les tests.

## ⚠️ Informations supplémentaires

Les exports sont déposés sous le préfixe `tmp/notifications/exports/` du bucket et l'URL pré-signée renvoyée expire au bout de 15 minutes (`EXPORT_URL_TTL = 900`). Il faut **ajouter une règle de cycle de vie côté S3** (sur ce préfixe) pour supprimer automatiquement les objets après 15 minutes — sans quoi les fichiers s'accumuleront indéfiniment dans le bucket alors qu'ils ne sont plus accessibles via l'URL.

Cette PR remplace https://github.com/betagouv/gestion-des-subventions-locales/pull/708