### PR TITLE
Modale de génération multiple : étape 2 conforme à la maquette Figma

### DIFF
--- a/gsl_notification/forms.py
+++ b/gsl_notification/forms.py
@@ -3,6 +3,7 @@ from functools import cached_property
 from django import forms
 from django.conf import settings
 from django.db import transaction
+from django.template.defaultfilters import pluralize
 from django.utils import timezone
 from dsfr.forms import DsfrBaseForm
 
@@ -430,10 +431,9 @@ class GenerateDocumentsStep2Form(BaseGenerateDocumentsForm):
     STRATEGY_CONSERVER = "conserver"
     STRATEGY_REMPLACER = "remplacer"
 
-    OVERWRITE_STRATEGY_CHOICES = [
-        (STRATEGY_CONSERVER, "Conserver"),
-        (STRATEGY_REMPLACER, "Remplacer"),
-    ]
+    # Plural noun per document type; (LETTRE, ARRETE) iteration order keeps
+    # "lettres" before "arrêtés" everywhere (selected_types is an unordered set).
+    _DOC_TYPE_NOUNS = {LETTRE: "lettres", ARRETE: "arrêtés"}
 
     @staticmethod
     def _modele_field(queryset, label):
@@ -453,31 +453,62 @@ class GenerateDocumentsStep2Form(BaseGenerateDocumentsForm):
         self.document_type = document_type
         self.programmation_projets = programmation_projets
 
-        if self.has_arrete:
-            self.fields["modele_arrete_id"] = self._modele_field(
-                self.modeles_arrete, "Modèle pour les arrêtés"
+        # Conserver/Remplacer first: its "…ci-dessous" wording refers to the
+        # model dropdowns rendered just below it.
+        if self.has_existing_docs():
+            self.fields["overwrite_strategy"] = forms.ChoiceField(
+                choices=[
+                    (self.STRATEGY_CONSERVER, self._conserver_label),
+                    (self.STRATEGY_REMPLACER, self._remplacer_label),
+                ],
+                widget=forms.RadioSelect,
+                required=True,
+                initial=self.STRATEGY_CONSERVER,
+                label=self._overwrite_field_label,
+                help_text="« Conserver » permet de ne pas régénérer les documents existants.",
             )
+
         if self.has_lettre:
             self.fields["modele_lettre_id"] = self._modele_field(
                 self.modeles_lettre,
                 "Modèle pour les lettres de notification",
             )
-
-        if self.has_existing_docs():
-            self.fields["overwrite_strategy"] = forms.ChoiceField(
-                choices=self.OVERWRITE_STRATEGY_CHOICES,
-                widget=forms.RadioSelect,
-                required=True,
-                initial=self.STRATEGY_CONSERVER,
-                label=f"Que voulez-vous faire avec les projets ayant déjà {
-                    ' ou '.join(
-                        [
-                            *(['une lettre'] if LETTRE in self.selected_types else []),
-                            *(['un arrêté'] if ARRETE in self.selected_types else []),
-                        ]
-                    )
-                } ?",
+        if self.has_arrete:
+            self.fields["modele_arrete_id"] = self._modele_field(
+                self.modeles_arrete, "Modèle pour les arrêtés"
             )
+
+    @cached_property
+    def _selected_nouns(self) -> list[str]:
+        return [
+            self._DOC_TYPE_NOUNS[t]
+            for t in (LETTRE, ARRETE)
+            if t in self.selected_types
+        ]
+
+    @property
+    def _overwrite_field_label(self) -> str:
+        nouns = " ou ".join(f"des {n}" for n in self._selected_nouns)
+        return f"Que voulez-vous faire avec les projets ayant déjà {nouns} ?"
+
+    @property
+    def _conserver_label(self) -> str:
+        nouns = " et ".join(f"les {n}" for n in self._selected_nouns)
+        # Feminine agreement only when "lettres" is the sole type.
+        fem = self.has_lettre and not self.has_arrete
+        return f"Conserver {nouns} existant{pluralize(fem, 'es,s')}"
+
+    @property
+    def _remplacer_label(self) -> str:
+        nouns = " et ".join(f"les {n}" for n in self._selected_nouns)
+        fem = self.has_lettre and not self.has_arrete
+        # "toutes/tous" agrees with the first noun ("lettres" when present).
+        quantifier = f"tou{pluralize(self.has_lettre, 'tes,s')}"
+        return (
+            f"Remplacer {quantifier} {nouns} par "
+            f"{pluralize(fem, 'celles,ceux')} "
+            f"sélectionné{pluralize(fem, 'es,s')} ci-dessous"
+        )
 
     @cached_property
     def has_arrete(self) -> bool:

--- a/gsl_notification/templates/gsl_notification/generated_document/multiple/modal_step2_body.html
+++ b/gsl_notification/templates/gsl_notification/generated_document/multiple/modal_step2_body.html
@@ -12,25 +12,28 @@
     {% endblock form_open %}
     {% block content %}
         {% if form.existing_lettre_count or form.existing_arrete_count %}
-            <div class="fr-alert fr-alert--warning fr-mt-2w fr-alert--sm" role="alert">
-                {% if form.existing_lettre_count %}
-                    <p>
-                        {{ form.existing_lettre_count }} projet{{ form.existing_lettre_count|pluralize }}
-                        {{ form.existing_lettre_count|pluralize:"a,ont" }}
-                        déjà une lettre.
-                    </p>
-                {% endif %}
-                {% if form.existing_arrete_count %}
-                    <p>
-                        {{ form.existing_arrete_count }} projet{{ form.existing_arrete_count|pluralize }}
-                        {{ form.existing_arrete_count|pluralize:"a,ont" }}
-                        déjà un arrêté.
-                    </p>
-                {% endif %}
+            <div class="fr-alert fr-alert--warning fr-mb-2w fr-alert--sm" role="alert">
+                <p>
+                    <strong>
+                        {% if form.existing_lettre_count %}
+                            {{ form.existing_lettre_count }} projet{{ form.existing_lettre_count|pluralize }}
+                            {{ form.existing_lettre_count|pluralize:"a,ont" }}
+                            {# keep the comma glued to "lettre": no space before it #}
+                            {# djlint:off #}
+                            déjà une lettre{% if form.existing_arrete_count %},{% endif %}
+                            {# djlint:on #}
+                        {% endif %}
+                        {% if form.existing_arrete_count %}
+                            {{ form.existing_arrete_count }} projet{{ form.existing_arrete_count|pluralize }}
+                            {{ form.existing_arrete_count|pluralize:"a,ont" }}
+                            déjà un arrêté
+                        {% endif %}
+                    </strong>
+                </p>
             </div>
         {% endif %}
         {% if form.has_arrete and not form.modeles_arrete %}
-            <div class="fr-alert fr-alert--warning fr-mt-2w fr-alert--sm">
+            <div class="fr-alert fr-alert--warning fr-mb-2w fr-alert--sm">
                 <p>
                     Vous n'avez créé aucun modèle d'arrêté pour le moment.
                     <a href="{% url 'gsl_notification:modele-creer' "arrete" dotation %}">Créer un modèle</a>
@@ -39,7 +42,7 @@
             </div>
         {% endif %}
         {% if form.has_lettre and not form.modeles_lettre %}
-            <div class="fr-alert fr-alert--warning fr-mt-2w fr-alert--sm">
+            <div class="fr-alert fr-alert--warning fr-mb-2w fr-alert--sm">
                 <p>
                     Vous n'avez créé aucun modèle de lettre pour le moment.
                     <a href="{% url 'gsl_notification:modele-creer' "lettre" dotation %}">Créer un modèle</a>

--- a/gsl_notification/tests/views/test_generate_document_for_multiple_projets_views.py
+++ b/gsl_notification/tests/views/test_generate_document_for_multiple_projets_views.py
@@ -262,6 +262,27 @@ def test_wizard_step1_to_step2_both_types_renders_two_selectors(
     assert form.document_type == ARRETE_ET_LETTRE
 
 
+def test_wizard_step2_field_order_matches_figma(
+    client, programmation_projets, detr_arrete_modele, detr_lettre_modele
+):
+    """Figma: Conserver/Remplacer first, then lettres, then arrêtés."""
+    for pp in programmation_projets:
+        LettreNotificationFactory(programmation_projet=pp)
+
+    _open_wizard_at_step1(client, programmation_projets)
+    response = client.post(
+        _wizard_url(),
+        _wizard_step_data("step1", {"document_type": ARRETE_ET_LETTRE}),
+        **HTMX_HEADERS,
+    )
+    form = response.context["form"]
+    assert list(form.fields) == [
+        "overwrite_strategy",
+        "modele_lettre_id",
+        "modele_arrete_id",
+    ]
+
+
 def test_wizard_step2_missing_modele_re_renders_step2(client, programmation_projets):
     """Regression: previously the step3 view rendered step2 on missing_modele."""
     _open_wizard_at_step1(client, programmation_projets)


### PR DESCRIPTION
## 🌮 Objectif

Réorganiser l'étape 2 de l'assistant de génération de documents multiples pour qu'elle corresponde à la maquette Figma.

## 🔍 Liste des modifications

- Ordre des champs de l'étape 2 conforme à la maquette : choix Conserver/Remplacer en premier, puis le modèle de lettre, puis le modèle d'arrêté
- Libellés Conserver/Remplacer générés dynamiquement selon les types de documents sélectionnés, avec l'accord grammatical correct (féminin pour « lettres », masculin pour « arrêtés »)
- Alerte « documents déjà existants » fusionnée en une seule alerte mise en avant, avec un espacement bas (`fr-mb-2w`) au lieu d'un espacement haut
- Ajout d'un test vérifiant l'ordre des champs de l'étape 2