### PR TITLE
Filtrage des dossiers du proxy DS par groupe instructeur

### DIFF
--- a/gsl_ds_proxy/admin.py
+++ b/gsl_ds_proxy/admin.py
@@ -1,19 +1,81 @@
+from django import forms
 from django.contrib import admin, messages
 
 from gsl_ds_proxy.models import ProxyToken
 
+_MAX_EMAILS_IN_LABEL = 5
+
+
+def _format_groupe_choice(groupe):
+    instructeurs = groupe.get("instructeurs") or []
+    emails = [i.get("email") for i in instructeurs if i.get("email")]
+    if len(emails) > _MAX_EMAILS_IN_LABEL:
+        shown = ", ".join(emails[:_MAX_EMAILS_IN_LABEL])
+        emails_part = f"{shown}… (+{len(emails) - _MAX_EMAILS_IN_LABEL})"
+    else:
+        emails_part = ", ".join(emails)
+    label = groupe.get("label") or ""
+    number = groupe.get("number")
+    base = f"{label} (#{number})" if number is not None else label
+    return f"{base} — {emails_part}" if emails_part else base
+
+
+class ProxyTokenAdminForm(forms.ModelForm):
+    class Meta:
+        model = ProxyToken
+        fields = ("label", "demarche", "groupe_instructeur_ds_id", "is_active")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        demarche = (
+            getattr(self.instance, "demarche", None) if self.instance.pk else None
+        )
+        groupes = (
+            (demarche.raw_ds_data or {}).get("groupeInstructeurs") if demarche else None
+        )
+
+        if groupes:
+            choices = [("", "---------")] + [
+                (g["id"], _format_groupe_choice(g)) for g in groupes if g.get("id")
+            ]
+            self.fields["groupe_instructeur_ds_id"] = forms.ChoiceField(
+                label="Groupe instructeur",
+                choices=choices,
+                required=False,
+            )
+        else:
+            self.fields["groupe_instructeur_ds_id"].disabled = True
+            self.fields["groupe_instructeur_ds_id"].help_text = (
+                "Sauvegardez le token après avoir choisi une démarche pour "
+                "pouvoir sélectionner un groupe instructeur."
+            )
+
 
 @admin.register(ProxyToken)
 class ProxyTokenAdmin(admin.ModelAdmin):
-    list_display = ("label", "demarche", "is_active", "created_at", "instructeur_count")
+    form = ProxyTokenAdminForm
+    list_display = (
+        "label",
+        "demarche",
+        "is_active",
+        "created_at",
+        "groupe_instructeur_label",
+    )
     list_filter = ("is_active", "demarche")
     readonly_fields = ("key_hash", "created_at", "updated_at")
-    filter_horizontal = ("instructeurs",)
 
-    def instructeur_count(self, obj):
-        return obj.instructeurs.count()
+    def groupe_instructeur_label(self, obj):
+        if not obj.groupe_instructeur_ds_id or not obj.demarche_id:
+            return ""
+        groupes = (obj.demarche.raw_ds_data or {}).get("groupeInstructeurs") or []
+        for g in groupes:
+            if g.get("id") == obj.groupe_instructeur_ds_id:
+                label = g.get("label") or ""
+                number = g.get("number")
+                return f"{label} (#{number})" if number is not None else label
+        return obj.groupe_instructeur_ds_id
 
-    instructeur_count.short_description = "Nb instructeurs"
+    groupe_instructeur_label.short_description = "Groupe instructeur"
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)

--- a/gsl_ds_proxy/filters.py
+++ b/gsl_ds_proxy/filters.py
@@ -1,31 +1,25 @@
 import copy
 
 
-def _dossier_is_visible(dossier, allowed_ids):
-    """Check if a dossier has at least one instructeur in allowed_ids."""
+def _dossier_is_visible(dossier, allowed_groupe_ds_id):
+    """Check if a dossier belongs to the allowed groupe instructeur."""
     if not dossier:
         return False
     groupe = dossier.get("groupeInstructeur") or {}
-    instructeurs = groupe.get("instructeurs") or []
-    instructeurs += dossier.get("instructeurs") or []
-
-    if not instructeurs:
-        return False
-
-    return any(inst.get("id") in allowed_ids for inst in instructeurs)
+    return groupe.get("id") == allowed_groupe_ds_id
 
 
-def _filter_dossier_nodes(dossiers_container, allowed_ids):
+def _filter_dossier_nodes(dossiers_container, allowed_groupe_ds_id):
     """Filter nodes[] inside a dossiers connection object in-place."""
     nodes = dossiers_container.get("nodes")
     if nodes is None:
         return
     dossiers_container["nodes"] = [
-        node for node in nodes if _dossier_is_visible(node, allowed_ids)
+        node for node in nodes if _dossier_is_visible(node, allowed_groupe_ds_id)
     ]
 
 
-def filter_response(response_data, allowed_instructeur_ids):
+def filter_response(response_data, allowed_groupe_ds_id):
     """Filter a DS GraphQL response to only include authorized dossiers.
 
     Returns a new dict (deep copy), leaving the original unchanged.
@@ -40,17 +34,17 @@ def filter_response(response_data, allowed_instructeur_ids):
     if demarche and isinstance(demarche, dict):
         dossiers = demarche.get("dossiers")
         if dossiers and isinstance(dossiers, dict):
-            _filter_dossier_nodes(dossiers, allowed_instructeur_ids)
+            _filter_dossier_nodes(dossiers, allowed_groupe_ds_id)
 
         for connection_field in ("pendingDeletedDossiers", "deletedDossiers"):
             connection = demarche.get(connection_field)
             if connection and isinstance(connection, dict):
-                _filter_dossier_nodes(connection, allowed_instructeur_ids)
+                _filter_dossier_nodes(connection, allowed_groupe_ds_id)
 
     # getDossier → data.dossier (single dossier)
     dossier = data.get("dossier")
     if dossier and isinstance(dossier, dict) and "number" in dossier:
-        if not _dossier_is_visible(dossier, allowed_instructeur_ids):
+        if not _dossier_is_visible(dossier, allowed_groupe_ds_id):
             data["dossier"] = None
             result.setdefault("errors", []).append(
                 {"message": "Dossier non autorisé pour ce token."}

--- a/gsl_ds_proxy/migrations/0002_groupe_instructeur.py
+++ b/gsl_ds_proxy/migrations/0002_groupe_instructeur.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("gsl_ds_proxy", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="proxytoken",
+            name="instructeurs",
+        ),
+        migrations.AddField(
+            model_name="proxytoken",
+            name="groupe_instructeur_ds_id",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                max_length=255,
+                verbose_name="ID du groupe instructeur DS",
+            ),
+        ),
+    ]

--- a/gsl_ds_proxy/models.py
+++ b/gsl_ds_proxy/models.py
@@ -1,6 +1,7 @@
 import hashlib
 import secrets
 
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from gsl_core.models import BaseModel
@@ -21,10 +22,11 @@ class ProxyToken(BaseModel):
         on_delete=models.PROTECT,
         related_name="proxy_tokens",
     )
-    instructeurs = models.ManyToManyField(
-        "gsl_demarches_simplifiees.Profile",
-        verbose_name="Instructeurs autorisés",
+    groupe_instructeur_ds_id = models.CharField(
+        "ID du groupe instructeur DS",
+        max_length=255,
         blank=True,
+        db_index=True,
     )
     is_active = models.BooleanField("Actif", default=True)
 
@@ -38,6 +40,32 @@ class ProxyToken(BaseModel):
     @staticmethod
     def hash_key(plaintext: str) -> str:
         return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
+
+    def clean(self):
+        super().clean()
+        if not self.is_active:
+            return
+        if not self.groupe_instructeur_ds_id:
+            raise ValidationError(
+                {
+                    "groupe_instructeur_ds_id": (
+                        "Un groupe instructeur doit être sélectionné "
+                        "pour activer le token."
+                    )
+                }
+            )
+        raw = (self.demarche.raw_ds_data or {}) if self.demarche_id else {}
+        groupes = raw.get("groupeInstructeurs") or []
+        known_ids = {g.get("id") for g in groupes}
+        if self.groupe_instructeur_ds_id not in known_ids:
+            raise ValidationError(
+                {
+                    "groupe_instructeur_ds_id": (
+                        "Le groupe instructeur sélectionné n'appartient pas "
+                        "à la démarche."
+                    )
+                }
+            )
 
     def save(self, *args, **kwargs):
         if not self.key_hash:

--- a/gsl_ds_proxy/tests/factories.py
+++ b/gsl_ds_proxy/tests/factories.py
@@ -12,6 +12,7 @@ class ProxyTokenFactory(factory.django.DjangoModelFactory):
 
     label = factory.Sequence(lambda n: f"Token {n}")
     demarche = factory.SubFactory(DemarcheFactory)
+    groupe_instructeur_ds_id = factory.Sequence(lambda n: f"GROUPE-{n}")
     is_active = True
 
     @classmethod

--- a/gsl_ds_proxy/tests/test_admin.py
+++ b/gsl_ds_proxy/tests/test_admin.py
@@ -1,0 +1,132 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from gsl_demarches_simplifiees.tests.factories import DemarcheFactory
+from gsl_ds_proxy.admin import ProxyTokenAdminForm
+from gsl_ds_proxy.tests.factories import ProxyTokenFactory
+
+
+def _raw_ds_data(groupes):
+    return {"groupeInstructeurs": groupes}
+
+
+class ProxyTokenAdminFormTest(TestCase):
+    def test_groupe_field_disabled_without_raw_ds_data(self):
+        demarche = DemarcheFactory(raw_ds_data=None)
+        token = ProxyTokenFactory(
+            demarche=demarche,
+            is_active=False,
+            groupe_instructeur_ds_id="",
+        )
+        form = ProxyTokenAdminForm(instance=token)
+        self.assertTrue(form.fields["groupe_instructeur_ds_id"].disabled)
+        self.assertIn(
+            "Sauvegardez le token",
+            form.fields["groupe_instructeur_ds_id"].help_text,
+        )
+
+    def test_groupes_are_offered_with_emails_in_label(self):
+        demarche = DemarcheFactory(
+            raw_ds_data=_raw_ds_data(
+                [
+                    {
+                        "id": "GROUPE-1",
+                        "number": 1,
+                        "label": "Centre",
+                        "instructeurs": [
+                            {"id": "i1", "email": "a@t.fr"},
+                            {"id": "i2", "email": "b@t.fr"},
+                        ],
+                    },
+                    {
+                        "id": "GROUPE-2",
+                        "number": 2,
+                        "label": "Nord",
+                        "instructeurs": [{"id": "i3", "email": "c@t.fr"}],
+                    },
+                ]
+            )
+        )
+        token = ProxyTokenFactory(
+            demarche=demarche,
+            is_active=False,
+            groupe_instructeur_ds_id="",
+        )
+        form = ProxyTokenAdminForm(instance=token)
+        choices = dict(form.fields["groupe_instructeur_ds_id"].choices)
+        self.assertIn("GROUPE-1", choices)
+        self.assertIn("GROUPE-2", choices)
+        self.assertIn("Centre (#1)", choices["GROUPE-1"])
+        self.assertIn("a@t.fr", choices["GROUPE-1"])
+        self.assertIn("b@t.fr", choices["GROUPE-1"])
+
+    def test_label_truncates_emails_above_threshold(self):
+        emails = [{"id": f"i{i}", "email": f"u{i}@t.fr"} for i in range(8)]
+        demarche = DemarcheFactory(
+            raw_ds_data=_raw_ds_data(
+                [
+                    {
+                        "id": "GROUPE-1",
+                        "number": 1,
+                        "label": "Big",
+                        "instructeurs": emails,
+                    }
+                ]
+            )
+        )
+        token = ProxyTokenFactory(
+            demarche=demarche,
+            is_active=False,
+            groupe_instructeur_ds_id="",
+        )
+        form = ProxyTokenAdminForm(instance=token)
+        label = dict(form.fields["groupe_instructeur_ds_id"].choices)["GROUPE-1"]
+        self.assertIn("(+3)", label)
+
+
+class ProxyTokenCleanTest(TestCase):
+    def test_active_token_requires_groupe(self):
+        demarche = DemarcheFactory(
+            raw_ds_data=_raw_ds_data([{"id": "GROUPE-1", "number": 1, "label": "X"}])
+        )
+        token = ProxyTokenFactory.build(
+            demarche=demarche,
+            is_active=True,
+            groupe_instructeur_ds_id="",
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            token.clean()
+        self.assertIn("groupe_instructeur_ds_id", ctx.exception.message_dict)
+
+    def test_active_token_rejects_unknown_groupe(self):
+        demarche = DemarcheFactory(
+            raw_ds_data=_raw_ds_data([{"id": "GROUPE-1", "number": 1, "label": "X"}])
+        )
+        token = ProxyTokenFactory.build(
+            demarche=demarche,
+            is_active=True,
+            groupe_instructeur_ds_id="UNKNOWN",
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            token.clean()
+        self.assertIn("groupe_instructeur_ds_id", ctx.exception.message_dict)
+
+    def test_active_token_accepts_known_groupe(self):
+        demarche = DemarcheFactory(
+            raw_ds_data=_raw_ds_data([{"id": "GROUPE-1", "number": 1, "label": "X"}])
+        )
+        token = ProxyTokenFactory.build(
+            demarche=demarche,
+            is_active=True,
+            groupe_instructeur_ds_id="GROUPE-1",
+        )
+        token.clean()
+
+    def test_inactive_token_does_not_require_groupe(self):
+        demarche = DemarcheFactory(raw_ds_data=None)
+        token = ProxyTokenFactory.build(
+            demarche=demarche,
+            is_active=False,
+            groupe_instructeur_ds_id="",
+        )
+        token.clean()

--- a/gsl_ds_proxy/tests/test_filters.py
+++ b/gsl_ds_proxy/tests/test_filters.py
@@ -3,18 +3,14 @@ from django.test import TestCase
 from gsl_ds_proxy.filters import filter_response
 
 
-class FilterResponseDemarcheTest(TestCase):
-    def _make_dossier(self, number, instructeur_ids):
-        return {
-            "number": number,
-            "groupeInstructeur": {
-                "instructeurs": [
-                    {"id": iid, "email": f"{iid}@test.fr"} for iid in instructeur_ids
-                ]
-            },
-            "instructeurs": [],
-        }
+def _make_dossier(number, groupe_id):
+    return {
+        "number": number,
+        "groupeInstructeur": {"id": groupe_id} if groupe_id is not None else None,
+    }
 
+
+class FilterResponseDemarcheTest(TestCase):
     def _make_demarche_response(self, dossiers):
         return {
             "data": {
@@ -33,85 +29,87 @@ class FilterResponseDemarcheTest(TestCase):
     def test_filters_unauthorized_dossiers(self):
         response = self._make_demarche_response(
             [
-                self._make_dossier(1, ["inst-a", "inst-b"]),
-                self._make_dossier(2, ["inst-c"]),
-                self._make_dossier(3, ["inst-a"]),
+                _make_dossier(1, "GROUPE-A"),
+                _make_dossier(2, "GROUPE-B"),
+                _make_dossier(3, "GROUPE-A"),
             ]
         )
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
         nodes = result["data"]["demarche"]["dossiers"]["nodes"]
         self.assertEqual([d["number"] for d in nodes], [1, 3])
 
     def test_preserves_page_info(self):
         response = self._make_demarche_response(
             [
-                self._make_dossier(1, ["inst-c"]),
+                _make_dossier(1, "GROUPE-B"),
             ]
         )
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
         page_info = result["data"]["demarche"]["dossiers"]["pageInfo"]
         self.assertEqual(page_info["endCursor"], "abc")
 
     def test_empty_nodes(self):
         response = self._make_demarche_response([])
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
         self.assertEqual(result["data"]["demarche"]["dossiers"]["nodes"], [])
 
     def test_does_not_mutate_original(self):
         response = self._make_demarche_response(
             [
-                self._make_dossier(1, ["inst-a"]),
-                self._make_dossier(2, ["inst-b"]),
+                _make_dossier(1, "GROUPE-A"),
+                _make_dossier(2, "GROUPE-B"),
             ]
         )
-        filter_response(response, {"inst-a"})
+        filter_response(response, "GROUPE-A")
         self.assertEqual(len(response["data"]["demarche"]["dossiers"]["nodes"]), 2)
 
-    def test_dossier_without_instructeur_data_is_filtered_out(self):
+    def test_dossier_without_groupe_instructeur_is_filtered_out(self):
         response = self._make_demarche_response(
             [
                 {"number": 1, "groupeInstructeur": {}},
                 {"number": 2},
             ]
         )
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
+        self.assertEqual(result["data"]["demarche"]["dossiers"]["nodes"], [])
+
+    def test_dossier_with_only_instructeurs_field_is_filtered_out(self):
+        """Selection is strictly by groupe; legacy `instructeurs` field is ignored."""
+        response = self._make_demarche_response(
+            [
+                {
+                    "number": 1,
+                    "instructeurs": [{"id": "inst-a", "email": "a@t.fr"}],
+                },
+            ]
+        )
+        result = filter_response(response, "GROUPE-A")
         self.assertEqual(result["data"]["demarche"]["dossiers"]["nodes"], [])
 
     def test_null_node_is_filtered_out(self):
         response = self._make_demarche_response(
             [
-                self._make_dossier(1, ["inst-a"]),
+                _make_dossier(1, "GROUPE-A"),
                 None,
-                self._make_dossier(2, ["inst-a"]),
+                _make_dossier(2, "GROUPE-A"),
             ]
         )
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
         nodes = result["data"]["demarche"]["dossiers"]["nodes"]
         self.assertEqual([d["number"] for d in nodes], [1, 2])
 
     def test_top_level_errors_kept_when_filtered_list_is_empty(self):
         response = self._make_demarche_response(
             [
-                self._make_dossier(1, ["inst-c"]),
+                _make_dossier(1, "GROUPE-B"),
             ]
         )
         response["errors"] = [{"message": "Could not fetch dossier 42"}]
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
         self.assertEqual(result["errors"], [{"message": "Could not fetch dossier 42"}])
 
 
 class FilterResponseDeletedDossiersTest(TestCase):
-    def _make_dossier(self, number, instructeur_ids):
-        return {
-            "number": number,
-            "groupeInstructeur": {
-                "instructeurs": [
-                    {"id": iid, "email": f"{iid}@test.fr"} for iid in instructeur_ids
-                ]
-            },
-            "instructeurs": [],
-        }
-
     def _wrap(self, connection_field, dossiers):
         return {
             "data": {
@@ -133,12 +131,12 @@ class FilterResponseDeletedDossiersTest(TestCase):
                 response = self._wrap(
                     connection_field,
                     [
-                        self._make_dossier(1, ["inst-a", "inst-b"]),
-                        self._make_dossier(2, ["inst-c"]),
-                        self._make_dossier(3, ["inst-a"]),
+                        _make_dossier(1, "GROUPE-A"),
+                        _make_dossier(2, "GROUPE-B"),
+                        _make_dossier(3, "GROUPE-A"),
                     ],
                 )
-                result = filter_response(response, {"inst-a"})
+                result = filter_response(response, "GROUPE-A")
                 nodes = result["data"]["demarche"][connection_field]["nodes"]
                 self.assertEqual([d["number"] for d in nodes], [1, 3])
 
@@ -147,9 +145,9 @@ class FilterResponseDeletedDossiersTest(TestCase):
             with self.subTest(connection_field=connection_field):
                 response = self._wrap(
                     connection_field,
-                    [self._make_dossier(1, ["inst-c"])],
+                    [_make_dossier(1, "GROUPE-B")],
                 )
-                result = filter_response(response, {"inst-a"})
+                result = filter_response(response, "GROUPE-A")
                 page_info = result["data"]["demarche"][connection_field]["pageInfo"]
                 self.assertEqual(page_info["endCursor"], "abc")
 
@@ -157,7 +155,7 @@ class FilterResponseDeletedDossiersTest(TestCase):
         for connection_field in ("pendingDeletedDossiers", "deletedDossiers"):
             with self.subTest(connection_field=connection_field):
                 response = self._wrap(connection_field, [])
-                result = filter_response(response, {"inst-a"})
+                result = filter_response(response, "GROUPE-A")
                 self.assertEqual(
                     result["data"]["demarche"][connection_field]["nodes"], []
                 )
@@ -169,7 +167,7 @@ class FilterResponseDeletedDossiersTest(TestCase):
                     connection_field,
                     [{"number": 1}, {"number": 2, "groupeInstructeur": {}}],
                 )
-                result = filter_response(response, {"inst-a"})
+                result = filter_response(response, "GROUPE-A")
                 self.assertEqual(
                     result["data"]["demarche"][connection_field]["nodes"], []
                 )
@@ -181,28 +179,28 @@ class FilterResponseDeletedDossiersTest(TestCase):
                     "dossiers": {
                         "pageInfo": {"hasNextPage": False, "endCursor": "a"},
                         "nodes": [
-                            self._make_dossier(1, ["inst-a"]),
-                            self._make_dossier(2, ["inst-c"]),
+                            _make_dossier(1, "GROUPE-A"),
+                            _make_dossier(2, "GROUPE-B"),
                         ],
                     },
                     "pendingDeletedDossiers": {
                         "pageInfo": {"hasNextPage": False, "endCursor": "b"},
                         "nodes": [
-                            self._make_dossier(10, ["inst-c"]),
-                            self._make_dossier(11, ["inst-a"]),
+                            _make_dossier(10, "GROUPE-B"),
+                            _make_dossier(11, "GROUPE-A"),
                         ],
                     },
                     "deletedDossiers": {
                         "pageInfo": {"hasNextPage": False, "endCursor": "c"},
                         "nodes": [
-                            self._make_dossier(20, ["inst-a"]),
-                            self._make_dossier(21, ["inst-b"]),
+                            _make_dossier(20, "GROUPE-A"),
+                            _make_dossier(21, "GROUPE-C"),
                         ],
                     },
                 }
             }
         }
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
         demarche = result["data"]["demarche"]
         self.assertEqual([d["number"] for d in demarche["dossiers"]["nodes"]], [1])
         self.assertEqual(
@@ -219,14 +217,11 @@ class FilterResponseSingleDossierTest(TestCase):
             "data": {
                 "dossier": {
                     "number": 1,
-                    "groupeInstructeur": {
-                        "instructeurs": [{"id": "inst-a", "email": "a@t.fr"}]
-                    },
-                    "instructeurs": [],
+                    "groupeInstructeur": {"id": "GROUPE-A"},
                 }
             }
         }
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
         self.assertIsNotNone(result["data"]["dossier"])
 
     def test_unauthorized_dossier_returns_null_with_error(self):
@@ -234,25 +229,34 @@ class FilterResponseSingleDossierTest(TestCase):
             "data": {
                 "dossier": {
                     "number": 1,
-                    "groupeInstructeur": {
-                        "instructeurs": [{"id": "inst-b", "email": "b@t.fr"}]
-                    },
-                    "instructeurs": [],
+                    "groupeInstructeur": {"id": "GROUPE-B"},
                 }
             }
         }
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
         self.assertIsNone(result["data"]["dossier"])
         self.assertEqual(len(result["errors"]), 1)
+
+    def test_dossier_without_groupe_instructeur_is_filtered_out(self):
+        response = {
+            "data": {
+                "dossier": {
+                    "number": 1,
+                    "instructeurs": [{"id": "inst-a", "email": "a@t.fr"}],
+                }
+            }
+        }
+        result = filter_response(response, "GROUPE-A")
+        self.assertIsNone(result["data"]["dossier"])
 
 
 class FilterResponsePassthroughTest(TestCase):
     def test_no_data_passes_through(self):
         response = {"errors": [{"message": "some error"}]}
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
         self.assertEqual(result, response)
 
     def test_demarche_without_dossiers_passes_through(self):
         response = {"data": {"demarche": {"title": "Test"}}}
-        result = filter_response(response, {"inst-a"})
+        result = filter_response(response, "GROUPE-A")
         self.assertEqual(result["data"]["demarche"]["title"], "Test")

--- a/gsl_ds_proxy/tests/test_views.py
+++ b/gsl_ds_proxy/tests/test_views.py
@@ -5,7 +5,6 @@ from django.test import TestCase, override_settings
 
 from gsl_demarches_simplifiees.tests.factories import (
     DemarcheFactory,
-    ProfileFactory,
 )
 from gsl_ds_proxy.tests.factories import ProxyTokenFactory
 
@@ -21,10 +20,11 @@ def _parse_stream(response):
 @override_settings(DS_API_TOKEN="test-ds-token", DS_API_URL="https://ds.test/graphql")
 class GraphqlProxyViewTest(TestCase):
     def setUp(self):
-        self.profile = ProfileFactory(ds_id="inst-a")
         self.demarche = DemarcheFactory(ds_number=123)
-        self.token = ProxyTokenFactory(demarche=self.demarche)
-        self.token.instructeurs.add(self.profile)
+        self.token = ProxyTokenFactory(
+            demarche=self.demarche,
+            groupe_instructeur_ds_id="GROUPE-1",
+        )
         self.url = "/ds-proxy/graphql/"
         self.headers = {"HTTP_AUTHORIZATION": f"Bearer {self.token.plaintext_key}"}
 
@@ -67,6 +67,14 @@ class GraphqlProxyViewTest(TestCase):
         response = self._post(self._get_demarche_payload())
         self.assertEqual(response.status_code, 401)
 
+    def test_unconfigured_token_returns_403(self):
+        self.token.groupe_instructeur_ds_id = ""
+        self.token.save()
+        response = self._post(self._get_demarche_payload())
+        self.assertEqual(response.status_code, 403)
+        body = json.loads(response.content)
+        self.assertEqual(body["errors"][0]["message"], "Token non configuré.")
+
     def test_invalid_json(self):
         response = self.client.post(
             self.url,
@@ -95,21 +103,11 @@ class GraphqlProxyViewTest(TestCase):
                         "nodes": [
                             {
                                 "number": 1,
-                                "groupeInstructeur": {
-                                    "instructeurs": [
-                                        {"id": "inst-a", "email": "a@t.fr"}
-                                    ]
-                                },
-                                "instructeurs": [],
+                                "groupeInstructeur": {"id": "GROUPE-1"},
                             },
                             {
                                 "number": 2,
-                                "groupeInstructeur": {
-                                    "instructeurs": [
-                                        {"id": "inst-b", "email": "b@t.fr"}
-                                    ]
-                                },
-                                "instructeurs": [],
+                                "groupeInstructeur": {"id": "GROUPE-2"},
                             },
                         ],
                     },

--- a/gsl_ds_proxy/views.py
+++ b/gsl_ds_proxy/views.py
@@ -209,21 +209,32 @@ def _forward_to_ds(query, variables, operation_name):
     return ds_response.json(), None
 
 
-@csrf_exempt
-@require_POST
-def graphql_proxy(request):
-    # Auth
+def _resolve_token(request):
+    """Return (proxy_token, None) or (None, error_response)."""
     auth_header = request.META.get("HTTP_AUTHORIZATION", "")
     if not auth_header.startswith("Bearer "):
-        return _error_response("Authorization header manquant ou invalide.", 401)
+        return None, _error_response("Authorization header manquant ou invalide.", 401)
 
     token_key = auth_header[7:]
     try:
-        proxy_token = ProxyToken.objects.prefetch_related("instructeurs").get(
+        proxy_token = ProxyToken.objects.get(
             key_hash=ProxyToken.hash_key(token_key), is_active=True
         )
     except ProxyToken.DoesNotExist:
-        return _error_response("Token invalide ou désactivé.", 401)
+        return None, _error_response("Token invalide ou désactivé.", 401)
+
+    if not proxy_token.groupe_instructeur_ds_id:
+        return None, _error_response("Token non configuré.", 403)
+
+    return proxy_token, None
+
+
+@csrf_exempt
+@require_POST
+def graphql_proxy(request):
+    proxy_token, error = _resolve_token(request)
+    if error is not None:
+        return error
 
     # Parse body
     try:
@@ -263,15 +274,20 @@ def graphql_proxy(request):
             f"Champ démarche non autorisé : `{forbidden_field}`.", 403
         )
 
-    allowed_ids = set(proxy_token.instructeurs.values_list("ds_id", flat=True))
+    allowed_groupe_ds_id = proxy_token.groupe_instructeur_ds_id
     stream = _stream_ds_response(
-        proxy_token, root_field, operation_name, query, variables, allowed_ids
+        proxy_token,
+        root_field,
+        operation_name,
+        query,
+        variables,
+        allowed_groupe_ds_id,
     )
     return StreamingHttpResponse(stream, content_type="application/json", status=200)
 
 
 def _stream_ds_response(
-    proxy_token, root_field, operation_name, query, variables, allowed_ids
+    proxy_token, root_field, operation_name, query, variables, allowed_groupe_ds_id
 ):
     # Send a single whitespace byte immediately to close Scalingo's
     # 30s-to-first-byte window. Leading whitespace is valid JSON.
@@ -297,7 +313,7 @@ def _stream_ds_response(
         yield _graphql_error_bytes(scope_error)
         return
 
-    filtered = filter_response(response_data, allowed_ids)
+    filtered = filter_response(response_data, allowed_groupe_ds_id)
     yield json.dumps(filtered).encode()
 
 


### PR DESCRIPTION
## 🌮 Objectif

Filtrer les dossiers exposés par le proxy DS sur un groupe instructeur unique plutôt que sur une liste d'instructeurs autorisés.

## 🔍 Liste des modifications

- `ProxyToken` : remplacement du champ `instructeurs` (M2M vers `Profile`) par un `groupe_instructeur_ds_id` (CharField indexé), + migration `0002_groupe_instructeur`.
- `ProxyToken.clean()` : un token actif doit référencer un groupe connu de la démarche (lu depuis `demarche.raw_ds_data["groupeInstructeurs"]`).
- Admin : nouveau `ProxyTokenAdminForm` qui propose un menu déroulant des groupes instructeurs de la démarche, étiquetés avec leur numéro et les emails des instructeurs (tronqués au-delà de 5). Le champ est désactivé tant que la démarche n'a pas encore de `raw_ds_data`.
- `filters.py` : `_dossier_is_visible` compare désormais `dossier.groupeInstructeur.id` à l'ID de groupe autorisé, au lieu d'inspecter la liste des instructeurs.
- `views.py` : extraction de la résolution du token dans `_resolve_token`, refus (`403`) si le token n'a pas de groupe configuré, suppression du `prefetch_related("instructeurs")`.
- Tests : ajout de `test_admin.py` (form admin + `clean()`), mise à jour de `test_filters.py`, `test_views.py` et de la factory pour le nouveau champ.

## ⚠️ Informations supplémentaires

Migration destructive : la table de liaison `ProxyToken.instructeurs` est supprimée. Les tokens existants devront être reconfigurés avec un `groupe_instructeur_ds_id` avant d'être réactivés (la validation l'impose).