### PR TITLE
Statut vide pour les projets sans DotationProjet

### DIFF
--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -115,6 +115,13 @@ class ProjetQuerySet(models.QuerySet):
             )
         )
 
+        has_refused = Exists(
+            DotationProjet.objects.filter(
+                projet=OuterRef("pk"),
+                status=PROJET_STATUS_REFUSED,
+            )
+        )
+
         return self.annotate(
             _status=Case(
                 # If not all dotations have programmation, return PROCESSING
@@ -132,8 +139,13 @@ class ProjetQuerySet(models.QuerySet):
                     has_dismissed,
                     then=Value(PROJET_STATUS_DISMISSED),
                 ),
-                # Otherwise return REFUSED
-                default=Value(PROJET_STATUS_REFUSED),
+                # If any dotation is REFUSED, return REFUSED
+                When(
+                    has_refused,
+                    then=Value(PROJET_STATUS_REFUSED),
+                ),
+                # Projects without any DotationProjet have no status
+                default=Value(None),
             )
         )
 
@@ -841,8 +853,13 @@ class ProjetNote(BaseModel):
     created_by = models.ForeignKey(Collegue, on_delete=models.PROTECT)
 
 
-def projet_status_from_dotation_statuses(statuses: List[str] | Tuple[str]) -> str:
+def projet_status_from_dotation_statuses(
+    statuses: List[str] | Tuple[str],
+) -> str | None:
     from gsl_simulation.models import SimulationProjet
+
+    if not statuses:
+        return None
 
     if any(
         status == PROJET_STATUS_PROCESSING

--- a/gsl_projet/tests/test_status.py
+++ b/gsl_projet/tests/test_status.py
@@ -14,6 +14,11 @@ from gsl_projet.tests.factories import DotationProjetFactory, ProjetFactory
 pytestmark = pytest.mark.django_db
 
 
+def test_projet_without_dotation_projet_has_no_status():
+    projet = ProjetFactory()
+    assert projet.status is None
+
+
 def test_update_projet_status_on_post_save():
     projet: Projet = ProjetFactory()
     dotation_projet: DotationProjet = DotationProjetFactory(

--- a/gsl_projet/tests/test_views.py
+++ b/gsl_projet/tests/test_views.py
@@ -787,6 +787,19 @@ def test_filter_by_status(req, view, projets_with_status, status, expected_count
     assert qs.first().status == status
 
 
+def test_filter_by_status_refused_excludes_project_without_dotation(req, view):
+    ProjetFactory()  # projet sans DotationProjet
+    projet_refuse = ProjetFactory()
+    DetrProjetFactory(projet=projet_refuse, status="refused")
+
+    request = req.get("/", data={"status": "refused"})
+    view.request = request
+    qs = view.get_filterset(ProjetFilters).qs
+
+    assert qs.count() == 1
+    assert qs.first().pk == projet_refuse.pk
+
+
 ### Test du filtre par territoire
 @pytest.fixture
 def perimetre_29(dep_finistere):


### PR DESCRIPTION
## 🌮 Objectif

Corriger un faux positif : les projets sans `DotationProjet` (dossiers reportés « SANS » en attente de traitement) apparaissaient dans le filtre « refusé » de la page liste des projets.

## 🔍 Liste des modifications

- `gsl_projet/models.py` — `annotate_status()` : ajout d'un sous-requête `has_refused` explicite avec un `When` dédié ; le `default` passe de `Value(PROJET_STATUS_REFUSED)` à `Value(None)` → les projets sans `DotationProjet` obtiennent `_status = NULL`
- `gsl_projet/models.py` — `projet_status_from_dotation_statuses()` : retour anticipé `None` si la liste est vide ; type de retour mis à jour en `str | None`
- `gsl_projet/tests/test_status.py` : nouveau test `test_projet_without_dotation_projet_has_no_status`
- `gsl_projet/tests/test_views.py` : nouveau test `test_filter_by_status_refused_excludes_project_without_dotation` sur `ProjetListView`

## ⚠️ Informations supplémentaires

Le comportement côté template et filtre était déjà correct : `_get_projet_statut()` retourne `""` si `dp` est `None`, et `filter_status()` exclut naturellement les projets dont `_status` est `None` (qui ne figure pas dans la liste de valeurs filtrées).