### PR TITLE
Rendre le QR code de suivi optionnel sur les documents générés

### DIFF
--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -53,6 +53,7 @@
                     "doubleDotation": "/static/js/controllers/doubleDotation.js",
                     "modeleArreteForm": "/static/js/modeleArreteForm.js",
                     "deleteNotificationDocumentModal": "/static/js/deleteNotificationDocumentModal.js",
+                    "qrCodeToggle": "/static/js/qrCodeToggle.js",
                     "chooseDocumentType": "/static/js/chooseDocumentType.js",
                     "checkboxSelection": "/static/js/checkboxSelection.js",
                     "bindAmountFields": "/static/js/controllers/bindAmountTields.js",
@@ -127,6 +128,7 @@
             import { TipTapEditor } from "tiptapEditor"
             import { ModeleArreteForm } from "modeleArreteForm"
             import { DeleteNotificationDocumentModal } from "deleteNotificationDocumentModal"
+            import { QrCodeToggle } from "qrCodeToggle"
             import { CheckboxSelection } from "checkboxSelection"
             import { BindAmountFields } from "bindAmountFields"
             import { FormUtils } from "formUtils"
@@ -140,6 +142,7 @@
             Stimulus.register("tiptap-editor", TipTapEditor)
             Stimulus.register("modele-arrete-form", ModeleArreteForm)
             Stimulus.register("delete-notification-document-modal", DeleteNotificationDocumentModal)
+            Stimulus.register("qr-code-toggle", QrCodeToggle)
             Stimulus.register("checkbox-selection", CheckboxSelection)
             Stimulus.register("bind-amount-fields", BindAmountFields)
             Stimulus.register("form-utils", FormUtils)

--- a/gsl_notification/exports.py
+++ b/gsl_notification/exports.py
@@ -25,18 +25,28 @@ EXPORT_URL_TTL = 900  # 15 minutes
 
 
 def build_export(
-    programmation_projets, attrs, export_format, document_type
+    programmation_projets, attrs, export_format, document_type, *, with_qr_code=True
 ) -> tuple[str, str, bytes]:
     if export_format == EXPORT_FORMAT_ONE_PDF_ALL:
-        return _build_single_merged_pdf(programmation_projets, attrs, document_type)
+        return _build_single_merged_pdf(
+            programmation_projets, attrs, document_type, with_qr_code=with_qr_code
+        )
     if export_format == EXPORT_FORMAT_ONE_PDF_PER_PROJECT:
-        return _build_one_pdf_per_project(programmation_projets, attrs)
+        return _build_one_pdf_per_project(
+            programmation_projets, attrs, with_qr_code=with_qr_code
+        )
     if export_format == EXPORT_FORMAT_ONE_PDF_ALL_GROUPED:
-        return _build_grouped_merged_pdf(programmation_projets, attrs)
-    return _build_one_pdf_per_doc(programmation_projets, attrs)
+        return _build_grouped_merged_pdf(
+            programmation_projets, attrs, with_qr_code=with_qr_code
+        )
+    return _build_one_pdf_per_doc(
+        programmation_projets, attrs, with_qr_code=with_qr_code
+    )
 
 
-def _build_one_pdf_per_doc(programmation_projets, attrs) -> tuple[str, str, bytes]:
+def _build_one_pdf_per_doc(
+    programmation_projets, attrs, *, with_qr_code=True
+) -> tuple[str, str, bytes]:
     documents = [
         doc
         for attr in attrs
@@ -45,14 +55,18 @@ def _build_one_pdf_per_doc(programmation_projets, attrs) -> tuple[str, str, byte
 
     if len(documents) == 1:
         document = documents[0]
-        pdf_content = generate_pdf_for_generated_document(document)
+        pdf_content = generate_pdf_for_generated_document(
+            document, with_qr_code=with_qr_code
+        )
         logger.info(f"#1 {document} généré")
         return document.name, "application/pdf", pdf_content
 
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, "w") as zip_file:
         for i, document in enumerate(documents, start=1):
-            pdf_content = generate_pdf_for_generated_document(document)
+            pdf_content = generate_pdf_for_generated_document(
+                document, with_qr_code=with_qr_code
+            )
             zip_file.writestr(f"{document.name}", pdf_content)
             logger.info(f"#{i} {document} généré")
     date_str = timezone.now().strftime("%d-%m-%Y")
@@ -60,13 +74,15 @@ def _build_one_pdf_per_doc(programmation_projets, attrs) -> tuple[str, str, byte
 
 
 def _build_single_merged_pdf(
-    programmation_projets, attrs, document_type
+    programmation_projets, attrs, document_type, *, with_qr_code=True
 ) -> tuple[str, str, bytes]:
     pdf_bytes_list = []
     for pp in programmation_projets:
         for attr in attrs:
             pdf_bytes_list.append(
-                generate_pdf_for_generated_document(getattr(pp, attr))
+                generate_pdf_for_generated_document(
+                    getattr(pp, attr), with_qr_code=with_qr_code
+                )
             )
     merged = _merge_pdfs_bytes(pdf_bytes_list)
     date_str = timezone.now().strftime("%d-%m-%Y")
@@ -80,11 +96,16 @@ def _build_single_merged_pdf(
     return filename, "application/pdf", merged
 
 
-def _build_one_pdf_per_project(programmation_projets, attrs) -> tuple[str, str, bytes]:
+def _build_one_pdf_per_project(
+    programmation_projets, attrs, *, with_qr_code=True
+) -> tuple[str, str, bytes]:
     if len(programmation_projets) == 1:
         pp = programmation_projets[0]
         pdf_bytes_list = [
-            generate_pdf_for_generated_document(getattr(pp, attr)) for attr in attrs
+            generate_pdf_for_generated_document(
+                getattr(pp, attr), with_qr_code=with_qr_code
+            )
+            for attr in attrs
         ]
         merged = _merge_pdfs_bytes(pdf_bytes_list)
         date_str = timezone.now().strftime("%d-%m-%Y")
@@ -98,7 +119,10 @@ def _build_one_pdf_per_project(programmation_projets, attrs) -> tuple[str, str, 
     with zipfile.ZipFile(zip_buffer, "w") as zip_file:
         for pp in programmation_projets:
             project_pdfs = [
-                generate_pdf_for_generated_document(getattr(pp, attr)) for attr in attrs
+                generate_pdf_for_generated_document(
+                    getattr(pp, attr), with_qr_code=with_qr_code
+                )
+                for attr in attrs
             ]
             merged = _merge_pdfs_bytes(project_pdfs)
             ds_number = pp.dossier.ds_number
@@ -112,12 +136,16 @@ def _build_one_pdf_per_project(programmation_projets, attrs) -> tuple[str, str, 
     )
 
 
-def _build_grouped_merged_pdf(programmation_projets, attrs) -> tuple[str, str, bytes]:
+def _build_grouped_merged_pdf(
+    programmation_projets, attrs, *, with_qr_code=True
+) -> tuple[str, str, bytes]:
     pdf_bytes_list = []
     for pp in programmation_projets:
         for attr in attrs:
             pdf_bytes_list.append(
-                generate_pdf_for_generated_document(getattr(pp, attr))
+                generate_pdf_for_generated_document(
+                    getattr(pp, attr), with_qr_code=with_qr_code
+                )
             )
     merged = _merge_pdfs_bytes(pdf_bytes_list)
     date_str = timezone.now().strftime("%d-%m-%Y")

--- a/gsl_notification/forms.py
+++ b/gsl_notification/forms.py
@@ -483,6 +483,16 @@ class GenerateDocumentsStep3Form(BaseGenerateDocumentsForm):
         },
     )
 
+    with_qr_code = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Inclure le QR code de suivi sur chaque page",
+        help_text=(
+            "Le QR code permet de rattacher automatiquement un document "
+            "signé scanné au bon projet. Il est retiré lors de l'import."
+        ),
+    )
+
     def __init__(self, *args, document_type, **kwargs):
         super().__init__(*args, **kwargs)
         self.document_type = document_type

--- a/gsl_notification/static/js/qrCodeToggle.js
+++ b/gsl_notification/static/js/qrCodeToggle.js
@@ -1,0 +1,26 @@
+import { Controller } from 'stimulus'
+
+export class QrCodeToggle extends Controller {
+  static targets = ['checkbox', 'link']
+
+  connect () {
+    this._sync()
+  }
+
+  toggle () {
+    this._sync()
+  }
+
+  _sync () {
+    const withQr = this.checkboxTarget.checked
+    this.linkTargets.forEach(link => {
+      const url = new URL(link.href, window.location.origin)
+      if (withQr) {
+        url.searchParams.delete('with_qr_code')
+      } else {
+        url.searchParams.set('with_qr_code', '0')
+      }
+      link.setAttribute('href', url.pathname + url.search)
+    })
+  }
+}

--- a/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications.html
+++ b/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications.html
@@ -49,14 +49,31 @@
                 </button>
             </div>
             {% if projet.documents %}
-                <ul class="arrete-list"
-                    data-controller="delete-notification-document-modal"
-                    data-delete-notification-document-modal-modal-id-value="delete-document-confirmation-modal"
-                    data-delete-notification-document-modal-form-id-value="delete-document-form">
-                    {% for document in projet.documents %}
-                        {% include "includes/_document_card.html" %}
-                    {% endfor %}
-                </ul>
+                <div data-controller="qr-code-toggle">
+                    <ul class="arrete-list"
+                        data-controller="delete-notification-document-modal"
+                        data-delete-notification-document-modal-modal-id-value="delete-document-confirmation-modal"
+                        data-delete-notification-document-modal-form-id-value="delete-document-form">
+                        {% for document in projet.documents %}
+                            {% include "includes/_document_card.html" %}
+                        {% endfor %}
+                    </ul>
+                    <div class="fr-checkbox-group fr-mt-3w">
+                        <input type="checkbox"
+                               id="with-qr-code"
+                               checked
+                               data-qr-code-toggle-target="checkbox"
+                               data-action="change->qr-code-toggle#toggle"
+                               aria-describedby="with-qr-code-hint">
+                        <label class="fr-label" for="with-qr-code">
+                            Inclure le QR code de suivi sur les documents
+                            <span class="fr-hint-text" id="with-qr-code-hint">
+                                Le QR code permet de rattacher automatiquement un document
+                                signé scanné au bon projet. Il est retiré lors de l’import.
+                            </span>
+                        </label>
+                    </div>
+                </div>
             {% else %}
                 <div class="no-documents-info">
                     Il n’y a pas de document pour le moment.

--- a/gsl_notification/templates/includes/_document_card.html
+++ b/gsl_notification/templates/includes/_document_card.html
@@ -47,7 +47,8 @@
         {% if document.is_downloadable %}
             <div class="fr-enlarge-link">
                 <a href="{{ document.get_view_url }}"
-                   class="arrete-card__image-container">
+                   class="arrete-card__image-container"
+                   data-qr-code-toggle-target="link">
                     <img class="arrete-card__image"
                          src="{% static 'img/arrete_vignette.png' %}"
                          alt="Image d'un arrêté">
@@ -55,7 +56,8 @@
                 </a>
             </div>
             <a class="fr-link fr-link--download"
-               href="{{ document.get_download_url }}">
+               href="{{ document.get_download_url }}"
+               data-qr-code-toggle-target="link">
                 {{ document.name }} -
                 {{ document.file_type|upper }} -
                 {{ document.size|filesizeformat }}

--- a/gsl_notification/tests/test_forms.py
+++ b/gsl_notification/tests/test_forms.py
@@ -3,9 +3,11 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 
 from gsl_core.tests.factories import CollegueFactory
 from gsl_notification.forms import (
+    EXPORT_FORMAT_ONE_PDF_ALL,
     AnnexeForm,
     ArreteEtLettreSigneForm,
     ArreteForm,
+    GenerateDocumentsStep3Form,
     LettreNotificationForm,
     ModeleDocumentStepTwoForm,
 )
@@ -15,7 +17,7 @@ from gsl_notification.tests.factories import (
     ModeleLettreNotificationFactory,
 )
 from gsl_programmation.tests.factories import ProgrammationProjetFactory
-from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL
+from gsl_projet.constants import ARRETE, DOTATION_DETR, DOTATION_DSIL
 
 # GeneratedDocumentForm
 
@@ -225,3 +227,31 @@ def test_modele_arrete_step_2_rejects_too_large_files(file_size, is_valid):
         },
     )
     assert form.is_valid() == is_valid, form.errors
+
+
+@pytest.mark.django_db
+def test_generate_documents_step3_form_exposes_with_qr_code():
+    user = CollegueFactory()
+    field = GenerateDocumentsStep3Form(
+        user=user,
+        dotation=DOTATION_DETR,
+        request=None,
+        document_type=ARRETE,
+    ).fields["with_qr_code"]
+    assert field.required is False
+    assert field.initial is True
+
+
+@pytest.mark.django_db
+def test_generate_documents_step3_form_valid_without_qr_field_submitted():
+    """An unchecked checkbox sends nothing: the form stays valid (opt-out)."""
+    user = CollegueFactory()
+    form = GenerateDocumentsStep3Form(
+        data={"export_format": EXPORT_FORMAT_ONE_PDF_ALL},
+        user=user,
+        dotation=DOTATION_DETR,
+        request=None,
+        document_type=ARRETE,
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["with_qr_code"] is False

--- a/gsl_notification/tests/test_qr.py
+++ b/gsl_notification/tests/test_qr.py
@@ -188,3 +188,42 @@ def test_decode_per_page_returns_bbox_in_bottom_left(tmp_path):
         assert (w * h) < 0.1 * image_area, (
             f"bbox too large: area={w * h} vs image_area={image_area}"
         )
+
+
+@pytest.mark.django_db
+def test_no_qr_when_with_qr_code_is_false(tmp_path):
+    """with_qr_code=False produces a PDF without any decodable GSL QR."""
+    pytest.importorskip("pypdfium2")
+    pytest.importorskip("zxingcpp")
+
+    from gsl_notification.tests.factories import (
+        LettreNotificationFactory,
+        ModeleLettreNotificationFactory,
+    )
+    from gsl_notification.utils import generate_pdf_for_generated_document
+    from gsl_programmation.tests.factories import ProgrammationProjetFactory
+
+    pp = ProgrammationProjetFactory(
+        dotation_projet__projet__dossier_ds__ds_number=2222222,
+    )
+    modele = ModeleLettreNotificationFactory(
+        dotation=pp.dotation,
+        perimetre=pp.dotation_projet.projet.dossier_ds.perimetre,
+    )
+    document = LettreNotificationFactory(
+        programmation_projet=pp,
+        modele=modele,
+        content="<p>" + ("Contenu de test. " * 200) + "</p>",
+    )
+
+    with patch("gsl_notification.utils.get_logo_base64", return_value="mocked_base64"):
+        pdf_bytes = generate_pdf_for_generated_document(document, with_qr_code=False)
+
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_bytes(pdf_bytes)
+
+    hits = decode_per_page(pdf_path)
+    assert hits, "no pages decoded"
+    assert all(hit is None for hit in hits), (
+        "no GSL QR should be present when with_qr_code=False"
+    )

--- a/gsl_notification/tests/views/test_views.py
+++ b/gsl_notification/tests/views/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.contrib.messages import get_messages
 from django.urls import reverse
@@ -720,10 +722,58 @@ def test_document_download_url_with_correct_perimetre(
         kwargs={"document_type": document_type, "document_id": doc.id},
     )
     assert url == f"/notification/document/{document_type}/{doc.id}/download/"
-    response = correct_perimetre_client_with_user_logged.get(url)
+    with patch("gsl_notification.utils.get_logo_base64", return_value="mocked_base64"):
+        response = correct_perimetre_client_with_user_logged.get(url)
     assert response.status_code == 200
     assert response["Content-Type"] == "application/pdf"
-    assert "attachment;filename=" in response["Content-Disposition"]
+    assert 'attachment; filename="' in response["Content-Disposition"]
+
+
+@pytest.mark.parametrize(
+    "document_type, factory",
+    (
+        (ARRETE, ArreteFactory),
+        (LETTRE, LettreNotificationFactory),
+    ),
+)
+def test_document_download_includes_qr_by_default_and_opts_out(
+    programmation_projet,
+    correct_perimetre_client_with_user_logged,
+    document_type,
+    factory,
+    tmp_path,
+):
+    pytest.importorskip("pypdfium2")
+    pytest.importorskip("zxingcpp")
+    from gsl_notification.qr import decode_per_page
+
+    doc = factory(
+        programmation_projet=programmation_projet,
+        content="<p>" + ("Contenu de test. " * 200) + "</p>",
+    )
+    url = reverse(
+        "notification:document-download",
+        kwargs={"document_type": document_type, "document_id": doc.id},
+    )
+
+    with patch("gsl_notification.utils.get_logo_base64", return_value="mocked_base64"):
+        # No param at all: QR included by default (opt-out).
+        default = correct_perimetre_client_with_user_logged.get(url)
+        # Explicit opt-out via query string: no QR.
+        opted_out = correct_perimetre_client_with_user_logged.get(
+            url, {"with_qr_code": "0"}
+        )
+
+    assert default.status_code == 200
+    assert opted_out.status_code == 200
+
+    default_path = tmp_path / "default.pdf"
+    default_path.write_bytes(default.content)
+    assert any(hit is not None for hit in decode_per_page(default_path))
+
+    opted_out_path = tmp_path / "opted_out.pdf"
+    opted_out_path.write_bytes(opted_out.content)
+    assert all(hit is None for hit in decode_per_page(opted_out_path))
 
 
 @pytest.mark.parametrize("document_type", (ARRETE, LETTRE))
@@ -783,9 +833,11 @@ def test_document_view_url_with_correct_perimetre(
         kwargs={"document_type": document_type, "document_id": document.id},
     )
     assert url == f"/notification/document/{document_type}/{document.id}/view/"
-    response = correct_perimetre_client_with_user_logged.get(url)
+    with patch("gsl_notification.utils.get_logo_base64", return_value="mocked_base64"):
+        response = correct_perimetre_client_with_user_logged.get(url)
     assert response.status_code == 200
     assert response["Content-Type"] == "application/pdf"
+    assert "inline; filename=" in response["Content-Disposition"]
 
 
 @pytest.mark.parametrize("document_type", (ARRETE, LETTRE))

--- a/gsl_notification/utils.py
+++ b/gsl_notification/utils.py
@@ -446,15 +446,21 @@ def fix_empty_paragraphs_for_weasyprint(html: str) -> str:
     return str(soup)
 
 
-def generate_pdf_for_generated_document(document: Arrete | LettreNotification) -> bytes:
+def generate_pdf_for_generated_document(
+    document: Arrete | LettreNotification, *, with_qr_code: bool = True
+) -> bytes:
     """
     Generate PDF bytes for a GeneratedDocument (Arrete or LettreNotification).
 
-    A per-page QR code is rendered at the bottom-left of every page so a
-    scanned, signed copy can be reattached to the right ProgrammationProjet.
-    Because each page needs a *different* QR (the payload includes the page
-    number), this is a two-pass render: first pass counts pages, second pass
-    emits one ``@page :nth(K)`` rule per page with the matching QR image.
+    When ``with_qr_code`` is True (default), a per-page QR code is rendered at
+    the bottom-left of every page so a scanned, signed copy can be reattached
+    to the right ProgrammationProjet. Because each page needs a *different* QR
+    (the payload includes the page number), this is a two-pass render: first
+    pass counts pages, second pass emits one ``@page :nth(K)`` rule per page
+    with the matching QR image.
+
+    When ``with_qr_code`` is False, a single, faster pass is rendered without
+    any QR code.
     """
     content = fix_empty_paragraphs_for_weasyprint(document.content)
     base_context = {
@@ -464,6 +470,17 @@ def generate_pdf_for_generated_document(document: Arrete | LettreNotification) -
         "top_right_text": document.modele.top_right_text.strip(),
         "content": mark_safe(content),
     }
+
+    if not with_qr_code:
+        html = render_to_string(
+            "gsl_notification/pdf/document.html",
+            {**base_context, "qr_css_rules": ""},
+        )
+        return HTML(
+            string=html,
+            url_fetcher=django_url_fetcher,
+            base_url=settings.STATIC_ROOT,
+        ).write_pdf()
 
     # Pass 1: render without QR to learn how many pages the document has.
     first_pass_html = render_to_string(

--- a/gsl_notification/views/generate_document_for_multiple_projets_views.py
+++ b/gsl_notification/views/generate_document_for_multiple_projets_views.py
@@ -177,6 +177,7 @@ class GenerateDocumentsWizard(SessionWizardView):
         step2_data = form_dict[self.STEP2].cleaned_data
         step3_data = form_dict[self.STEP3].cleaned_data
         export_format = step3_data.get("export_format")
+        with_qr_code = step3_data.get("with_qr_code")
 
         refreshed = form.save(
             modele_arrete=step2_data.get("modele_arrete_id"),
@@ -186,7 +187,11 @@ class GenerateDocumentsWizard(SessionWizardView):
 
         attrs = [get_programmation_projet_attribute(t) for t in form.selected_types]
         filename, content_type, body = build_export(
-            refreshed, attrs, export_format, form.document_type
+            refreshed,
+            attrs,
+            export_format,
+            form.document_type,
+            with_qr_code=with_qr_code,
         )
         download_url = upload_export_and_get_url(filename, content_type, body)
 

--- a/gsl_notification/views/views.py
+++ b/gsl_notification/views/views.py
@@ -1,4 +1,5 @@
 from django.contrib import messages
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
@@ -8,7 +9,6 @@ from django.utils.safestring import mark_safe
 from django.views.decorators.http import require_http_methods, require_POST
 from django.views.generic import DeleteView, DetailView, UpdateView
 from django_htmx.http import HttpResponseClientRedirect
-from django_weasyprint import WeasyTemplateResponseMixin
 
 from gsl.utils.csp import csp_update
 from gsl_core.decorators import htmx_only
@@ -32,8 +32,7 @@ from gsl_notification.models import (
     GeneratedDocument,
 )
 from gsl_notification.utils import (
-    fix_empty_paragraphs_for_weasyprint,
-    get_doc_title,
+    generate_pdf_for_generated_document,
     get_form_class,
     get_generated_document_class,
     get_modele_class,
@@ -453,12 +452,11 @@ class DeleteDocumentView(DeleteView):
 # View and Download views -----------------------------------------------------------------------
 
 
-class PrintDocumentView(WeasyTemplateResponseMixin, DetailView):
+class PrintDocumentView(DetailView):
     model = GeneratedDocument
-    template_name = "gsl_notification/pdf/document.html"
     pk_url_kwarg = "document_id"
 
-    # show pdf in-line (default: True, show download dialog)
+    # show pdf in-line (False) or as a download dialog (True)
     pdf_attachment = False
 
     def get_queryset(self):
@@ -474,23 +472,14 @@ class PrintDocumentView(WeasyTemplateResponseMixin, DetailView):
             )
         )
 
-    def get_pdf_filename(self):
-        return self.get_object().name
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
+    def get(self, request, *args, **kwargs):
         document = self.get_object()
-        content = fix_empty_paragraphs_for_weasyprint(document.content)
-        context.update(
-            {
-                "doc_title": get_doc_title(self.document_type),
-                "logo": document.modele.logo.url,
-                "alt_logo": document.modele.logo_alt_text,
-                "top_right_text": document.modele.top_right_text.strip(),
-                "content": mark_safe(content),
-            }
-        )
-        return context
+        with_qr_code = request.GET.get("with_qr_code") != "0"
+        pdf = generate_pdf_for_generated_document(document, with_qr_code=with_qr_code)
+        disposition = "attachment" if self.pdf_attachment else "inline"
+        response = HttpResponse(pdf, content_type="application/pdf")
+        response["Content-Disposition"] = f'{disposition}; filename="{document.name}"'
+        return response
 
 
 class DownloadDocumentView(PrintDocumentView):


### PR DESCRIPTION
## 🌮 Objectif

Permettre de ne pas inclure le QR code de suivi sur les documents générés (arrêtés / lettres).

## 🔍 Liste des modifications

- Ajout d'un paramètre `with_qr_code` (activé par défaut) à `generate_pdf_for_generated_document` : quand il est désactivé, une passe unique plus rapide génère le PDF sans QR code
- Propagation du flag dans `build_export` et les helpers `_build_*` (export en masse)
- Génération en masse : case à cocher « Inclure le QR code de suivi sur chaque page » à l'étape « Format d'export » (cochée par défaut, opt-out), avec texte d'aide
- Téléchargement / visualisation d'un document seul : bascule vers la génération QR-capable, alignée sur l'export en masse (logo en base64, etc.)
- Nouveau contrôleur Stimulus `qr-code-toggle` : réécrit le `href` des liens (`?with_qr_code=0`) selon l'état de la case, sans soumission de formulaire
- Onglet notification d'un projet : case à cocher (cochée par défaut) sous la carte « Documents de notification », avec texte d'aide
- Tests : QR absent quand désactivé, opt-out via query string, filtrage périmètre conservé, champ de formulaire exposé

## ⚠️ Informations supplémentaires

Aucune persistance : le choix n'est jamais enregistré en base, il n'influe que sur le PDF produit au moment du téléchargement / de l'export. Pas de champ modèle, pas de migration. Sans JS (cas dégradé), les liens produisent le PDF avec QR (comportement par défaut, opt-out).