### PR TITLE
Verrou anti-concurrence sur la synchronisation des dossiers DS

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -412,6 +412,18 @@ CELERY_RESULT_EXTENDED = True
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 100
 
+# Durée de vie max d'un verrou de synchronisation DS (secondes). Filet de
+# sécurité : si un worker meurt, le verrou est libéré au plus tard à l'expiration.
+# Chaque TTL doit rester supérieur à la durée réelle de la sync correspondante.
+#
+# Sync incrémentale (depuis le dernier curseur) : courte, peu de pages.
+DS_SYNC_LOCK_TIMEOUT = int(os.getenv("DS_SYNC_LOCK_TIMEOUT", 30 * 60))  # 30 min
+# Réinitialisation complète depuis une date passée (admin) : peut rejouer tout
+# l'historique de la démarche, donc bien plus longue.
+DS_INIT_SYNC_LOCK_TIMEOUT = int(
+    os.getenv("DS_INIT_SYNC_LOCK_TIMEOUT", 6 * 60 * 60)
+)  # 6 h
+
 
 # CSP Configuration
 

--- a/gsl_demarches_simplifiees/locks.py
+++ b/gsl_demarches_simplifiees/locks.py
@@ -1,0 +1,41 @@
+import logging
+from contextlib import contextmanager
+
+import redis
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def demarche_sync_lock(demarche_number, timeout):
+    """Verrou Redis non bloquant, par démarche, pour la sync des dossiers.
+
+    Yield True si le verrou a été acquis, False s'il est déjà détenu
+    (une autre sync de la même démarche tourne déjà).
+
+    `timeout` est le TTL (secondes) du verrou : court pour une sync
+    incrémentale depuis le dernier curseur, long pour une réinitialisation
+    complète qui repart d'une date passée. Les deux partagent la même clé,
+    donc s'excluent mutuellement quel que soit leur TTL.
+    """
+    client = redis.Redis.from_url(settings.CELERY_BROKER_URL)
+    lock = client.lock(
+        f"ds:demarche-sync:{demarche_number}",
+        timeout=timeout,
+    )
+    acquired = lock.acquire(blocking=False)
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                lock.release()
+            except redis.exceptions.LockError:
+                # Le TTL a expiré avant la fin de la sync : le verrou ne nous
+                # appartient plus. On laisse passer (try étroit, type ciblé).
+                logger.warning(
+                    "DS sync lock for demarche %s expired before release "
+                    "(sync longer than DS_SYNC_LOCK_TIMEOUT?)",
+                    demarche_number,
+                )

--- a/gsl_demarches_simplifiees/tasks.py
+++ b/gsl_demarches_simplifiees/tasks.py
@@ -1,6 +1,8 @@
+import logging
 from datetime import datetime
 
 from celery import shared_task
+from django.conf import settings
 from django.utils import timezone
 
 from gsl_demarches_simplifiees.importer.demarche import (
@@ -12,7 +14,10 @@ from gsl_demarches_simplifiees.importer.dossier import (
     save_demarche_dossiers_from_ds,
     save_one_dossier_from_ds,
 )
+from gsl_demarches_simplifiees.locks import demarche_sync_lock
 from gsl_demarches_simplifiees.models import Demarche, Dossier
+
+logger = logging.getLogger(__name__)
 
 
 ## Refresh demarches from DN
@@ -47,7 +52,16 @@ def task_fetch_new_or_modified_ds_dossiers_for_every_published_demarche():
 #### of one demarche — incremental sync
 @shared_task
 def task_save_demarche_dossiers_from_ds(demarche_number):
-    return save_demarche_dossiers_from_ds(demarche_number)
+    with demarche_sync_lock(
+        demarche_number, timeout=settings.DS_SYNC_LOCK_TIMEOUT
+    ) as acquired:
+        if not acquired:
+            logger.info(
+                "A DS sync is already running for demarche %s, skipping.",
+                demarche_number,
+            )
+            return
+        return save_demarche_dossiers_from_ds(demarche_number)
 
 
 #### init sync for one demarche from a given date
@@ -66,21 +80,30 @@ def task_init_demarche_sync(demarche_number, updated_since_iso: str):
     if timezone.is_naive(updated_since):
         updated_since = timezone.make_aware(updated_since)
 
-    demarche = Demarche.objects.get(ds_number=demarche_number)
-    demarche.updated_since = updated_since
-    demarche.sync_cursor = ""
-    demarche.pending_deleted_cursor = ""
-    demarche.deleted_cursor = ""
-    demarche.save(
-        update_fields=[
-            "updated_since",
-            "sync_cursor",
-            "pending_deleted_cursor",
-            "deleted_cursor",
-        ]
-    )
+    with demarche_sync_lock(
+        demarche_number, timeout=settings.DS_INIT_SYNC_LOCK_TIMEOUT
+    ) as acquired:
+        if not acquired:
+            logger.info(
+                "A DS sync is already running for demarche %s, skipping init.",
+                demarche_number,
+            )
+            return
+        demarche = Demarche.objects.get(ds_number=demarche_number)
+        demarche.updated_since = updated_since
+        demarche.sync_cursor = ""
+        demarche.pending_deleted_cursor = ""
+        demarche.deleted_cursor = ""
+        demarche.save(
+            update_fields=[
+                "updated_since",
+                "sync_cursor",
+                "pending_deleted_cursor",
+                "deleted_cursor",
+            ]
+        )
 
-    return save_demarche_dossiers_from_ds(demarche_number)
+        return save_demarche_dossiers_from_ds(demarche_number)
 
 
 #### of one dossier

--- a/gsl_demarches_simplifiees/tests/test_locks.py
+++ b/gsl_demarches_simplifiees/tests/test_locks.py
@@ -1,0 +1,127 @@
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.conf import settings
+
+from gsl_demarches_simplifiees.locks import demarche_sync_lock
+from gsl_demarches_simplifiees.tasks import (
+    task_init_demarche_sync,
+    task_save_demarche_dossiers_from_ds,
+)
+from gsl_demarches_simplifiees.tests.factories import DemarcheFactory
+
+
+@contextmanager
+def _fake_lock(acquired):
+    """Remplace demarche_sync_lock en yieldant la valeur voulue."""
+    yield acquired
+
+
+# --- task_save_demarche_dossiers_from_ds -----------------------------------
+
+
+@patch("gsl_demarches_simplifiees.tasks.save_demarche_dossiers_from_ds")
+@patch("gsl_demarches_simplifiees.tasks.demarche_sync_lock")
+def test_save_dossiers_skips_when_lock_held(mock_lock, mock_save):
+    mock_lock.return_value = _fake_lock(False)
+
+    result = task_save_demarche_dossiers_from_ds(123)
+
+    assert result is None
+    mock_save.assert_not_called()
+
+
+@patch("gsl_demarches_simplifiees.tasks.save_demarche_dossiers_from_ds")
+@patch("gsl_demarches_simplifiees.tasks.demarche_sync_lock")
+def test_save_dossiers_runs_when_lock_free(mock_lock, mock_save):
+    mock_lock.return_value = _fake_lock(True)
+    mock_save.return_value = "done"
+
+    result = task_save_demarche_dossiers_from_ds(123)
+
+    assert result == "done"
+    mock_save.assert_called_once_with(123)
+    mock_lock.assert_called_once_with(123, timeout=settings.DS_SYNC_LOCK_TIMEOUT)
+
+
+# --- task_init_demarche_sync -----------------------------------------------
+
+
+@pytest.mark.django_db
+@patch("gsl_demarches_simplifiees.tasks.save_demarche_dossiers_from_ds")
+@patch("gsl_demarches_simplifiees.tasks.demarche_sync_lock")
+def test_init_sync_skips_when_lock_held(mock_lock, mock_save):
+    mock_lock.return_value = _fake_lock(False)
+    demarche = DemarcheFactory(
+        sync_cursor="cursor-1",
+        pending_deleted_cursor="cursor-2",
+        deleted_cursor="cursor-3",
+    )
+
+    result = task_init_demarche_sync(demarche.ds_number, "2026-01-01T00:00:00Z")
+
+    assert result is None
+    mock_save.assert_not_called()
+    demarche.refresh_from_db()
+    assert demarche.sync_cursor == "cursor-1"
+    assert demarche.pending_deleted_cursor == "cursor-2"
+    assert demarche.deleted_cursor == "cursor-3"
+
+
+@pytest.mark.django_db
+@patch("gsl_demarches_simplifiees.tasks.save_demarche_dossiers_from_ds")
+@patch("gsl_demarches_simplifiees.tasks.demarche_sync_lock")
+def test_init_sync_resets_cursors_when_lock_free(mock_lock, mock_save):
+    mock_lock.return_value = _fake_lock(True)
+    mock_save.return_value = "done"
+    demarche = DemarcheFactory(
+        sync_cursor="cursor-1",
+        pending_deleted_cursor="cursor-2",
+        deleted_cursor="cursor-3",
+    )
+
+    result = task_init_demarche_sync(demarche.ds_number, "2026-01-01T00:00:00Z")
+
+    assert result == "done"
+    mock_save.assert_called_once_with(demarche.ds_number)
+    mock_lock.assert_called_once_with(
+        demarche.ds_number, timeout=settings.DS_INIT_SYNC_LOCK_TIMEOUT
+    )
+    demarche.refresh_from_db()
+    assert demarche.sync_cursor == ""
+    assert demarche.pending_deleted_cursor == ""
+    assert demarche.deleted_cursor == ""
+
+
+# --- demarche_sync_lock context manager ------------------------------------
+
+
+@patch("gsl_demarches_simplifiees.locks.redis.Redis.from_url")
+def test_lock_yields_true_and_releases_when_acquired(mock_from_url):
+    lock = MagicMock()
+    lock.acquire.return_value = True
+    client = MagicMock()
+    client.lock.return_value = lock
+    mock_from_url.return_value = client
+
+    with demarche_sync_lock(42, timeout=123) as acquired:
+        assert acquired is True
+
+    client.lock.assert_called_once_with("ds:demarche-sync:42", timeout=123)
+    lock.acquire.assert_called_once_with(blocking=False)
+    lock.release.assert_called_once()
+
+
+@patch("gsl_demarches_simplifiees.locks.redis.Redis.from_url")
+def test_lock_yields_false_and_does_not_release_when_held(mock_from_url):
+    lock = MagicMock()
+    lock.acquire.return_value = False
+    client = MagicMock()
+    client.lock.return_value = lock
+    mock_from_url.return_value = client
+
+    with demarche_sync_lock(42, timeout=123) as acquired:
+        assert acquired is False
+
+    lock.release.assert_not_called()


### PR DESCRIPTION
## 🌮 Objectif

Empêcher deux synchronisations concurrentes des dossiers d'une même démarche DS de tourner en même temps.

## 🔍 Liste des modifications

- Ajout d'un verrou Redis non bloquant par démarche (`gsl_demarches_simplifiees/locks.py`), via un context manager `demarche_sync_lock` qui yield `True` si le verrou est acquis, `False` s'il est déjà détenu.
- `task_save_demarche_dossiers_from_ds` (sync incrémentale) et `task_init_demarche_sync` (réinitialisation complète) sont désormais encadrées par ce verrou. Les deux partagent la même clé et s'excluent donc mutuellement ; si le verrou est déjà pris, la tâche logge et s'arrête sans rien faire.
- Deux TTL configurables ajoutés aux settings : `DS_SYNC_LOCK_TIMEOUT` (30 min) et `DS_INIT_SYNC_LOCK_TIMEOUT` (6 h). Ils servent de filet de sécurité : si un worker meurt, le verrou est libéré au plus tard à expiration.
- Tests couvrant le skip quand le verrou est détenu, l'exécution quand il est libre (y compris la non-réinitialisation des curseurs en cas de skip de l'init), et le comportement acquire/release du context manager.

## ⚠️ Informations supplémentaires

Les TTL sont surchargeables par variables d'environnement (`DS_SYNC_LOCK_TIMEOUT`, `DS_INIT_SYNC_LOCK_TIMEOUT`, en secondes). Chaque TTL doit rester supérieur à la durée réelle de la sync correspondante.
