### PR TITLE
Correction du décochage silencieux des filtres de type ModelMultipleChoiceFilter

### DIFF
--- a/gsl_projet/utils/django_filters_custom_widget.py
+++ b/gsl_projet/utils/django_filters_custom_widget.py
@@ -36,10 +36,11 @@ class CustomCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
     def render(self, name, value, attrs=None, renderer=None):
         """Customize how the checkboxes are displayed in the HTML output."""
         output = []
+        str_values = {str(v) for v in value} if value else set()
         for i, (option_value, option_label) in enumerate(self.choices):
             color = self._get_color(option_value)
             color_class = f"color-{color}" if color else ""
-            checked = "checked" if value and option_value in value else ""
+            checked = "checked" if str(option_value) in str_values else ""
             checkbox = f'<input type="checkbox" name="{name}" value="{option_value}" id="id_{name}_{i}" {checked}>'
             label = f'<label for="id_{name}_{i}" class="fr-label {color_class}">{option_label}</label>'
             output.append(

--- a/ui/templatetags/ui_tags.py
+++ b/ui/templatetags/ui_tags.py
@@ -30,10 +30,10 @@ def ui_multiselect(*args, **kwargs) -> dict:
     tag_data["is_active"] = bool(selected)
 
     if selected:
-        choices_dict = dict(field.field.choices)
+        choices_dict = {str(k): v for k, v in field.field.choices}
         tag_data["placeholder"] = ", ".join(
-            str(choices_dict[v]) for v in selected if v in choices_dict
-        )
+            str(choices_dict[str(v)]) for v in selected if str(v) in choices_dict
+        ) or tag_data.get("default_placeholder", "")
     else:
         tag_data["placeholder"] = tag_data.get("default_placeholder", "")
 


### PR DESCRIPTION
## 🌮 Objectif

Corriger deux bugs liés à un décalage de type entier/chaîne dans les filtres utilisant `ModelMultipleChoiceFilter` (cofinancement, catégorie DETR/DSIL…).

## 🔍 Liste des modifications

- **`gsl_projet/utils/django_filters_custom_widget.py`** — `CustomCheckboxSelectMultiple.render()` : normalisation des valeurs en `str` avant comparaison
- **`ui/templatetags/ui_tags.py`** — tag `ui_multiselect` : même normalisation pour le calcul du placeholder

## ⚠️ Explication du bug

### Cause racine

Les filtres Django de type `ModelMultipleChoiceFilter` (ex. *cofinancement*, *catégorie DETR*) produisent des choices dont les clés sont des **entiers** (PKs de modèle, encapsulés dans `ModelChoiceIteratorValue`). En revanche, les données issues d'une requête GET sont des **chaînes de caractères** (`["1", "2"]`).

Ce décalage de type causait deux problèmes indépendants :

### Bug 1 — Filtre perdu à la prochaine soumission (comportement observé)

Dans `CustomCheckboxSelectMultiple.render()` :

```python
# Avant — option_value est un int, value est une liste de str
checked = "checked" if value and option_value in value else ""
# → 1 in ["1"] == False → case toujours rendue décochée
```

Conséquence : après avoir filtré sur *cofinancement*, la page affichait bien les résultats filtrés (le backend Django gère la conversion), mais les cases à cocher étaient rendues **décochées** visuellement. Lors de la soumission suivante (ex. clic sur « Filtrer » dans le dropdown *Catégorie DETR*), les cases décochées n'étaient pas incluses dans le GET → le filtre *cofinancement* disparaissait silencieusement.

### Bug 2 — Placeholder vide sur le bouton du filtre

Dans le tag `ui_multiselect` :

```python
# Avant
choices_dict = dict(field.field.choices)  # clés = int
tag_data["placeholder"] = ", ".join(
    str(choices_dict[v]) for v in selected if v in choices_dict
    # → "1" in {1: …} == False → jointure vide
)
```

Le bouton du filtre affichait un texte vide au lieu des labels sélectionnés.

### Correction

Normaliser les deux côtés de la comparaison en `str` :

```python
# django_filters_custom_widget.py
str_values = {str(v) for v in value} if value else set()
checked = "checked" if str(option_value) in str_values else ""

# ui_tags.py
choices_dict = {str(k): v for k, v in field.field.choices}
tag_data["placeholder"] = ", ".join(
    str(choices_dict[str(v)]) for v in selected if str(v) in choices_dict
) or tag_data.get("default_placeholder", "")
```

La même correction existait déjà dans le tag `filter_placeholder` (lignes 56–58 de `ui_tags.py`), mais n'avait pas été appliquée aux deux endroits ci-dessus.