### PR TITLE
Recherche par sous-chaîne du numéro de dossier

### DIFF
--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -899,6 +899,14 @@ def test_filter_search_matches_ds_number_exactly(req, view, searchable_projets):
     assert list(qs) == [searchable_projets["voirie"]]
 
 
+def test_filter_search_matches_ds_number_substring(req, view, searchable_projets):
+    # "123" n'est un fragment que du numéro de dossier 1234567
+    request = req.get("/", data={"search": "123"})
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+    assert list(qs) == [searchable_projets["ecole"]]
+
+
 def test_filter_search_empty_returns_all(req, view, searchable_projets):
     request = req.get("/", data={"search": ""})
     view.request = request

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.db import connection
-from django.db.models import Count, Exists, F, Func, OuterRef, Q, Value
+from django.db.models import CharField, Count, Exists, F, Func, OuterRef, Q, Value
+from django.db.models.functions import Cast
 from django.forms.utils import pretty_name
 from django.utils.translation import gettext_lazy as _
 from django_filters import (
@@ -237,7 +238,10 @@ def make_filter_search(intitule_field, raison_sociale_field, ds_number_field):
             )
 
         if value.isdigit():
-            q |= Q(**{ds_number_field: int(value)})
+            queryset = queryset.annotate(
+                _search_ds_number_str=Cast(F(ds_number_field), output_field=CharField())
+            )
+            q |= Q(_search_ds_number_str__contains=value)
 
         return queryset.filter(q).distinct()
 


### PR DESCRIPTION
## 🌮 Objectif

Permettre la recherche libre par fragment du numéro de dossier DS.

## 🔍 Liste des modifications

- Dans la factory `make_filter_search()`, le numéro de dossier est désormais matché par sous-chaîne (`Cast` du champ entier en texte puis `__contains`) au lieu d'une égalité entière exacte. La recherche libre des listes projets, programmation et simulation en bénéficie via cette unique factory.
- Ajout du test `test_filter_search_matches_ds_number_substring` ; le test de match exact existant reste couvert.