### PR TITLE
Affiche le périmètre, les dates Turgot et le report dans l'admin

### DIFF
--- a/gsl_demarches_simplifiees/admin.py
+++ b/gsl_demarches_simplifiees/admin.py
@@ -5,6 +5,7 @@ from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.csp import CSP
 from django.utils.decorators import method_decorator
+from django.utils.formats import date_format
 from django.utils.safestring import mark_safe
 from django_json_widget.widgets import JSONEditorWidget
 from import_export.admin import ImportExportMixin
@@ -313,6 +314,7 @@ class DossierAdmin(AllPermsForStaffUser, admin.ModelAdmin):
                     "is_active",
                     "raison_desactivation",
                     "ds_demandeur",
+                    "perimetre",
                     "admin_projet_link",
                     "app_projet_link",
                     "link_to_ds",
@@ -346,6 +348,8 @@ class DossierAdmin(AllPermsForStaffUser, admin.ModelAdmin):
                     "ds_date_traitement",
                     "ds_date_derniere_modification",
                     "ds_date_derniere_modification_champs",
+                    "turgot_created_at",
+                    "turgot_updated_at",
                 ),
             },
         ),
@@ -376,7 +380,17 @@ class DossierAdmin(AllPermsForStaffUser, admin.ModelAdmin):
         "link_to_ds",
         "link_to_json",
         "link_to_edit_dossier_data",
+        "turgot_created_at",
+        "turgot_updated_at",
     ]
+
+    @admin.display(description="Import dans Turgot")
+    def turgot_created_at(self, obj: Dossier):
+        return date_format(timezone.localtime(obj.created_at), "DATETIME_FORMAT")
+
+    @admin.display(description="Dernière synchro dans Turgot")
+    def turgot_updated_at(self, obj: Dossier):
+        return date_format(timezone.localtime(obj.updated_at), "DATETIME_FORMAT")
 
     def get_urls(self):
         urls = super().get_urls()

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -75,6 +75,7 @@ class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
         "get_status_display",
         "dossier_departement",
         "dotations",
+        "notified_at",
     )
     list_filter = (
         "dossier_ds__is_active",
@@ -87,7 +88,7 @@ class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
         DotationProjetInline,
     ]
     search_fields = ("dossier_ds__ds_number", "dossier_ds__projet_intitule")
-    readonly_fields = ("created_at", "updated_at")
+    readonly_fields = ("created_at", "updated_at", "perimetre", "reporte")
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
@@ -143,6 +144,17 @@ class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
     dossier_departement.admin_order_field = (
         "dossier_ds__perimetre__departement__insee_code"
     )
+
+    def reporte(self, obj: Projet):
+        return obj.dossier_ds.demande_renouvellement or None
+
+    reporte.short_description = "Report / Renouvellement"
+    reporte.admin_order_field = "dossier_ds__demande_renouvellement"
+
+    def perimetre(self, obj: Projet):
+        return obj.perimetre
+
+    perimetre.short_description = "Périmètre"
 
 
 class SimulationProjetInline(admin.TabularInline):


### PR DESCRIPTION
## 🌮 Objectif

Exposer dans l'admin Django des métadonnées utiles sur les dossiers et les projets.

## 🔍 Liste des modifications

- Admin Dossier (`DossierAdmin`) :
  - affichage du périmètre
  - ajout de deux champs en lecture seule avec les dates localisées d'import dans Turgot (`turgot_created_at`) et de dernière synchronisation (`turgot_updated_at`)
- Admin Projet (`ProjetAdmin`) :
  - ajout de la date de notification (`notified_at`) dans la liste
  - exposition du périmètre et du statut de report / renouvellement (`reporte`) en lecture seule