### PR TITLE
Amélioration du formatage de l'adresse du demandeur dans les documents

### DIFF
--- a/gsl_core/models.py
+++ b/gsl_core/models.py
@@ -77,6 +77,12 @@ class Adresse(BaseModel):
             return f"{self.street_address} {self.postal_code} {self.commune.name}"
         return self.label
 
+    @property
+    def two_lines(self):
+        if self.commune:
+            return f"{self.street_address}\n{self.postal_code} {self.commune.name}"
+        return self.label
+
     def update_from_raw_ds_data(self, raw_ds_data):
         if isinstance(raw_ds_data, str):
             self.label = raw_ds_data

--- a/gsl_core/tests/test_model_adresse.py
+++ b/gsl_core/tests/test_model_adresse.py
@@ -2,6 +2,8 @@ import json
 
 import pytest
 
+from gsl_core.tests.factories import AdresseFactory
+
 from ..models import Adresse, Commune, Region
 
 pytestmark = pytest.mark.django_db
@@ -99,3 +101,13 @@ def test_it_works_with_a_simple_string(simple_string_address):
     adresse.save()
 
     assert adresse.label == simple_string_address
+
+
+def test_two_lines_returns_street_address_and_postal_code():
+    adresse = AdresseFactory(
+        street_address="1 rue de la Paix",
+        postal_code="75001",
+        commune__name="Paris",
+    )
+
+    assert adresse.two_lines == "1 rue de la Paix\n75001 Paris"

--- a/gsl_notification/tests/test_utils.py
+++ b/gsl_notification/tests/test_utils.py
@@ -89,7 +89,11 @@ def programmation_projet():
         ("porteur-fonction", "Fonction du porteur de projet", "Maire"),
         ("porteur-prenom", "Prénom du porteur de projet", "Jean"),
         ("porteur-nom", "Nom du porteur de projet", "Dupont"),
-        ("adresse-demandeur", "Adresse du demandeur", "1 rue de la Paix 75001 Paris"),
+        (
+            "adresse-demandeur",
+            "Adresse du demandeur",
+            "1 rue de la Paix<br/>75001 Paris",
+        ),
         ("commentaire-1", "Commentaire 1", "Commentaire important"),
         (
             "montant-subvention-lettres",
@@ -111,6 +115,9 @@ def test_replace_mentions_in_html_multiline_address():
     perimetre = PerimetreDepartementalFactory()
     adresse = AdresseFactory(
         label="DIRECTION GENERALE DES COLLECTIVITES LOCALES\r\n\r\n2 PLACE DES SAUSSAIES\r\n75008 PARIS\r\nFRANCE",
+        street_address="2 PLACE DES SAUSSAIES",
+        postal_code="75008",
+        commune__name="PARIS",
     )
     pp = ProgrammationProjetFactory(
         dotation_projet__projet__dossier_ds__ds_demandeur=PersonneMoraleFactory(
@@ -120,10 +127,28 @@ def test_replace_mentions_in_html_multiline_address():
     )
     html_content = '<p><span class="mention" data-type="mention" data-id="adresse-demandeur" data-label="Adresse du demandeur" data-mention-suggestion-char="@">@Adresse du demandeur</span></p>'
     result = replace_mentions_in_html(html_content, pp)
-    assert (
-        result
-        == "<p>DIRECTION GENERALE DES COLLECTIVITES LOCALES<br/><br/>2 PLACE DES SAUSSAIES<br/>75008 PARIS<br/>FRANCE</p>"
+    assert result == "<p>2 PLACE DES SAUSSAIES<br/>75008 PARIS</p>"
+
+
+@pytest.mark.django_db
+def test_replace_mentions_in_html_uses_address_two_lines():
+    perimetre = PerimetreDepartementalFactory()
+    adresse = AdresseFactory(
+        street_address="1 rue de la Paix",
+        postal_code="75001",
+        commune__name="Paris",
     )
+    pp = ProgrammationProjetFactory(
+        dotation_projet__projet__dossier_ds__ds_demandeur=PersonneMoraleFactory(
+            address=adresse,
+        ),
+        dotation_projet__projet__dossier_ds__perimetre=perimetre,
+    )
+    html_content = '<p><span class="mention" data-type="mention" data-id="adresse-demandeur" data-label="Adresse du demandeur" data-mention-suggestion-char="@">@Adresse du demandeur</span></p>'
+
+    result = replace_mentions_in_html(html_content, pp)
+
+    assert result == "<p>1 rue de la Paix<br/>75001 Paris</p>"
 
 
 @pytest.mark.django_db

--- a/gsl_notification/utils.py
+++ b/gsl_notification/utils.py
@@ -172,7 +172,7 @@ MENTIONS = [
     Mention(
         "adresse-demandeur",
         "Adresse du demandeur",
-        "dossier.ds_demandeur.address.label",
+        "dossier.ds_demandeur.address.two_lines",
     ),
     Mention(
         "date-arrete",


### PR DESCRIPTION
## 🌮 Objectif

Afficher l'adresse du demandeur sur deux lignes dans les documents générés (arrêtés, lettres), au lieu d'une seule ligne à plat.

## 🔍 Liste des modifications

- Ajout d'une propriété `Adresse.two_lines` qui retourne l'adresse formatée sur deux lignes (`rue\ncode postal commune`)
- Utilisation de `two_lines` à la place de `label` pour la mention `@Adresse du demandeur` dans les documents
- Tests unitaires sur `Adresse.two_lines` et sur le rendu HTML de la mention