### PR TITLE
Réalignement des lock files et garde-fou CI contre la dérive

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+        pip install -r requirements.txt -r requirements-dev.txt
 
     - name: Check linting
       run: |
@@ -85,7 +85,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+        pip install -r requirements.txt -r requirements-dev.txt
 
     - name: Check migrations
       run: python manage.py makemigrations --check --dry-run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,11 @@
 [project]
 name = "gsl"
 dynamic = ["version"]
-authors = [{ name = "Agnès Haasser", email = "agnes.haasser@beta.gouv.fr" }]
+authors = [
+    { name = "Agnès Haasser", email = "agnes.haasser@beta.gouv.fr" },
+    { name = "Maud Royer", email = "maud.royer@beta.gouv.fr" },
+    { name = "Maxime Allain", email = "maxime.allain@beta.gouv.fr" }
+]
 readme = "README.md"
 license = { file = "LICENSE" }
 dependencies = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -297,7 +297,7 @@ pygments==2.20.0
     #   pytest
 pyjwt==2.12.1
     # via mozilla-django-oidc
-pypdfium2==5.8.0
+pypdfium2==4.30.0
     # via gsl (pyproject.toml)
 pyphen==0.17.2
     # via weasyprint
@@ -444,7 +444,7 @@ xlwt==1.3.0
     # via tablib
 zopfli==0.4.1
     # via fonttools
-zxing-cpp==3.0.0
+zxing-cpp==2.3.0
     # via gsl (pyproject.toml)
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -211,10 +211,10 @@ pygments==2.20.0
     # via
     #   ipython
     #   ipython-pygments-lexers
-pypdfium2==4.30.0
-    # via gsl (pyproject.toml)
 pyjwt==2.12.1
     # via mozilla-django-oidc
+pypdfium2==4.30.0
+    # via gsl (pyproject.toml)
 pyphen==0.17.2
     # via weasyprint
 python-crontab==3.3.0


### PR DESCRIPTION
## 🌮 Objectif

Réaligner `requirements.txt` et `requirements-dev.txt` (qui avaient divergé sur `pypdfium2` et `zxing-cpp`) et empêcher toute future dérive depuis la CI.

## 🔍 Liste des modifications

- Réalignement de `requirements-dev.txt` sur `requirements.txt` :
  - `pypdfium2` repasse à `4.30.0` (était `5.8.0` côté dev)
  - `zxing-cpp` repasse à `2.3.0` (était `3.0.0` côté dev)
- CI : les jobs `lint-python` et `tests` installent désormais `requirements.txt` ET `requirements-dev.txt` dans le même `pip install`. Si les deux fichiers divergent sur un pin partagé, pip remonte une `ResolutionImpossible` et la PR échoue.
- Ajout de Maud Royer et Maxime Allain aux `authors` dans `pyproject.toml`.

## ⚠️ Informations supplémentaires

La dérive avait été introduite par le commit `da568cfb` : les deux fichiers avaient été recompilés indépendamment et la CI ne voyait jamais les deux ensemble. Le garde-fou ne coûte rien à la CI (`requirements-dev.txt` est censé être un sur-ensemble de `requirements.txt`) mais évite que cela se reproduise silencieusement.