### PR TITLE
Alertes email admin sur opérations sensibles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,8 @@ SCALEWAY_S3_REGION=
 # CLAMAV_DISABLE_PROCESS_TYPES=web,postdeploy,one-off  # only run ClamAV on worker container
 
 # ENABLE_QUERY_COUNTER=True # Enable Django Debug Toolbar and query counting in dev environment. Warning: can cause performance issues if you have a lot of queries.
+
+# Email alerts admin (smtp://user:password@host:port?...; vide = backend console par défaut)
+# SMTP_URL=
+# DEFAULT_FROM_EMAIL=turgot-alerts@turgot.beta.gouv.fr
+# ADMIN_ALERT_RECIPIENTS=ops@example.fr,admin@example.fr

--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 import dj_database_url
+import dj_email_url
 from django.utils.csp import CSP
 from dotenv import load_dotenv
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -189,6 +190,19 @@ if DATABASE_URL:
     }
 else:
     raise ValueError("Please set the DATABASE_URL environment variable")
+
+# Email configuration
+SMTP_URL = os.getenv("SMTP_URL")
+if SMTP_URL:
+    vars().update(dj_email_url.parse(SMTP_URL))
+
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "turgot-alerts@beta.gouv.fr")
+
+ADMIN_ALERT_RECIPIENTS = [
+    e.strip()
+    for e in os.getenv("ADMIN_ALERT_RECIPIENTS", "").split(ENV_SEPARATOR)
+    if e.strip()
+]
 
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators

--- a/gsl_core/admin.py
+++ b/gsl_core/admin.py
@@ -8,7 +8,7 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import Group
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Count, OuterRef, Subquery
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -16,6 +16,7 @@ from import_export.admin import ImportMixin
 from import_export.formats.base_formats import CSV
 from import_export.forms import ImportForm
 
+from gsl_core.admin_alerts import notify_admins
 from gsl_core.models import (
     Adresse,
     Arrondissement,
@@ -190,6 +191,109 @@ class CollegueAdmin(AllPermsForStaffUser, ImportMixin, UserAdmin, admin.ModelAdm
             readonly += ["is_superuser", "is_staff"]
         return readonly
 
+    @transaction.atomic
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        actor = request.user
+        # Cas création
+        if not change:
+            if obj.is_staff or obj.is_superuser:
+                notify_admins(
+                    f"Création d'utilisateur admin : {obj.username}",
+                    (
+                        f"Créé par {actor} ({actor.email}).\n"
+                        f"Emai  : {obj.email}\n"
+                        f"Statut équipe : {obj.is_staff}\n"
+                        f"Statut super-utilisateur : {obj.is_superuser}"
+                    ),
+                )
+            if obj.perimetre is not None:
+                notify_admins(
+                    "Création d'utilisateur",
+                    f"Créé par {actor} ({actor.email}).\n"
+                    f"Emai  : {obj.email}\n"
+                    f"Perimètre : {obj.perimetre}",
+                )
+            return
+        # Cas modification
+        for flag in ("is_staff", "is_superuser"):
+            if flag in form.changed_data and getattr(obj, flag):
+                notify_admins(
+                    f"Droit {flag} octroyé à {obj.email} ({obj.username})",
+                    f"Octroyé par {actor} ({actor.email}).",
+                )
+        if "ds_profile" in form.changed_data and obj.ds_profile_id:
+            notify_admins(
+                f"Profil DN associé à {obj.email} ({obj.username})",
+                (
+                    f"Associé par {actor} ({actor.email}).\n"
+                    f"Profil DN : {obj.ds_profile.ds_email} (id={obj.ds_profile.ds_id})"
+                ),
+            )
+        if "perimetre" in form.changed_data and obj.perimetre_id:
+            notify_admins(
+                f"Perimètre associé à {obj.email} ({obj.username})",
+                (
+                    f"Associé par {actor} ({actor.email}).\n"
+                    f"Perimètre : {obj.perimetre.entity_name} (id={obj.perimetre_id})"
+                ),
+            )
+        if "is_active" in form.changed_data and obj.is_active is True:
+            notify_admins(
+                f"Réactivation d'un utilisateur désactivé {obj.email} ({obj.username})",
+                f"Modifié par {actor} ({actor.email}).\n",
+            )
+
+    def process_result(self, result, request):
+        response = super().process_result(result, request)
+        self._notify_admins_of_import(result, request)
+        return response
+
+    def _notify_admins_of_import(self, result, request):
+        from import_export.results import RowResult
+
+        new_ids = [
+            r.object_id
+            for r in result.rows
+            if r.import_type == RowResult.IMPORT_TYPE_NEW and r.object_id
+        ]
+        updated_ids = [
+            r.object_id
+            for r in result.rows
+            if r.import_type == RowResult.IMPORT_TYPE_UPDATE and r.object_id
+        ]
+        if not new_ids and not updated_ids:
+            return
+
+        users_by_id = {
+            u.pk: u
+            for u in Collegue.objects.filter(
+                pk__in=new_ids + updated_ids
+            ).select_related(
+                "perimetre__region",
+                "perimetre__departement",
+                "perimetre__arrondissement",
+            )
+        }
+        actor = request.user
+        lines = [f"Action déclenchée par {actor} ({actor.email})."]
+        if new_ids:
+            lines.append(f"\nCréés ({len(new_ids)}) :")
+            lines += [
+                f"- {users_by_id[i].email} — {users_by_id[i].perimetre}"
+                for i in new_ids
+                if i in users_by_id
+            ]
+        if updated_ids:
+            lines.append(f"\nMis à jour ({len(updated_ids)}) :")
+            lines += [
+                f"- {users_by_id[i].email}" for i in updated_ids if i in users_by_id
+            ]
+        notify_admins(
+            f"Import groupé d'utilisateurs : {len(new_ids)} créé(s), {len(updated_ids)} mis à jour",
+            "\n".join(lines),
+        )
+
     def get_queryset(self, request):
         qs = super().get_queryset(request)
 
@@ -225,7 +329,29 @@ class CollegueAdmin(AllPermsForStaffUser, ImportMixin, UserAdmin, admin.ModelAdm
     @admin.action(description="🔃 Association des profils DN aux utilisateurs")
     def associate_ds_profile_to_users(self, request, queryset):
         user_ids = list(queryset.values_list("id", flat=True))
+        before = dict(
+            Collegue.objects.filter(pk__in=user_ids).values_list("pk", "ds_profile_id")
+        )
         associate_or_update_ds_profile_to_users(user_ids)
+        newly_associated = (
+            Collegue.objects.filter(pk__in=user_ids, ds_profile__isnull=False)
+            .exclude(ds_profile_id__in=[v for v in before.values() if v is not None])
+            .select_related("ds_profile")
+        )
+        newly_associated = [
+            u for u in newly_associated if before.get(u.pk) != u.ds_profile_id
+        ]
+        if newly_associated:
+            lines = "\n".join(
+                f"- {u.username} ↔ {u.ds_profile.ds_email}" for u in newly_associated
+            )
+            notify_admins(
+                f"Association DN groupée : {len(newly_associated)} utilisateur(s)",
+                (
+                    f"Action déclenchée par {request.user} ({request.user.email}).\n"
+                    f"{lines}"
+                ),
+            )
 
     @admin.action(description="🚫 Désactivation des utilisateurs")
     def deactivate_users(self, request, queryset):
@@ -531,9 +657,27 @@ class DepartementAdmin(
     list_filter = ("region", "active")
     actions = ("activate_departement", "deactivate_departement")
 
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if change and "active" in form.changed_data and obj.active:
+            notify_admins(
+                f"Département activé : {obj.insee_code} {obj.name}",
+                f"Activé par {request.user} ({request.user.email}).",
+            )
+
     @admin.action(description="Activer le département")
     def activate_departement(self, request, queryset):
+        newly_activated = list(queryset.filter(active=False))
         queryset.update(active=True)
+        if newly_activated:
+            lines = "\n".join(f"- {d.insee_code} {d.name}" for d in newly_activated)
+            notify_admins(
+                f"Activation groupée de départements : {len(newly_activated)}",
+                (
+                    f"Action déclenchée par {request.user} ({request.user.email}).\n"
+                    f"{lines}"
+                ),
+            )
 
     @admin.action(description="Désactiver le département")
     def deactivate_departement(self, request, queryset):

--- a/gsl_core/admin_alerts.py
+++ b/gsl_core/admin_alerts.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django.core.mail import send_mail
+
+
+def notify_admins(subject: str, body: str) -> None:
+    """Envoie une alerte aux destinataires configurés. No-op si non configuré."""
+    if not settings.ADMIN_ALERT_RECIPIENTS:
+        return
+    send_mail(
+        subject=f"[Turgot {settings.ENV}] {subject}",
+        message=body,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=settings.ADMIN_ALERT_RECIPIENTS,
+        fail_silently=False,
+    )

--- a/gsl_core/apps.py
+++ b/gsl_core/apps.py
@@ -5,3 +5,6 @@ class GslcoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "gsl_core"
     verbose_name = "1. Socle"
+
+    def ready(self):
+        import gsl_core.signals  # noqa F401

--- a/gsl_core/signals.py
+++ b/gsl_core/signals.py
@@ -1,0 +1,22 @@
+from axes.signals import user_locked_out
+from django.dispatch import receiver
+
+from gsl_core.admin_alerts import notify_admins
+
+
+@receiver(user_locked_out)
+def alert_on_lockout(sender, request, username, ip_address, **kwargs):
+    from gsl_core.models import Collegue
+
+    user_agent = request.META.get("HTTP_USER_AGENT", "?") if request else "?"
+    try:
+        user = Collegue.objects.get(username=username)
+        notify_admins(
+            f"Utilisateur bloqué (brute force) : {user.email} ({username})",
+            f"Email : {user.email}\nUsername : {username}\nIP : {ip_address}\nUser-Agent : {user_agent}",
+        )
+    except Collegue.DoesNotExist:
+        notify_admins(
+            f"Utilisateur bloqué (brute force) : {username}",
+            f"Username : {username}\nIP : {ip_address}\nUser-Agent : {user_agent}",
+        )

--- a/gsl_core/tests/test_admin_alerts.py
+++ b/gsl_core/tests/test_admin_alerts.py
@@ -1,0 +1,296 @@
+import re
+
+import pytest
+from django.core import mail
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
+from django.urls import reverse
+
+from gsl_core.admin_alerts import notify_admins
+from gsl_core.models import Departement
+from gsl_core.tests.factories import (
+    CollegueFactory,
+    DepartementFactory,
+    PerimetreDepartementalFactory,
+    RegionFactory,
+)
+from gsl_demarches_simplifiees.tests.factories import ProfileFactory
+
+
+@pytest.fixture
+def superuser(db):
+    return CollegueFactory(
+        is_staff=True,
+        is_superuser=True,
+        username="alerts_superuser",
+        email="alerts_superuser@example.fr",
+    )
+
+
+@pytest.fixture
+def admin_alert_recipients():
+    with override_settings(ADMIN_ALERT_RECIPIENTS=["ops@test.local"]):
+        yield ["ops@test.local"]
+
+
+def _change_user_payload(user, **overrides):
+    data = {
+        "username": user.username,
+        "email": user.email or "",
+        "first_name": user.first_name or "",
+        "last_name": user.last_name or "",
+        "comment": user.comment or "",
+        "proconnect_uid": user.proconnect_uid or "",
+        "proconnect_siret": user.proconnect_siret or "",
+        "proconnect_chorusdt": user.proconnect_chorusdt or "",
+        "date_joined_0": user.date_joined.strftime("%Y-%m-%d"),
+        "date_joined_1": user.date_joined.strftime("%H:%M:%S"),
+        "_save": "Save",
+    }
+    if user.is_active:
+        data["is_active"] = "on"
+    if user.is_staff:
+        data["is_staff"] = "on"
+    if user.is_superuser:
+        data["is_superuser"] = "on"
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.django_db
+class TestNotifyAdminsHelper:
+    def test_no_recipients_is_noop(self, settings):
+        settings.ADMIN_ALERT_RECIPIENTS = []
+        mail.outbox = []
+        notify_admins("subject", "body")
+        assert mail.outbox == []
+
+    def test_sends_when_recipients_configured(self, admin_alert_recipients, settings):
+        mail.outbox = []
+        notify_admins("subject", "body")
+        assert len(mail.outbox) == 1
+        m = mail.outbox[0]
+        assert m.to == ["ops@test.local"]
+        assert f"[Turgot {settings.ENV}]" in m.subject
+        assert "subject" in m.subject
+        assert m.body == "body"
+
+
+@pytest.mark.django_db
+class TestCollegueAdminAlerts:
+    def test_basic_user_creation_via_admin_sends_no_alert(
+        self, otp_verified_client, superuser, admin_alert_recipients
+    ):
+        """Création d'un utilisateur de base (ni staff/superuser ni périmètre)
+        ne déclenche pas d'alerte ; les alertes sont émises lors d'une
+        élévation ultérieure (couvertes par les tests d'octroi de droits)."""
+        client = otp_verified_client(superuser)
+        mail.outbox = []
+        url = reverse("admin:gsl_core_collegue_add")
+        response = client.post(
+            url,
+            {
+                "username": "newuser",
+                "password1": "Abc!def123ghi456",
+                "password2": "Abc!def123ghi456",
+            },
+        )
+        assert response.status_code in (200, 302)
+        assert mail.outbox == []
+
+    def test_grant_is_staff_sends_alert(
+        self, otp_verified_client, superuser, admin_alert_recipients
+    ):
+        target = CollegueFactory(
+            is_staff=False, is_superuser=False, username="grantable"
+        )
+        client = otp_verified_client(superuser)
+        mail.outbox = []
+        url = reverse("admin:gsl_core_collegue_change", args=[target.pk])
+        client.post(url, _change_user_payload(target, is_staff="on"))
+        target.refresh_from_db()
+        assert target.is_staff
+        assert any("is_staff" in m.subject for m in mail.outbox)
+
+    def test_grant_is_superuser_sends_alert(
+        self, otp_verified_client, superuser, admin_alert_recipients
+    ):
+        target = CollegueFactory(
+            is_staff=True, is_superuser=False, username="superable"
+        )
+        client = otp_verified_client(superuser)
+        mail.outbox = []
+        url = reverse("admin:gsl_core_collegue_change", args=[target.pk])
+        client.post(url, _change_user_payload(target, is_superuser="on"))
+        target.refresh_from_db()
+        assert target.is_superuser
+        assert any("is_superuser" in m.subject for m in mail.outbox)
+
+    def test_associate_ds_profile_sends_alert(
+        self, otp_verified_client, superuser, admin_alert_recipients
+    ):
+        profile = ProfileFactory(ds_email="dn@example.fr")
+        target = CollegueFactory(
+            is_staff=True, is_superuser=False, username="associable"
+        )
+        client = otp_verified_client(superuser)
+        mail.outbox = []
+        url = reverse("admin:gsl_core_collegue_change", args=[target.pk])
+        client.post(url, _change_user_payload(target, ds_profile=str(profile.pk)))
+        target.refresh_from_db()
+        assert target.ds_profile_id == profile.pk
+        assert any("Profil DN associé" in m.subject for m in mail.outbox)
+
+    def test_no_alert_when_recipients_empty(self, otp_verified_client, superuser):
+        target = CollegueFactory(is_staff=False, username="silent")
+        client = otp_verified_client(superuser)
+        mail.outbox = []
+        url = reverse("admin:gsl_core_collegue_change", args=[target.pk])
+        with override_settings(ADMIN_ALERT_RECIPIENTS=[]):
+            client.post(url, _change_user_payload(target, is_staff="on"))
+        assert mail.outbox == []
+
+    def test_import_users_sends_recap(
+        self, otp_verified_client, superuser, admin_alert_recipients
+    ):
+        region = RegionFactory(insee_code="84", name="Auvergne-Rhône-Alpes")
+        dept = DepartementFactory(insee_code="01", name="AIN", region=region)
+        perimetre = PerimetreDepartementalFactory(
+            departement=dept, region=region, arrondissement=None
+        )
+        existing = CollegueFactory(
+            email="existing@ain.gouv.fr",
+            username="existing@ain.gouv.fr",
+            first_name="Old",
+            last_name="Name",
+            perimetre=perimetre,
+        )
+        csv_content = (
+            "email,departement_code,arrondissement_code,first_name,last_name\n"
+            "new@ain.gouv.fr,01,,Jean,Dupont\n"
+            "existing@ain.gouv.fr,01,,New,Name\n"
+        )
+        client = otp_verified_client(superuser)
+        mail.outbox = []
+
+        upload_url = reverse("admin:gsl_core_collegue_import")
+        upload = SimpleUploadedFile(
+            "users.csv", csv_content.encode("utf-8"), content_type="text/csv"
+        )
+        response = client.post(upload_url, {"format": "0", "import_file": upload})
+        assert response.status_code == 200
+
+        content = response.content.decode("utf-8")
+        import_file_name = re.search(
+            r'name="import_file_name" value="([^"]+)"', content
+        ).group(1)
+        original_file_name_match = re.search(
+            r'name="original_file_name" value="([^"]+)"', content
+        )
+
+        confirm_url = reverse("admin:gsl_core_collegue_process_import")
+        confirm_data = {"import_file_name": import_file_name, "format": "0"}
+        if original_file_name_match:
+            confirm_data["original_file_name"] = original_file_name_match.group(1)
+        response = client.post(confirm_url, confirm_data)
+        assert response.status_code == 302
+
+        existing.refresh_from_db()
+        assert existing.first_name == "New"
+
+        recap = [m for m in mail.outbox if "Import groupé d'utilisateurs" in m.subject]
+        assert len(recap) == 1, [m.subject for m in mail.outbox]
+        body = recap[0].body
+        assert "1 créé(s)" in recap[0].subject
+        assert "1 mis à jour" in recap[0].subject
+        assert "new@ain.gouv.fr" in body
+        assert "existing@ain.gouv.fr" in body
+
+    def test_associate_ds_profile_bulk_action_sends_recap(
+        self, otp_verified_client, superuser, admin_alert_recipients
+    ):
+        profile = ProfileFactory(ds_email="recap@example.fr")
+        target = CollegueFactory(username="bulky", email="recap@example.fr")
+        client = otp_verified_client(superuser)
+        mail.outbox = []
+        url = reverse("admin:gsl_core_collegue_changelist")
+        client.post(
+            url,
+            {
+                "action": "associate_ds_profile_to_users",
+                "_selected_action": [str(target.pk)],
+            },
+        )
+        target.refresh_from_db()
+        assert target.ds_profile_id == profile.pk
+        assert any("Association DN groupée" in m.subject for m in mail.outbox), [
+            m.subject for m in mail.outbox
+        ]
+
+
+@pytest.mark.django_db
+class TestDepartementAdminAlerts:
+    def test_save_model_activation_sends_alert(
+        self, otp_verified_client, superuser, admin_alert_recipients
+    ):
+        dpt = DepartementFactory(insee_code="42", name="Loire", active=False)
+        client = otp_verified_client(superuser)
+        mail.outbox = []
+        url = reverse("admin:gsl_core_departement_change", args=[dpt.pk])
+        client.post(
+            url,
+            {
+                "insee_code": dpt.insee_code,
+                "name": dpt.name,
+                "region": dpt.region_id,
+                "active": "on",
+                "_save": "Save",
+            },
+        )
+        dpt.refresh_from_db()
+        assert dpt.active
+        assert any("Département activé" in m.subject for m in mail.outbox)
+
+    def test_bulk_activate_sends_recap(
+        self, otp_verified_client, superuser, admin_alert_recipients
+    ):
+        d1 = DepartementFactory(insee_code="91", name="Essonne", active=False)
+        d2 = DepartementFactory(insee_code="92", name="Hauts-de-Seine", active=False)
+        client = otp_verified_client(superuser)
+        mail.outbox = []
+        url = reverse("admin:gsl_core_departement_changelist")
+        client.post(
+            url,
+            {
+                "action": "activate_departement",
+                "_selected_action": [d1.pk, d2.pk],
+            },
+        )
+        assert Departement.objects.get(pk=d1.pk).active
+        assert Departement.objects.get(pk=d2.pk).active
+        recap = [m for m in mail.outbox if "Activation groupée" in m.subject]
+        assert len(recap) == 1
+        assert "Essonne" in recap[0].body
+        assert "Hauts-de-Seine" in recap[0].body
+
+
+@pytest.mark.django_db
+class TestLockoutAlert:
+    def test_lockout_signal_sends_alert(self, admin_alert_recipients):
+        from axes.signals import user_locked_out
+
+        mail.outbox = []
+
+        class _FakeRequest:
+            META = {"HTTP_USER_AGENT": "pytest"}
+
+        user_locked_out.send(
+            sender=None,
+            request=_FakeRequest(),
+            username="bruteforced",
+            ip_address="1.2.3.4",
+        )
+        assert len(mail.outbox) == 1
+        assert "Utilisateur bloqué" in mail.outbox[0].subject
+        assert "bruteforced" in mail.outbox[0].body
+        assert "1.2.3.4" in mail.outbox[0].body

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "bs4",
     "celery",
     "dj-database-url",
+    "dj-email-url",
     "django-axes",
     "django_celery_results",
     "django-celery-beat>=2.9.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,8 @@ diff-match-patch==20241021
     # via django-import-export
 dj-database-url==3.1.2
     # via gsl (pyproject.toml)
+dj-email-url==1.0.6
+    # via gsl (pyproject.toml)
 django==6.0.5
     # via
     #   dj-database-url


### PR DESCRIPTION
## 🌮 Objectif

Tracer par email à une liste de destinataires de confiance les opérations admin sensibles, pour qu'un admin/ops puisse réagir vite à toute action inattendue.

## 🔍 Liste des modifications

- Ajout de la dépendance `dj-email-url` pour parser une variable `SMTP_URL` unique (parallèle à `DATABASE_URL`).
- Nouvelles variables d'environnement : `SMTP_URL`, `DEFAULT_FROM_EMAIL`, `ADMIN_ALERT_RECIPIENTS`.
- Helper `gsl_core.admin_alerts.notify_admins()` (envoi synchrone via `send_mail`, no-op si la liste est vide).
- Hooks `save_model` sur `CollegueAdmin` :
  - création d'un utilisateur staff/superuser ou avec périmètre
  - octroi de `is_staff` ou `is_superuser`
  - association d'un profil DN
  - association d'un périmètre
  - réactivation (`is_active` repassant à `True`)
- Recap email pour la bulk action `associate_ds_profile_to_users`.
- Recap email pour l'import groupé d'utilisateurs (CSV/Excel via `ImportMixin`), avec la liste des comptes créés et mis à jour — hook `process_result` car `save_model` n'est pas appelé sur cette voie.
- Hook `save_model` sur `DepartementAdmin` et recap pour la bulk action `activate_departement`.
- Receiver du signal `axes.signals.user_locked_out` (alerte brute-force), branché depuis `GslcoreConfig.ready()`.
- Tests E2E dans `gsl_core/tests/test_admin_alerts.py` (client admin + `mail.outbox`).

## ⚠️ Informations supplémentaires

Configuration recommandée par environnement :
- Dev : `SMTP_URL=console://` (les mails s'affichent dans la console runserver).
- Staging/prod : `SMTP_URL=smtp://...` + `ADMIN_ALERT_RECIPIENTS=ops@...,admin@...`.

Sans `ADMIN_ALERT_RECIPIENTS`, `notify_admins()` est un no-op : aucun envoi, aucune erreur.