### PR TITLE
Corrige l'erreur de manifest staticfiles sur l'importmap

### DIFF
--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -54,7 +54,6 @@
                     "modeleArreteForm": "{% static 'js/modeleArreteForm.js' %}",
                     "deleteNotificationDocumentModal": "{% static 'js/deleteNotificationDocumentModal.js' %}",
                     "qrCodeToggle": "{% static 'js/qrCodeToggle.js' %}",
-                    "chooseDocumentType": "{% static 'js/chooseDocumentType.js' %}",
                     "checkboxSelection": "{% static 'js/checkboxSelection.js' %}",
                     "bindAmountFields": "{% static 'js/controllers/bindAmountTields.js' %}",
                     "formUtils": "{% static 'js/controllers/formUtils.js' %}",


### PR DESCRIPTION
## 🌮 Objectif

Corrige l'erreur `Missing staticfiles manifest entry for 'js/chooseDocumentType.js'` apparue en production.

## 🔍 Liste des modifications

- Suppression de l'entrée `chooseDocumentType` de l'importmap dans `base.html` : le fichier `js/chooseDocumentType.js` a été supprimé mais sa référence dans l'importmap n'avait pas été nettoyée. Depuis le passage de l'importmap au tag `{% static %}`, `ManifestStaticFilesStorage` lève une erreur en production car le fichier n'existe plus. Aucun module n'importe `chooseDocumentType`.