### PR TITLE
Corrige la perte du curseur des dossiers supprimés sur les pages vides

### DIFF
--- a/gsl_demarches_simplifiees/importer/dossier.py
+++ b/gsl_demarches_simplifiees/importer/dossier.py
@@ -213,7 +213,10 @@ def _advance_stream(
 ) -> tuple[bool, str | None]:
     if result is None:
         return False, current_cursor
-    return result.has_more, result.cursor
+    # An empty connection returns endCursor=None (with hasNextPage=False); keep the
+    # cursor we already have instead of resetting the stream to the beginning.
+    next_cursor = current_cursor if result.cursor is None else result.cursor
+    return result.has_more, next_cursor
 
 
 def _save_cursors_after_page(

--- a/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
+++ b/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
@@ -221,6 +221,52 @@ def test_save_demarche_dossiers_from_ds_update_sync_cursor():
     assert demarche.sync_cursor == expected_cursor
 
 
+@pytest.mark.django_db
+def test_save_demarche_dossiers_from_ds_empty_deleted_page_keeps_cursor():
+    """
+    Quand un flux est déjà à jour, DS renvoie une page vide (nodes=[],
+    hasNextPage=False, endCursor=None). Le curseur existant doit être conservé,
+    pas réinitialisé à "" — sinon le flux repart du début à la synchro suivante et
+    redésactive tous les dossiers historiquement supprimés (symptôme « 1 synchro
+    sur 2 »).
+    """
+    demarche_number = 123
+    demarche = DemarcheFactory(
+        ds_number=demarche_number,
+        updated_since="2025-01-01T00:00:00+00:00",
+        sync_cursor="s1",
+        pending_deleted_cursor="p1",
+        deleted_cursor="d1",
+        raw_ds_data={"groupeInstructeurs": [{"id": "GROUPE-1", "instructeurs": []}]},
+    )
+
+    # Les trois flux renvoient une page vide (endCursor=None par défaut).
+    empty_page = _make_demarche_page()
+
+    with patch(
+        "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
+        return_value=(empty_page, False),
+    ):
+        save_demarche_dossiers_from_ds(demarche_number)
+
+    demarche.refresh_from_db()
+    assert demarche.sync_cursor == "s1"
+    assert demarche.pending_deleted_cursor == "p1"
+    assert demarche.deleted_cursor == "d1"
+
+    # Deuxième synchro consécutive : les curseurs restent stables (pas d'oscillation).
+    with patch(
+        "gsl_demarches_simplifiees.ds_client.DsClient.fetch_demarche_page",
+        return_value=(empty_page, False),
+    ):
+        save_demarche_dossiers_from_ds(demarche_number)
+
+    demarche.refresh_from_db()
+    assert demarche.sync_cursor == "s1"
+    assert demarche.pending_deleted_cursor == "p1"
+    assert demarche.deleted_cursor == "d1"
+
+
 def _ds_dossier(ds_id, number, departement_code="75"):
     return {
         "id": ds_id,


### PR DESCRIPTION
## 🌮 Objectif

Empêcher la resynchronisation complète des dossiers supprimés une synchro DS/DN sur deux.

## 🔍 Liste des modifications

- `_advance_stream` conserve désormais le curseur existant quand une page renvoie une connexion vide (`endCursor=null`), au lieu de le propager à `null`.
- Sans ce correctif, `_save_cursors_after_page` transformait ce `null` en `""`, et la synchro suivante relisait `""` comme « pas de curseur » et repartait du début du flux, redésactivant tous les dossiers précédemment supprimés (oscillation observée « 1 synchro sur 2 »).
- Ajout d'un test de non-régression `test_save_demarche_dossiers_from_ds_empty_deleted_page_keeps_cursor` (vérifie la stabilité des trois curseurs sur deux synchros consécutives avec des pages vides).

## ⚠️ Informations supplémentaires

C'est sûr car `endCursor=null` ne survient que pour une connexion vide, qui a toujours `hasNextPage=false` : le flux s'arrête sur la même itération et le curseur conservé est le bon point de reprise. Aucune modification de modèle, migration, requête `.gql` ou `DsClient` n'est nécessaire.
