### PR TITLE
Prise en compte des erreurs renvoyées par DN dans la sauvegarde des curseurs

### DIFF
--- a/gsl_demarches_simplifiees/ds_client.py
+++ b/gsl_demarches_simplifiees/ds_client.py
@@ -28,7 +28,7 @@ class DsClientBase:
         ) as query_file:
             self.query = query_file.read()
 
-    def launch_graphql_query(self, operation_name, variables=None) -> dict:
+    def launch_graphql_query(self, operation_name, variables=None) -> (dict, bool):
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
@@ -46,7 +46,10 @@ class DsClientBase:
 
         if response.status_code == 200:
             results = response.json()
+            has_errors = False
+
             if "errors" in results.keys():
+                has_errors = len(results["errors"]) > 0
                 for error in results["errors"]:
                     logger.warning(
                         "DN request error",
@@ -60,7 +63,7 @@ class DsClientBase:
                     raise DsServiceException(
                         level=logging.ERROR, log_message="DN request returned errors"
                     )
-            return results
+            return results, has_errors
 
         if response.status_code == 403:
             raise DsConnectionError(
@@ -92,7 +95,7 @@ class DsClient(DsClientBase):
             "includeGroupeInstructeurs": True,
             "includeRevision": True,  # to list custom fields with their ids
         }
-        return self.launch_graphql_query("getDemarche", variables=variables)
+        return self.launch_graphql_query("getDemarche", variables=variables)[0]
 
     def fetch_demarche_page(
         self,
@@ -105,7 +108,7 @@ class DsClient(DsClientBase):
         include_pending_deleted: bool = True,
         include_deleted: bool = True,
         page_size: int = 50,
-    ) -> dict:
+    ) -> (dict, bool):
         """
         Fetch one page of dossiers, pendingDeletedDossiers, and/or deletedDossiers.
         Only the sets for which the corresponding include_* flag is True are fetched.
@@ -128,14 +131,16 @@ class DsClient(DsClientBase):
             "deletedFirst": page_size,
             "deletedSince": updated_since_iso,
         }
-        result = self.launch_graphql_query("getDemarche", variables=variables)
-        return result["data"]["demarche"]
+        result, has_error = self.launch_graphql_query(
+            "getDemarche", variables=variables
+        )
+        return (result["data"]["demarche"], has_error)
 
     def get_one_dossier(self, dossier_number) -> dict:
         variables = {
             "dossierNumber": dossier_number,
         }
-        result = self.launch_graphql_query("getDossier", variables)
+        result, _ = self.launch_graphql_query("getDossier", variables)
         return result["data"]["dossier"]
 
 
@@ -158,7 +163,7 @@ class DsMutator(DsClientBase):
         }
         return self.launch_graphql_query(
             "dossierModifierAnnotations", variables=variables
-        )
+        )[0]
 
     def dossier_repasser_en_instruction(
         self, dossier_id, instructeur_id, disable_notification=False
@@ -175,7 +180,7 @@ class DsMutator(DsClientBase):
         # for the moment, if the dossier is in construction, it silently fails without any error
         return self.launch_graphql_query(
             "dossierRepasserEnInstruction", variables=variables
-        )
+        )[0]
 
     def dossier_passer_en_instruction(
         self, dossier_id, instructeur_id, disable_notification=False
@@ -190,7 +195,7 @@ class DsMutator(DsClientBase):
         }
         return self.launch_graphql_query(
             "dossierPasserEnInstruction", variables=variables
-        )
+        )[0]
 
     def _mutate_with_justificatif_and_motivation(
         self,
@@ -214,7 +219,7 @@ class DsMutator(DsClientBase):
 
         if justificatif_id:
             variables["input"]["justificatif"] = justificatif_id
-        return self.launch_graphql_query(action, variables=variables)
+        return self.launch_graphql_query(action, variables=variables)[0]
 
     def _upload_attachment(self, dossier_ds_id: str, file: UploadedFile) -> str:
         """
@@ -237,7 +242,7 @@ class DsMutator(DsClientBase):
                     "contentType": "application/pdf",
                 }
             },
-        )
+        )[0]
         upload_url = res["data"]["createDirectUpload"]["directUpload"]["url"]
         credential_headers = json.loads(
             res["data"]["createDirectUpload"]["directUpload"]["headers"]

--- a/gsl_demarches_simplifiees/ds_client.py
+++ b/gsl_demarches_simplifiees/ds_client.py
@@ -108,7 +108,7 @@ class DsClient(DsClientBase):
         include_pending_deleted: bool = True,
         include_deleted: bool = True,
         page_size: int = 50,
-    ) -> (dict, bool):
+    ) -> tuple[dict, bool]:
         """
         Fetch one page of dossiers, pendingDeletedDossiers, and/or deletedDossiers.
         Only the sets for which the corresponding include_* flag is True are fetched.
@@ -131,10 +131,10 @@ class DsClient(DsClientBase):
             "deletedFirst": page_size,
             "deletedSince": updated_since_iso,
         }
-        result, has_error = self.launch_graphql_query(
+        result, has_errors = self.launch_graphql_query(
             "getDemarche", variables=variables
         )
-        return (result["data"]["demarche"], has_error)
+        return (result["data"]["demarche"], has_errors)
 
     def get_one_dossier(self, dossier_number) -> dict:
         variables = {

--- a/gsl_demarches_simplifiees/importer/dossier.py
+++ b/gsl_demarches_simplifiees/importer/dossier.py
@@ -36,25 +36,23 @@ def save_demarche_dossiers_from_ds(demarche_number):
     client = DsClient()
 
     if demarche.updated_since is None:
-        api_updated_since = demarche.created_at
-        dossiers_cursor = pending_deleted_cursor = deleted_cursor = None
-        has_date_changed = True
-    else:
-        dossiers_cursor = demarche.sync_cursor or None
-        pending_deleted_cursor = demarche.pending_deleted_cursor or None
-        deleted_cursor = demarche.deleted_cursor or None
-        api_updated_since = demarche.updated_since
-        has_date_changed = False
+        _reinit_demarche_sync_state(demarche)
+
+    api_updated_since = demarche.updated_since
+    dossiers_cursor = demarche.sync_cursor or None
+    pending_deleted_cursor = demarche.pending_deleted_cursor or None
+    deleted_cursor = demarche.deleted_cursor or None
 
     active_departement_insee_codes = _get_active_departement_insee_codes()
     groupe_index = _get_or_refresh_groupe_index(demarche, demarche_number)
 
     dossiers_count = 0
     has_more_dossiers = has_more_pending = has_more_deleted = True
+    any_request_error = False
     dossiers_any_error = pending_any_error = deleted_any_error = False
 
     while has_more_dossiers or has_more_pending or has_more_deleted:
-        demarche_data, has_error_in_request = client.fetch_demarche_page(
+        demarche_data, has_errors = client.fetch_demarche_page(
             demarche_number,
             updated_since=api_updated_since,
             dossiers_after=dossiers_cursor,
@@ -64,6 +62,9 @@ def save_demarche_dossiers_from_ds(demarche_number):
             include_pending_deleted=has_more_pending,
             include_deleted=has_more_deleted,
         )
+
+        if has_errors:
+            any_request_error = True
 
         dossiers_result = pending_result = deleted_result = None
 
@@ -108,18 +109,16 @@ def save_demarche_dossiers_from_ds(demarche_number):
             deleted_result, deleted_cursor
         )
 
-    _commit_sync_cursors(
-        demarche,
-        has_date_changed,
-        has_error_in_request,
-        dossiers_cursor=dossiers_cursor,
-        dossiers_any_error=dossiers_any_error,
-        pending_deleted_cursor=pending_deleted_cursor,
-        pending_any_error=pending_any_error,
-        deleted_cursor=deleted_cursor,
-        deleted_any_error=deleted_any_error,
-        api_updated_since=api_updated_since,
-    )
+        _save_cursors_after_page(
+            demarche,
+            any_request_error=any_request_error,
+            dossiers_cursor=dossiers_cursor,
+            dossiers_any_error=dossiers_any_error,
+            pending_deleted_cursor=pending_deleted_cursor,
+            pending_any_error=pending_any_error,
+            deleted_cursor=deleted_cursor,
+            deleted_any_error=deleted_any_error,
+        )
 
     logger.info(
         "Demarche dossiers has been updated from DN",
@@ -217,42 +216,33 @@ def _advance_stream(
     return result.has_more, result.cursor
 
 
-def _commit_sync_cursors(
+def _save_cursors_after_page(
     demarche: "Demarche",
-    has_date_changed: bool,
-    has_error_in_request: bool,
     *,
+    any_request_error: bool,
     dossiers_cursor: str | None,
     dossiers_any_error: bool,
     pending_deleted_cursor: str | None,
     pending_any_error: bool,
     deleted_cursor: str | None,
     deleted_any_error: bool,
-    api_updated_since,
 ):
-    demarche.updated_since = api_updated_since
+    if any_request_error:
+        return
 
-    if has_date_changed:
-        demarche.sync_cursor = ""
-        demarche.pending_deleted_cursor = ""
-        demarche.deleted_cursor = ""
+    update_fields = []
+    if not dossiers_any_error:
+        demarche.sync_cursor = dossiers_cursor or ""
+        update_fields.append("sync_cursor")
+    if not pending_any_error:
+        demarche.pending_deleted_cursor = pending_deleted_cursor or ""
+        update_fields.append("pending_deleted_cursor")
+    if not deleted_any_error:
+        demarche.deleted_cursor = deleted_cursor or ""
+        update_fields.append("deleted_cursor")
 
-    if not has_error_in_request:
-        if not dossiers_any_error:
-            demarche.sync_cursor = dossiers_cursor or ""
-        if not pending_any_error:
-            demarche.pending_deleted_cursor = pending_deleted_cursor or ""
-        if not deleted_any_error:
-            demarche.deleted_cursor = deleted_cursor or ""
-
-    demarche.save(
-        update_fields=[
-            "sync_cursor",
-            "updated_since",
-            "pending_deleted_cursor",
-            "deleted_cursor",
-        ]
-    )
+    if update_fields:
+        demarche.save(update_fields=update_fields)
 
 
 def save_one_dossier_from_ds(
@@ -597,3 +587,19 @@ def _is_dossier_in_active_departement(
 
     # Champ non trouvé
     return False, "inconnu"
+
+
+def _reinit_demarche_sync_state(demarche: Demarche):
+    new_updated_since = demarche.created_at
+    demarche.updated_since = new_updated_since
+    demarche.sync_cursor = ""
+    demarche.pending_deleted_cursor = ""
+    demarche.deleted_cursor = ""
+    demarche.save(
+        update_fields=[
+            "updated_since",
+            "sync_cursor",
+            "pending_deleted_cursor",
+            "deleted_cursor",
+        ]
+    )

--- a/gsl_demarches_simplifiees/importer/dossier.py
+++ b/gsl_demarches_simplifiees/importer/dossier.py
@@ -54,7 +54,7 @@ def save_demarche_dossiers_from_ds(demarche_number):
     dossiers_any_error = pending_any_error = deleted_any_error = False
 
     while has_more_dossiers or has_more_pending or has_more_deleted:
-        demarche_data = client.fetch_demarche_page(
+        demarche_data, has_error_in_request = client.fetch_demarche_page(
             demarche_number,
             updated_since=api_updated_since,
             dossiers_after=dossiers_cursor,
@@ -111,6 +111,7 @@ def save_demarche_dossiers_from_ds(demarche_number):
     _commit_sync_cursors(
         demarche,
         has_date_changed,
+        has_error_in_request,
         dossiers_cursor=dossiers_cursor,
         dossiers_any_error=dossiers_any_error,
         pending_deleted_cursor=pending_deleted_cursor,
@@ -219,6 +220,7 @@ def _advance_stream(
 def _commit_sync_cursors(
     demarche: "Demarche",
     has_date_changed: bool,
+    has_error_in_request: bool,
     *,
     dossiers_cursor: str | None,
     dossiers_any_error: bool,
@@ -230,23 +232,18 @@ def _commit_sync_cursors(
 ):
     demarche.updated_since = api_updated_since
 
-    if dossiers_any_error:
-        if has_date_changed:
-            demarche.sync_cursor = ""
-    else:
-        demarche.sync_cursor = dossiers_cursor or ""
+    if has_date_changed:
+        demarche.sync_cursor = ""
+        demarche.pending_deleted_cursor = ""
+        demarche.deleted_cursor = ""
 
-    if pending_any_error:
-        if has_date_changed:
-            demarche.pending_deleted_cursor = ""
-    else:
-        demarche.pending_deleted_cursor = pending_deleted_cursor or ""
-
-    if deleted_any_error:
-        if has_date_changed:
-            demarche.deleted_cursor = ""
-    else:
-        demarche.deleted_cursor = deleted_cursor or ""
+    if not has_error_in_request:
+        if not dossiers_any_error:
+            demarche.sync_cursor = dossiers_cursor or ""
+        if not pending_any_error:
+            demarche.pending_deleted_cursor = pending_deleted_cursor or ""
+        if not deleted_any_error:
+            demarche.deleted_cursor = deleted_cursor or ""
 
     demarche.save(
         update_fields=[

--- a/gsl_demarches_simplifiees/tests/ds_client/test_ds_client.py
+++ b/gsl_demarches_simplifiees/tests/ds_client/test_ds_client.py
@@ -137,14 +137,14 @@ def test_fetch_demarche_page_returns_demarche_data():
         "launch_graphql_query",
         return_value=(_make_fetch_page_response(dossiers=nodes), False),
     ):
-        result, has_error = client.fetch_demarche_page(123)
+        result, has_errors = client.fetch_demarche_page(123)
 
         assert result["dossiers"]["nodes"] == nodes
         assert result["dossiers"]["pageInfo"]["hasNextPage"] is False
-        assert has_error is False
+        assert has_errors is False
 
 
-def test_fetch_demarche_page_propagates_has_error_true():
+def test_fetch_demarche_page_propagates_has_errors_true():
     client = DsClient()
 
     with patch.object(
@@ -152,9 +152,9 @@ def test_fetch_demarche_page_propagates_has_error_true():
         "launch_graphql_query",
         return_value=(_make_fetch_page_response(), True),
     ):
-        _, has_error = client.fetch_demarche_page(123)
+        _, has_errors = client.fetch_demarche_page(123)
 
-        assert has_error is True
+        assert has_errors is True
 
 
 @responses.activate

--- a/gsl_demarches_simplifiees/tests/ds_client/test_ds_client.py
+++ b/gsl_demarches_simplifiees/tests/ds_client/test_ds_client.py
@@ -59,7 +59,9 @@ def test_fetch_demarche_page_converts_datetime_to_iso_format():
     updated_since = timezone.datetime(2024, 1, 15)
 
     with patch.object(
-        client, "launch_graphql_query", return_value=_make_fetch_page_response()
+        client,
+        "launch_graphql_query",
+        return_value=(_make_fetch_page_response(), False),
     ) as mock_query:
         client.fetch_demarche_page(123, updated_since=updated_since)
 
@@ -72,7 +74,9 @@ def test_fetch_demarche_page_passes_none_when_no_updated_since():
     client = DsClient()
 
     with patch.object(
-        client, "launch_graphql_query", return_value=_make_fetch_page_response()
+        client,
+        "launch_graphql_query",
+        return_value=(_make_fetch_page_response(), False),
     ) as mock_query:
         client.fetch_demarche_page(123)
 
@@ -84,7 +88,9 @@ def test_fetch_demarche_page_passes_cursors_and_include_flags():
     client = DsClient()
 
     with patch.object(
-        client, "launch_graphql_query", return_value=_make_fetch_page_response()
+        client,
+        "launch_graphql_query",
+        return_value=(_make_fetch_page_response(), False),
     ) as mock_query:
         client.fetch_demarche_page(
             123,
@@ -110,7 +116,9 @@ def test_fetch_demarche_page_respects_page_size():
     client = DsClient()
 
     with patch.object(
-        client, "launch_graphql_query", return_value=_make_fetch_page_response()
+        client,
+        "launch_graphql_query",
+        return_value=(_make_fetch_page_response(), False),
     ) as mock_query:
         client.fetch_demarche_page(123, page_size=20)
 
@@ -127,9 +135,62 @@ def test_fetch_demarche_page_returns_demarche_data():
     with patch.object(
         client,
         "launch_graphql_query",
-        return_value=_make_fetch_page_response(dossiers=nodes),
+        return_value=(_make_fetch_page_response(dossiers=nodes), False),
     ):
-        result = client.fetch_demarche_page(123)
+        result, has_error = client.fetch_demarche_page(123)
 
         assert result["dossiers"]["nodes"] == nodes
         assert result["dossiers"]["pageInfo"]["hasNextPage"] is False
+        assert has_error is False
+
+
+def test_fetch_demarche_page_propagates_has_error_true():
+    client = DsClient()
+
+    with patch.object(
+        client,
+        "launch_graphql_query",
+        return_value=(_make_fetch_page_response(), True),
+    ):
+        _, has_error = client.fetch_demarche_page(123)
+
+        assert has_error is True
+
+
+@responses.activate
+def test_launch_graphql_query_returns_has_errors_false_when_no_errors():
+    responses.add(
+        responses.POST,
+        settings.DS_API_URL,
+        json={"data": {"demarche": {}}},
+        status=200,
+    )
+
+    client = DsClient()
+    results, has_errors = client.launch_graphql_query("someOperation")
+
+    assert has_errors is False
+    assert results == {"data": {"demarche": {}}}
+
+
+@responses.activate
+def test_launch_graphql_query_returns_has_errors_true_for_non_fatal_errors(caplog):
+    responses.add(
+        responses.POST,
+        settings.DS_API_URL,
+        json={
+            "data": {"demarche": {}},
+            "errors": [
+                {"message": "some partial error", "extensions": {"code": "partial"}}
+            ],
+        },
+        status=200,
+    )
+
+    client = DsClient()
+    with caplog.at_level(logging.WARNING):
+        results, has_errors = client.launch_graphql_query("someOperation")
+
+    assert has_errors is True
+    assert results["data"] == {"demarche": {}}
+    assert "DN request error" in caplog.text

--- a/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
+++ b/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
@@ -84,7 +84,7 @@ def test_save_demarche_dossiers_from_ds_calls_save_dossier_data_and_refresh_doss
 
     with patch(
         "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
-        return_value=_make_demarche_page(dossiers=ds_dossiers),
+        return_value=(_make_demarche_page(dossiers=ds_dossiers), False),
     ):
         with patch(
             "gsl_demarches_simplifiees.importer.dossier._get_active_departement_insee_codes",
@@ -136,7 +136,7 @@ def test_save_demarche_dossiers_from_ds_update_raw_ds_data_dossiers():
 
     with patch(
         "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
-        return_value=_make_demarche_page(dossiers=ds_dossiers),
+        return_value=(_make_demarche_page(dossiers=ds_dossiers), False),
     ):
         with patch(
             "gsl_demarches_simplifiees.importer.dossier._get_active_departement_insee_codes",
@@ -188,7 +188,7 @@ def test_save_demarche_dossiers_from_ds_with_one_empty_data(caplog):
 
     with patch(
         "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
-        return_value=_make_demarche_page(dossiers=ds_dossiers),
+        return_value=(_make_demarche_page(dossiers=ds_dossiers), False),
     ):
         with patch(
             "gsl_demarches_simplifiees.importer.dossier._get_active_departement_insee_codes",
@@ -212,7 +212,7 @@ def test_save_demarche_dossiers_from_ds_update_sync_cursor():
 
     with patch(
         "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
-        return_value=_make_demarche_page(end_cursor=expected_cursor),
+        return_value=(_make_demarche_page(end_cursor=expected_cursor), False),
     ):
         save_demarche_dossiers_from_ds(demarche_number)
 
@@ -264,7 +264,7 @@ def test_save_demarche_dossiers_from_ds_multipage_different_stream_lengths():
 
     with patch(
         "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
-        side_effect=[page1, page2],
+        side_effect=[(page1, False), (page2, False)],
     ) as mock_fetch:
         with patch(
             "gsl_demarches_simplifiees.importer.dossier._get_active_departement_insee_codes",
@@ -319,7 +319,7 @@ def test_save_demarche_dossiers_from_ds_error_on_page_continues_but_skips_cursor
 
     with patch(
         "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
-        side_effect=[page1, page2],
+        side_effect=[(page1, False), (page2, False)],
     ) as mock_fetch:
         with patch(
             "gsl_demarches_simplifiees.importer.dossier._create_or_update_dossier_from_ds_data",
@@ -742,7 +742,7 @@ def test_archived_dossier_in_ds_stream_deactivates_existing_dossier():
 
     with patch(
         "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
-        return_value=_make_demarche_page(dossiers=ds_dossiers),
+        return_value=(_make_demarche_page(dossiers=ds_dossiers), False),
     ):
         with patch(
             "gsl_demarches_simplifiees.importer.dossier._get_active_departement_insee_codes",
@@ -893,6 +893,7 @@ def test_commit_sync_cursors_no_errors_updates_all_cursors():
     _commit_sync_cursors(
         demarche,
         False,
+        False,
         dossiers_cursor="new-d",
         dossiers_any_error=False,
         pending_deleted_cursor="new-p",
@@ -916,6 +917,7 @@ def test_commit_sync_cursors_updated_since_always_saved():
     _commit_sync_cursors(
         demarche,
         True,
+        False,
         dossiers_cursor=None,
         dossiers_any_error=True,
         pending_deleted_cursor=None,
@@ -939,6 +941,7 @@ def test_commit_sync_cursors_dossiers_error_keeps_sync_cursor():
     _commit_sync_cursors(
         demarche,
         False,
+        False,
         dossiers_cursor="new-d",
         dossiers_any_error=True,
         pending_deleted_cursor="new-p",
@@ -961,6 +964,7 @@ def test_commit_sync_cursors_pending_error_keeps_pending_cursor():
     _commit_sync_cursors(
         demarche,
         False,
+        False,
         dossiers_cursor="new-d",
         dossiers_any_error=False,
         pending_deleted_cursor="new-p",
@@ -982,6 +986,7 @@ def test_commit_sync_cursors_deleted_error_keeps_deleted_cursor():
 
     _commit_sync_cursors(
         demarche,
+        False,
         False,
         dossiers_cursor="new-d",
         dossiers_any_error=False,
@@ -1008,6 +1013,7 @@ def test_commit_sync_cursors_dossiers_error_with_date_changed_resets_cursor():
     _commit_sync_cursors(
         demarche,
         True,
+        False,
         dossiers_cursor="new-d",
         dossiers_any_error=True,
         pending_deleted_cursor="new-p",
@@ -1030,6 +1036,7 @@ def test_commit_sync_cursors_pending_error_with_date_changed_resets_cursor():
     _commit_sync_cursors(
         demarche,
         True,
+        False,
         dossiers_cursor="new-d",
         dossiers_any_error=False,
         pending_deleted_cursor="new-p",
@@ -1052,6 +1059,7 @@ def test_commit_sync_cursors_deleted_error_with_date_changed_resets_cursor():
     _commit_sync_cursors(
         demarche,
         True,
+        False,
         dossiers_cursor="new-d",
         dossiers_any_error=False,
         pending_deleted_cursor="new-p",
@@ -1065,3 +1073,87 @@ def test_commit_sync_cursors_deleted_error_with_date_changed_resets_cursor():
     assert demarche.sync_cursor == "new-d"
     assert demarche.pending_deleted_cursor == "new-p"
     assert demarche.deleted_cursor == ""  # remis à zéro
+
+
+# has_error_in_request=True : erreur HTTP-level dans la requête DS
+
+
+@pytest.mark.django_db
+def test_commit_sync_cursors_request_error_keeps_all_cursors():
+    """Quand la requête DS renvoie une erreur, aucun curseur n'est avancé."""
+    demarche = DemarcheFactory(
+        sync_cursor="old-d",
+        pending_deleted_cursor="old-p",
+        deleted_cursor="old-del",
+    )
+
+    _commit_sync_cursors(
+        demarche,
+        False,
+        True,  # has_error_in_request
+        dossiers_cursor="new-d",
+        dossiers_any_error=False,
+        pending_deleted_cursor="new-p",
+        pending_any_error=False,
+        deleted_cursor="new-del",
+        deleted_any_error=False,
+        api_updated_since=_API_UPDATED_SINCE,
+    )
+
+    demarche.refresh_from_db()
+    assert demarche.sync_cursor == "old-d"
+    assert demarche.pending_deleted_cursor == "old-p"
+    assert demarche.deleted_cursor == "old-del"
+    assert demarche.updated_since == _API_UPDATED_SINCE
+
+
+@pytest.mark.django_db
+def test_commit_sync_cursors_request_error_with_date_changed_resets_all_cursors():
+    """Quand la requête DS renvoie une erreur lors d'une première sync, tous les curseurs sont remis à zéro."""
+    demarche = DemarcheFactory(
+        sync_cursor="old-d",
+        pending_deleted_cursor="old-p",
+        deleted_cursor="old-del",
+    )
+
+    _commit_sync_cursors(
+        demarche,
+        True,  # has_date_changed
+        True,  # has_error_in_request
+        dossiers_cursor="new-d",
+        dossiers_any_error=False,
+        pending_deleted_cursor="new-p",
+        pending_any_error=False,
+        deleted_cursor="new-del",
+        deleted_any_error=False,
+        api_updated_since=_API_UPDATED_SINCE,
+    )
+
+    demarche.refresh_from_db()
+    assert demarche.sync_cursor == ""
+    assert demarche.pending_deleted_cursor == ""
+    assert demarche.deleted_cursor == ""
+
+
+@pytest.mark.django_db
+def test_save_demarche_dossiers_from_ds_request_error_keeps_cursors():
+    """Quand fetch_demarche_page signale une erreur DS, les curseurs ne sont pas avancés."""
+    demarche_number = 123
+    initial_cursor = "old-cursor"
+    demarche = DemarcheFactory(
+        ds_number=demarche_number,
+        sync_cursor=initial_cursor,
+        updated_since="2025-01-01T00:00:00+00:00",
+        raw_ds_data={"groupeInstructeurs": [{"id": "GROUPE-1", "instructeurs": []}]},
+    )
+
+    page = _make_demarche_page(end_cursor="new-cursor")
+
+    with patch(
+        "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
+        return_value=(page, True),  # has_error_in_request=True
+    ):
+        save_demarche_dossiers_from_ds(demarche_number)
+
+    demarche.refresh_from_db()
+    assert demarche.sync_cursor == initial_cursor

--- a/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
+++ b/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
@@ -8,8 +8,9 @@ from django.utils.timezone import datetime
 from gsl_demarches_simplifiees.ds_client import DsClient
 from gsl_demarches_simplifiees.exceptions import DsConnectionError, DsServiceException
 from gsl_demarches_simplifiees.importer.dossier import (
-    _commit_sync_cursors,
     _is_dossier_in_active_departement,
+    _reinit_demarche_sync_state,
+    _save_cursors_after_page,
     _save_dossier_data_and_refresh_dossier_and_projet_and_co,
     import_one_dossier_from_ds,
     refresh_dossier_instructeurs,
@@ -877,78 +878,49 @@ def test_import_one_dossier_from_ds_cree_le_dossier():
     mock_refresh.assert_called_once()
 
 
-# tests _commit_sync_cursors
+# tests _save_cursors_after_page
 
 _API_UPDATED_SINCE = datetime.fromisoformat("2025-06-01T00:00:00+00:00")
 
 
 @pytest.mark.django_db
-def test_commit_sync_cursors_no_errors_updates_all_cursors():
+def test_save_cursors_after_page_no_errors_updates_all_cursors():
     demarche = DemarcheFactory(
         sync_cursor="old-d",
         pending_deleted_cursor="old-p",
         deleted_cursor="old-del",
     )
 
-    _commit_sync_cursors(
+    _save_cursors_after_page(
         demarche,
-        False,
-        False,
+        any_request_error=False,
         dossiers_cursor="new-d",
         dossiers_any_error=False,
         pending_deleted_cursor="new-p",
         pending_any_error=False,
         deleted_cursor="new-del",
         deleted_any_error=False,
-        api_updated_since=_API_UPDATED_SINCE,
     )
 
     demarche.refresh_from_db()
     assert demarche.sync_cursor == "new-d"
     assert demarche.pending_deleted_cursor == "new-p"
     assert demarche.deleted_cursor == "new-del"
-    assert demarche.updated_since == _API_UPDATED_SINCE
 
 
 @pytest.mark.django_db
-def test_commit_sync_cursors_updated_since_always_saved():
-    demarche = DemarcheFactory(updated_since=None)
-
-    _commit_sync_cursors(
-        demarche,
-        True,
-        False,
-        dossiers_cursor=None,
-        dossiers_any_error=True,
-        pending_deleted_cursor=None,
-        pending_any_error=True,
-        deleted_cursor=None,
-        deleted_any_error=True,
-        api_updated_since=_API_UPDATED_SINCE,
-    )
-
-    demarche.refresh_from_db()
-    assert demarche.updated_since == _API_UPDATED_SINCE
-
-
-# has_date_changed=False (sync suivante) : erreur → on garde l'ancien curseur
-
-
-@pytest.mark.django_db
-def test_commit_sync_cursors_dossiers_error_keeps_sync_cursor():
+def test_save_cursors_after_page_dossiers_error_keeps_sync_cursor():
     demarche = DemarcheFactory(sync_cursor="old-d")
 
-    _commit_sync_cursors(
+    _save_cursors_after_page(
         demarche,
-        False,
-        False,
+        any_request_error=False,
         dossiers_cursor="new-d",
         dossiers_any_error=True,
         pending_deleted_cursor="new-p",
         pending_any_error=False,
         deleted_cursor="new-del",
         deleted_any_error=False,
-        api_updated_since=_API_UPDATED_SINCE,
     )
 
     demarche.refresh_from_db()
@@ -958,20 +930,18 @@ def test_commit_sync_cursors_dossiers_error_keeps_sync_cursor():
 
 
 @pytest.mark.django_db
-def test_commit_sync_cursors_pending_error_keeps_pending_cursor():
+def test_save_cursors_after_page_pending_error_keeps_pending_cursor():
     demarche = DemarcheFactory(pending_deleted_cursor="old-p")
 
-    _commit_sync_cursors(
+    _save_cursors_after_page(
         demarche,
-        False,
-        False,
+        any_request_error=False,
         dossiers_cursor="new-d",
         dossiers_any_error=False,
         pending_deleted_cursor="new-p",
         pending_any_error=True,
         deleted_cursor="new-del",
         deleted_any_error=False,
-        api_updated_since=_API_UPDATED_SINCE,
     )
 
     demarche.refresh_from_db()
@@ -981,20 +951,18 @@ def test_commit_sync_cursors_pending_error_keeps_pending_cursor():
 
 
 @pytest.mark.django_db
-def test_commit_sync_cursors_deleted_error_keeps_deleted_cursor():
+def test_save_cursors_after_page_deleted_error_keeps_deleted_cursor():
     demarche = DemarcheFactory(deleted_cursor="old-del")
 
-    _commit_sync_cursors(
+    _save_cursors_after_page(
         demarche,
-        False,
-        False,
+        any_request_error=False,
         dossiers_cursor="new-d",
         dossiers_any_error=False,
         pending_deleted_cursor="new-p",
         pending_any_error=False,
         deleted_cursor="new-del",
         deleted_any_error=True,
-        api_updated_since=_API_UPDATED_SINCE,
     )
 
     demarche.refresh_from_db()
@@ -1003,141 +971,63 @@ def test_commit_sync_cursors_deleted_error_keeps_deleted_cursor():
     assert demarche.deleted_cursor == "old-del"
 
 
-# has_date_changed=True (première sync) : erreur → on remet le curseur à None
-
-
 @pytest.mark.django_db
-def test_commit_sync_cursors_dossiers_error_with_date_changed_resets_cursor():
-    demarche = DemarcheFactory(sync_cursor="old-d")
-
-    _commit_sync_cursors(
-        demarche,
-        True,
-        False,
-        dossiers_cursor="new-d",
-        dossiers_any_error=True,
-        pending_deleted_cursor="new-p",
-        pending_any_error=False,
-        deleted_cursor="new-del",
-        deleted_any_error=False,
-        api_updated_since=_API_UPDATED_SINCE,
-    )
-
-    demarche.refresh_from_db()
-    assert demarche.sync_cursor == ""  # remis à zéro
-    assert demarche.pending_deleted_cursor == "new-p"
-    assert demarche.deleted_cursor == "new-del"
-
-
-@pytest.mark.django_db
-def test_commit_sync_cursors_pending_error_with_date_changed_resets_cursor():
-    demarche = DemarcheFactory(pending_deleted_cursor="old-p")
-
-    _commit_sync_cursors(
-        demarche,
-        True,
-        False,
-        dossiers_cursor="new-d",
-        dossiers_any_error=False,
-        pending_deleted_cursor="new-p",
-        pending_any_error=True,
-        deleted_cursor="new-del",
-        deleted_any_error=False,
-        api_updated_since=_API_UPDATED_SINCE,
-    )
-
-    demarche.refresh_from_db()
-    assert demarche.sync_cursor == "new-d"
-    assert demarche.pending_deleted_cursor == ""  # remis à zéro
-    assert demarche.deleted_cursor == "new-del"
-
-
-@pytest.mark.django_db
-def test_commit_sync_cursors_deleted_error_with_date_changed_resets_cursor():
-    demarche = DemarcheFactory(deleted_cursor="old-del")
-
-    _commit_sync_cursors(
-        demarche,
-        True,
-        False,
-        dossiers_cursor="new-d",
-        dossiers_any_error=False,
-        pending_deleted_cursor="new-p",
-        pending_any_error=False,
-        deleted_cursor="new-del",
-        deleted_any_error=True,
-        api_updated_since=_API_UPDATED_SINCE,
-    )
-
-    demarche.refresh_from_db()
-    assert demarche.sync_cursor == "new-d"
-    assert demarche.pending_deleted_cursor == "new-p"
-    assert demarche.deleted_cursor == ""  # remis à zéro
-
-
-# has_error_in_request=True : erreur HTTP-level dans la requête DS
-
-
-@pytest.mark.django_db
-def test_commit_sync_cursors_request_error_keeps_all_cursors():
-    """Quand la requête DS renvoie une erreur, aucun curseur n'est avancé."""
+def test_save_cursors_after_page_request_error_keeps_all_cursors():
+    """Une erreur globale bloque la sauvegarde de tous les curseurs."""
     demarche = DemarcheFactory(
         sync_cursor="old-d",
         pending_deleted_cursor="old-p",
         deleted_cursor="old-del",
     )
 
-    _commit_sync_cursors(
+    _save_cursors_after_page(
         demarche,
-        False,
-        True,  # has_error_in_request
+        any_request_error=True,
         dossiers_cursor="new-d",
         dossiers_any_error=False,
         pending_deleted_cursor="new-p",
         pending_any_error=False,
         deleted_cursor="new-del",
         deleted_any_error=False,
-        api_updated_since=_API_UPDATED_SINCE,
     )
 
     demarche.refresh_from_db()
     assert demarche.sync_cursor == "old-d"
     assert demarche.pending_deleted_cursor == "old-p"
     assert demarche.deleted_cursor == "old-del"
-    assert demarche.updated_since == _API_UPDATED_SINCE
+
+
+# tests d'intégration : sauvegarde des curseurs par page
 
 
 @pytest.mark.django_db
-def test_commit_sync_cursors_request_error_with_date_changed_resets_all_cursors():
-    """Quand la requête DS renvoie une erreur lors d'une première sync, tous les curseurs sont remis à zéro."""
+def test_save_demarche_dossiers_from_ds_saves_cursor_after_first_successful_page():
+    """Le curseur de la première page est sauvegardé même si la deuxième page échoue."""
+    demarche_number = 123
+    initial_cursor = "old-cursor"
     demarche = DemarcheFactory(
-        sync_cursor="old-d",
-        pending_deleted_cursor="old-p",
-        deleted_cursor="old-del",
+        ds_number=demarche_number,
+        sync_cursor=initial_cursor,
+        updated_since="2025-01-01T00:00:00+00:00",
+        raw_ds_data={"groupeInstructeurs": [{"id": "GROUPE-1", "instructeurs": []}]},
     )
 
-    _commit_sync_cursors(
-        demarche,
-        True,  # has_date_changed
-        True,  # has_error_in_request
-        dossiers_cursor="new-d",
-        dossiers_any_error=False,
-        pending_deleted_cursor="new-p",
-        pending_any_error=False,
-        deleted_cursor="new-del",
-        deleted_any_error=False,
-        api_updated_since=_API_UPDATED_SINCE,
-    )
+    page1 = _make_demarche_page(end_cursor="cursor-page-1", has_more_dossiers=True)
+    page2 = _make_demarche_page(end_cursor="cursor-page-2")
+
+    with patch(
+        "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
+        side_effect=[(page1, False), (page2, True)],  # page 2 : erreur globale
+    ):
+        save_demarche_dossiers_from_ds(demarche_number)
 
     demarche.refresh_from_db()
-    assert demarche.sync_cursor == ""
-    assert demarche.pending_deleted_cursor == ""
-    assert demarche.deleted_cursor == ""
+    assert demarche.sync_cursor == "cursor-page-1"
 
 
 @pytest.mark.django_db
 def test_save_demarche_dossiers_from_ds_request_error_keeps_cursors():
-    """Quand fetch_demarche_page signale une erreur DS, les curseurs ne sont pas avancés."""
+    """Quand la seule page a une erreur DS, le curseur initial est conservé."""
     demarche_number = 123
     initial_cursor = "old-cursor"
     demarche = DemarcheFactory(
@@ -1157,3 +1047,50 @@ def test_save_demarche_dossiers_from_ds_request_error_keeps_cursors():
 
     demarche.refresh_from_db()
     assert demarche.sync_cursor == initial_cursor
+
+
+# tests _reinit_demarche_sync_state
+
+
+@pytest.mark.django_db
+def test_reinit_demarche_sync_state_sets_updated_since_and_clears_cursors():
+    demarche = DemarcheFactory(
+        sync_cursor="old-d",
+        pending_deleted_cursor="old-p",
+        deleted_cursor="old-del",
+        updated_since=None,
+    )
+    expected_created_at = demarche.created_at
+
+    _reinit_demarche_sync_state(demarche)
+
+    assert demarche.updated_since == expected_created_at
+    assert demarche.sync_cursor == ""
+    assert demarche.pending_deleted_cursor == ""
+    assert demarche.deleted_cursor == ""
+
+
+@pytest.mark.django_db
+def test_save_demarche_dossiers_from_ds_calls_reinit_when_updated_since_is_none():
+    demarche_number = 123
+    demarche = DemarcheFactory(
+        ds_number=demarche_number,
+        updated_since=None,
+        raw_ds_data={"groupeInstructeurs": [{"id": "GROUPE-1", "instructeurs": []}]},
+    )
+
+    def _fake_reinit(d):
+        d.updated_since = d.created_at
+        return d.created_at
+
+    with patch(
+        "gsl_demarches_simplifiees.importer.dossier._reinit_demarche_sync_state",
+        side_effect=_fake_reinit,
+    ) as mock_reinit:
+        with patch(
+            "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
+            return_value=(_make_demarche_page(), False),
+        ):
+            save_demarche_dossiers_from_ds(demarche_number)
+
+    mock_reinit.assert_called_once_with(demarche)


### PR DESCRIPTION
## 🌮 Objectif

Corriger la sauvegarde des curseurs de pagination lors de la synchronisation des dossiers depuis Démarches Numériques :
1. Ne pas avancer les curseurs si la requête DN renvoie des erreurs
2. Sauvegarder les curseurs **après chaque page** (et non à la fin de toute la pagination), afin de conserver la progression en cas d'erreur partielle

## ⚠️ Informations supplémentaires

La sauvegarde par page garantit qu'un run interrompu (erreur réseau, erreur DS partielle) reprend bien depuis la dernière page traitée avec succès, sans retraiter des pages déjà intégrées.