### PR TITLE
Correction du test flaky CollegueFactory + statut vide dans ProjetAdmin

### DIFF
--- a/gsl_core/tests/factories.py
+++ b/gsl_core/tests/factories.py
@@ -93,7 +93,7 @@ class CollegueFactory(factory.django.DjangoModelFactory):
         django_get_or_create = ("email",)
 
     username = factory.Sequence(lambda n: f"collegue_{n}")
-    email = factory.Faker("email")
+    email = factory.Sequence(lambda n: f"collegue_{n}@example.com")
     is_staff = False
     is_active = True
     perimetre = factory.SubFactory(PerimetreFactory)

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -132,7 +132,7 @@ class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
         return ", ".join(obj.dotations)
 
     def get_status_display(self, obj: Projet):
-        return dict(PROJET_STATUS_CHOICES)[obj.status]
+        return dict(PROJET_STATUS_CHOICES)[obj.status] if obj.status else None
 
     get_status_display.short_description = "Statut"
 


### PR DESCRIPTION
## 🌮 Objectif

Corriger un test flaky sur la vue `select-modele` et un crash potentiel dans l'admin des projets.

## 🔍 Liste des modifications

- **`gsl_core/tests/factories.py`** : `CollegueFactory.email` utilise désormais une `Sequence` (`collegue_N@example.com`) au lieu de `factory.Faker("email")`.
  Le test `test_associate_or_update_ds_profile_to_users_async_task` est marqué `transaction=True` et commit 3 Collegues en base. Faker ne génère qu'~9 800 emails distincts, donc après suffisamment de tests, un appel à `CollegueFactory(perimetre=X)` pouvait tomber sur un Collegue commité avec le même email. `django_get_or_create` retournait alors l'objet existant *sans* mettre à jour son périmètre → le projet devenait invisible → `get_object_or_404` levait Http404 → `KeyError: 'modeles_list'`.

- **`gsl_projet/admin.py`** : `get_status_display` retourne `None` si le statut est vide, au lieu de lever une `KeyError`.

## ⚠️ Informations supplémentaires

Le test flaky concerné : `test_get_select_modele_gives_correct_perimetre_and_dotation_modele[ModeleLettreNotificationFactory-lettre]`