### PR TITLE
Nommage du fichier PDF lors de la notification d'acceptation

### DIFF
--- a/gsl_notification/forms.py
+++ b/gsl_notification/forms.py
@@ -1,3 +1,4 @@
+import os
 from functools import cached_property
 
 from django import forms
@@ -231,15 +232,59 @@ class NotificationMessageForm(DsfrBaseForm, forms.ModelForm):
         required=False,
         widget=forms.Textarea,
     )
+    nom_du_fichier = forms.CharField(
+        label="Nom du fichier (facultatif)",
+        required=False,
+        widget=forms.TextInput,
+        help_text="Si non renseigné, le nom du premier document signé importé sera utilisé.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["annexes"].queryset = Annexe.objects.filter(
+            programmation_projet__dotation_projet__projet=self.instance
+        )
+        first_lettre = LettreEtArreteSignes.objects.filter(
+            programmation_projet__dotation_projet__projet=self.instance
+        ).first()
+        if first_lettre:
+            self[
+                "nom_du_fichier"
+            ].help_text = f"Si non renseigné, le nom du premier document signé importé sera utilisé : « {first_lettre.name} »."
+            # We don't use self.fields because DsfrBaseForm adds the necessary classes on relevant fields in __init__, so we need to update the help_text on the already initialized field.
+
+    def clean_nom_du_fichier(self):
+        value = self.cleaned_data["nom_du_fichier"].strip()
+        if not value:
+            return value
+        stem, ext = os.path.splitext(value)
+        if ext.lower() == ".pdf":
+            return stem
+        if ext:
+            raise forms.ValidationError(
+                "Le nom du fichier ne peut pas avoir une extension autre que .pdf."
+            )
+        return value
 
     def save(self, user):
+        lettres = LettreEtArreteSignes.objects.filter(
+            programmation_projet__dotation_projet__projet=self.instance
+        )
+        nom = self.cleaned_data.get("nom_du_fichier")
+        if not nom:
+            nom = (
+                os.path.splitext(lettres.first().name)[0]
+                if lettres.exists()
+                else "documents"
+            )
+        filename = nom + ".pdf"
+
         justificatif_file = merge_documents_into_pdf(
             [
-                *LettreEtArreteSignes.objects.filter(
-                    programmation_projet__dotation_projet__projet=self.instance
-                ),
+                *lettres,
                 *self.cleaned_data["annexes"],
-            ]
+            ],
+            filename=filename,
         )
 
         # Dossier was recently refreshed DN
@@ -259,12 +304,6 @@ class NotificationMessageForm(DsfrBaseForm, forms.ModelForm):
             )
 
             return self.instance
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["annexes"].queryset = Annexe.objects.filter(
-            programmation_projet__dotation_projet__projet=self.instance
-        )
 
     class Meta:
         model = Projet

--- a/gsl_notification/forms.py
+++ b/gsl_notification/forms.py
@@ -1,5 +1,6 @@
 import os
 from functools import cached_property
+from pathlib import Path
 
 from django import forms
 from django.conf import settings
@@ -257,6 +258,10 @@ class NotificationMessageForm(DsfrBaseForm, forms.ModelForm):
         value = self.cleaned_data["nom_du_fichier"].strip()
         if not value:
             return value
+        if Path(value).name != value:
+            raise forms.ValidationError(
+                'Le nom du fichier ne peut pas contenir de "/".'
+            )
         stem, ext = os.path.splitext(value)
         if ext.lower() == ".pdf":
             return stem

--- a/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications_message.html
+++ b/gsl_notification/templates/gsl_notification/tab_simulation_projet/tab_notifications_message.html
@@ -50,6 +50,14 @@
                 Les pièces jointes vont être compressées en un seul fichier. Le message va être envoyé au demandeur
                 dans la messagerie de ce dossier, sur Démarche Numérique.
             </p>
+            <div class="fr-input-group{% if form.nom_du_fichier.errors %} fr-input-group--error{% endif %} fr-mb-2w">
+                <label class="fr-label" for="{{ form.nom_du_fichier.id_for_label }}">
+                    <b>{{ form.nom_du_fichier.label }}</b>
+                    <span class="fr-hint-text">{{ form.nom_du_fichier.help_text }}</span>
+                </label>
+                {{ form.nom_du_fichier }}
+                {{ form.nom_du_fichier.errors }}
+            </div>
             <div class="input-group fr-mb-2w">
                 <label class="fr-label" for="id_justification">
                     <b>

--- a/gsl_notification/tests/test_forms.py
+++ b/gsl_notification/tests/test_forms.py
@@ -305,3 +305,11 @@ def test_clean_nom_du_fichier_empty_is_valid():
     form.is_valid()
     assert "nom_du_fichier" not in form.errors
     assert form.cleaned_data["nom_du_fichier"] == ""
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("invalid_name", ["foo/bar", "../etc/passwd", "/etc/passwd"])
+def test_clean_nom_du_fichier_rejects_path_traversal(invalid_name):
+    form = _make_notification_form(invalid_name)
+    form.is_valid()
+    assert "nom_du_fichier" in form.errors

--- a/gsl_notification/tests/test_forms.py
+++ b/gsl_notification/tests/test_forms.py
@@ -10,6 +10,7 @@ from gsl_notification.forms import (
     GenerateDocumentsStep3Form,
     LettreNotificationForm,
     ModeleDocumentStepTwoForm,
+    NotificationMessageForm,
 )
 from gsl_notification.models import ModeleArrete
 from gsl_notification.tests.factories import (
@@ -255,3 +256,52 @@ def test_generate_documents_step3_form_valid_without_qr_field_submitted():
     )
     assert form.is_valid(), form.errors
     assert form.cleaned_data["with_qr_code"] is False
+
+
+# NotificationMessageForm.clean_nom_du_fichier
+
+
+def _make_notification_form(nom_du_fichier):
+    from gsl_projet.tests.factories import ProjetFactory
+
+    projet = ProjetFactory()
+    return NotificationMessageForm(
+        data={"nom_du_fichier": nom_du_fichier},
+        instance=projet,
+    )
+
+
+@pytest.mark.django_db
+def test_clean_nom_du_fichier_strips_pdf_extension():
+    form = _make_notification_form("mon-fichier.pdf")
+    form.is_valid()
+    assert form.cleaned_data["nom_du_fichier"] == "mon-fichier"
+
+
+@pytest.mark.django_db
+def test_clean_nom_du_fichier_strips_pdf_extension_uppercase():
+    form = _make_notification_form("MON-FICHIER.PDF")
+    form.is_valid()
+    assert form.cleaned_data["nom_du_fichier"] == "MON-FICHIER"
+
+
+@pytest.mark.django_db
+def test_clean_nom_du_fichier_accepts_no_extension():
+    form = _make_notification_form("mon-fichier")
+    form.is_valid()
+    assert form.cleaned_data["nom_du_fichier"] == "mon-fichier"
+
+
+@pytest.mark.django_db
+def test_clean_nom_du_fichier_rejects_other_extension():
+    form = _make_notification_form("mon-fichier.docx")
+    form.is_valid()
+    assert "nom_du_fichier" in form.errors
+
+
+@pytest.mark.django_db
+def test_clean_nom_du_fichier_empty_is_valid():
+    form = _make_notification_form("")
+    form.is_valid()
+    assert "nom_du_fichier" not in form.errors
+    assert form.cleaned_data["nom_du_fichier"] == ""

--- a/gsl_notification/tests/test_utils.py
+++ b/gsl_notification/tests/test_utils.py
@@ -418,6 +418,18 @@ class TestMergeDocumentsIntoPdf:
         # Verify S3 was called with correct file name
         mock_get_s3.assert_called_once_with("test_annexe.pdf")
 
+    @patch("gsl_notification.utils.get_s3_object")
+    def test_merge_custom_filename(self, mock_get_s3, mock_annexe, sample_pdf_bytes):
+        """Test that a custom filename is used when provided."""
+        mock_get_s3.return_value = {
+            "Body": Mock(read=Mock(return_value=sample_pdf_bytes)),
+            "ContentType": "application/pdf",
+        }
+
+        result = merge_documents_into_pdf([mock_annexe], filename="mon-rapport.pdf")
+
+        assert result.name == "mon-rapport.pdf"
+
 
 @pytest.mark.django_db
 def test_generate_pdf_for_generated_document(programmation_projet):

--- a/gsl_notification/utils.py
+++ b/gsl_notification/utils.py
@@ -530,6 +530,7 @@ def _build_qr_css_rules(document: Arrete | LettreNotification, page_count: int) 
 
 def merge_documents_into_pdf(
     documents: list[LettreEtArreteSignes | Annexe],
+    filename: str = "documents.pdf",
 ) -> SimpleUploadedFile:
     documents_file_bytes = [_get_uploaded_document_pdf(doc) for doc in documents]
 
@@ -543,5 +544,5 @@ def merge_documents_into_pdf(
     pdf.save(bytes)
     bytes.seek(0)
     return SimpleUploadedFile(
-        name="documents.pdf", content=bytes.read(), content_type="application/pdf"
+        name=filename, content=bytes.read(), content_type="application/pdf"
     )


### PR DESCRIPTION
## 🌮 Objectif

Permettre à l'utilisateur de choisir le nom du fichier PDF envoyé à Démarches Numériques lors de la notification d'acceptation d'un projet.

## 🔍 Liste des modifications

- `gsl_notification/utils.py` : ajout d'un paramètre `filename` (valeur par défaut `"documents.pdf"`) à `merge_documents_into_pdf()`
- `gsl_notification/forms.py` : ajout du champ `nom_du_fichier` (facultatif) dans `NotificationMessageForm`, avec `help_text` dynamique basé sur le premier document signé importé, validation (`clean_nom_du_fichier`) qui retire silencieusement l'extension `.pdf` et rejette toute autre extension, et construction du nom final dans `save()`
- Template `tab_notifications_message.html` : affichage du champ avant le paragraphe de compression
- Tests : 1 test dans `test_utils.py` (nom personnalisé), 5 tests dans `test_forms.py` (validation du champ)

## Visuels

<img width="856" height="616" alt="image" src="https://github.com/user-attachments/assets/59d9d8c4-3fba-4888-8336-cac770fa53f5" />

ça donne ça.
J'ai un petit doute sur les "(facultatif)" => est-ce qu'on les met ainsi ?