### PR TITLE
Priorise les tâches Celery selon le contexte d'appel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,6 +418,27 @@ Run with: `python -m celery --app gsl worker --beat --scheduler django_celery_be
 
 Or use `just run-celery`.
 
+#### Task priorities
+
+Priority is decided **at the dispatch site**, not baked into the task — the same
+task can be high or low depending on context. Constants and helper live in
+`gsl/celery.py` (Redis: lower number = served first): `TASK_PRIORITY_HIGH = 0`,
+`TASK_PRIORITY_NORMAL = 5` (= `CELERY_TASK_DEFAULT_PRIORITY`),
+`TASK_PRIORITY_LOW = 9`, `TASK_BULK_DISPATCH_THRESHOLD = 10`.
+
+- **High (0)** — short non-blocking task, including a small interactive batch
+  (count < 10), admin or not.
+- **Normal (5, default)** — long task that blocks the agent waiting on it, or a
+  moderate count. Use plain `.delay()` (no override).
+- **Low (9)** — long admin task, or a high count (≥ 10: batch wrappers and their
+  children, sync fan-out).
+
+Sites dispatched both per-unit and en masse: use `priority_for_dispatch_count(count)`
+(high if `< 10` else low). If the dispatch lives in a shared helper reached by
+several contexts, thread the priority down as a parameter per entry point instead
+of hardcoding it (see `_save_dossier_data_and_refresh_dossier_and_projet_and_co`'s
+`refresh_priority`).
+
 ## Coding Conventions
 
 ### General

--- a/gsl/celery.py
+++ b/gsl/celery.py
@@ -11,3 +11,21 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gsl.settings")
 app = Celery("gsl")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
+
+# Niveaux de priorité des tâches Celery (Redis: plus le nombre est bas, plus la
+# tâche est servie tôt). La priorité par défaut de la file est définie dans les
+# settings via CELERY_TASK_DEFAULT_PRIORITY (= TASK_PRIORITY_NORMAL).
+TASK_PRIORITY_HIGH = 0
+TASK_PRIORITY_NORMAL = 5
+TASK_PRIORITY_LOW = 9
+# Au-delà de ce nombre d'éléments, un dispatch est considéré "de masse" → priorité basse
+TASK_BULK_DISPATCH_THRESHOLD = 10
+
+
+def priority_for_dispatch_count(count):
+    """Priorité haute pour un petit lot interactif (< seuil), basse au-delà."""
+    return (
+        TASK_PRIORITY_HIGH
+        if count < TASK_BULK_DISPATCH_THRESHOLD
+        else TASK_PRIORITY_LOW
+    )

--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -412,6 +412,11 @@ CELERY_RESULT_BACKEND = "django-db"
 CELERY_RESULT_EXTENDED = True
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 100
+CELERY_BROKER_TRANSPORT_OPTIONS = {"queue_order_strategy": "priority"}
+CELERY_TASK_QUEUE_MAX_PRIORITY = 10
+# Redis: 0 = servi en premier. 5 = priorité normale par défaut (cf. TASK_PRIORITY_* dans gsl.celery)
+CELERY_TASK_DEFAULT_PRIORITY = 5
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 
 # Durée de vie max d'un verrou de synchronisation DS (secondes). Filet de
 # sécurité : si un worker meurt, le verrou est libéré au plus tard à l'expiration.

--- a/gsl_demarches_simplifiees/admin.py
+++ b/gsl_demarches_simplifiees/admin.py
@@ -10,6 +10,7 @@ from django.utils.safestring import mark_safe
 from django_json_widget.widgets import JSONEditorWidget
 from import_export.admin import ImportExportMixin
 
+from gsl.celery import TASK_PRIORITY_LOW, priority_for_dispatch_count
 from gsl.utils.csp import csp_update
 from gsl_core.admin import AllPermsForStaffUser
 from gsl_core.models import Arrondissement
@@ -211,9 +212,9 @@ class DemarcheAdmin(AllPermsForStaffUser, admin.ModelAdmin):
             if form.is_valid():
                 demarche = form.cleaned_data["demarche"]
                 updated_after = form.cleaned_data["updated_after"]
-                task_init_demarche_sync.delay(
-                    demarche.ds_number,
-                    updated_after.isoformat(),
+                task_init_demarche_sync.apply_async(
+                    (demarche.ds_number, updated_after.isoformat()),
+                    priority=TASK_PRIORITY_LOW,
                 )
                 self.message_user(
                     request,
@@ -437,8 +438,12 @@ class DossierAdmin(AllPermsForStaffUser, admin.ModelAdmin):
         if queryset.count() == 1:
             refresh_dossier_from_saved_data(queryset.get())
         else:
+            count = queryset.count()
             for dossier in queryset:
-                task_refresh_dossier_from_saved_data.delay(dossier.ds_number)
+                task_refresh_dossier_from_saved_data.apply_async(
+                    (dossier.ds_number,),
+                    priority=priority_for_dispatch_count(count),
+                )
 
     @admin.action(description="☁️ Rafraîchir depuis DN")
     def refresh_from_ds(self, request, queryset):
@@ -456,8 +461,12 @@ class DossierAdmin(AllPermsForStaffUser, admin.ModelAdmin):
                 )
 
         else:
+            count = queryset.count()
             for dossier in queryset:
-                task_save_one_dossier_from_ds.delay(dossier.ds_number)
+                task_save_one_dossier_from_ds.apply_async(
+                    (dossier.ds_number,),
+                    priority=priority_for_dispatch_count(count),
+                )
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)

--- a/gsl_demarches_simplifiees/importer/dossier.py
+++ b/gsl_demarches_simplifiees/importer/dossier.py
@@ -4,6 +4,7 @@ from typing import Iterable, NamedTuple
 from django.contrib import messages
 from django.utils import timezone
 
+from gsl.celery import TASK_PRIORITY_HIGH, TASK_PRIORITY_LOW
 from gsl_core.models import Departement
 from gsl_demarches_simplifiees.ds_client import DsClient
 from gsl_demarches_simplifiees.exceptions import DsServiceException
@@ -350,8 +351,12 @@ def import_one_dossier_from_ds(dossier_number: int):
             f"Le dossier #{dossier_number} appartient au territoire « {departement} » qui n'est pas géré sur Turgot.",
         )
 
+    # Import interactif d'un seul dossier (admin) : le refresh associé doit
+    # passer devant la sync de fond, d'où la priorité haute.
     _create_or_update_dossier_from_ds_data(
-        dossier_data, handled_departement_insee_codes
+        dossier_data,
+        handled_departement_insee_codes,
+        refresh_priority=TASK_PRIORITY_HIGH,
     )
     return (
         messages.SUCCESS,
@@ -481,6 +486,7 @@ def _save_dossier_data_and_refresh_dossier_and_projet_and_co(
     async_refresh: bool = False,
     refresh_only_if_dossier_has_been_updated: bool = True,
     groupe_index: dict | None = None,
+    refresh_priority: int = TASK_PRIORITY_LOW,
 ):
     if refresh_only_if_dossier_has_been_updated:
         must_refresh_dossier = _has_dossier_been_updated_on_ds(dossier, dossier_data)
@@ -501,7 +507,9 @@ def _save_dossier_data_and_refresh_dossier_and_projet_and_co(
                 task_refresh_dossier_from_saved_data,
             )
 
-            task_refresh_dossier_from_saved_data.delay(dossier.ds_number)
+            task_refresh_dossier_from_saved_data.apply_async(
+                (dossier.ds_number,), priority=refresh_priority
+            )
         else:
             refresh_dossier_from_saved_data(dossier)
 
@@ -539,6 +547,7 @@ def _create_or_update_dossier_from_ds_data(
     handled_departement_insee_codes: Iterable[str],
     demarche: Demarche | None = None,
     groupe_index: dict | None = None,
+    refresh_priority: int = TASK_PRIORITY_LOW,
 ):
     ds_id = dossier_data["id"]
     ds_dossier_number = dossier_data["number"]
@@ -575,6 +584,7 @@ def _create_or_update_dossier_from_ds_data(
         async_refresh=True,
         refresh_only_if_dossier_has_been_updated=False,
         groupe_index=groupe_index,
+        refresh_priority=refresh_priority,
     )
 
 

--- a/gsl_demarches_simplifiees/tasks.py
+++ b/gsl_demarches_simplifiees/tasks.py
@@ -5,6 +5,7 @@ from celery import shared_task
 from django.conf import settings
 from django.utils import timezone
 
+from gsl.celery import priority_for_dispatch_count
 from gsl_demarches_simplifiees.importer.demarche import (
     refresh_field_mappings_on_demarche,
     save_demarche_from_ds,
@@ -24,9 +25,12 @@ logger = logging.getLogger(__name__)
 #### of every demarches => useful in cron tasks !
 @shared_task
 def task_refresh_every_demarche(refresh_only_if_demarche_has_been_updated=True):
-    for d in Demarche.objects.all():
-        task_save_demarche_from_ds.delay(
-            d.ds_number, refresh_only_if_demarche_has_been_updated
+    demarches = list(Demarche.objects.all())
+    priority = priority_for_dispatch_count(len(demarches))
+    for d in demarches:
+        task_save_demarche_from_ds.apply_async(
+            (d.ds_number, refresh_only_if_demarche_has_been_updated),
+            priority=priority,
         )
 
 

--- a/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
+++ b/gsl_demarches_simplifiees/tests/importer/test_dossier_importer.py
@@ -541,12 +541,12 @@ def test_save_dossier_data_and_refresh_dossier_and_projet_and_co_calls_async_tas
     ds_data = {"dateDerniereModification": "2025-01-01T12:00:00+02:00"}
 
     with patch(
-        "gsl_demarches_simplifiees.tasks.task_refresh_dossier_from_saved_data.delay"
+        "gsl_demarches_simplifiees.tasks.task_refresh_dossier_from_saved_data.apply_async"
     ) as target_task:
         _save_dossier_data_and_refresh_dossier_and_projet_and_co(
             dossier, ds_data, async_refresh=True
         )
-        target_task.assert_called_once_with(dossier.ds_number)
+        target_task.assert_called_once_with((dossier.ds_number,), priority=9)
 
 
 @pytest.mark.django_db
@@ -962,6 +962,8 @@ def test_import_one_dossier_from_ds_cree_le_dossier():
     assert level == messages.SUCCESS
     assert "20240001" in message
     mock_refresh.assert_called_once()
+    # Import interactif d'un seul dossier : le refresh doit être prioritaire.
+    assert mock_refresh.call_args.kwargs["refresh_priority"] == 0
 
 
 # tests _save_cursors_after_page

--- a/gsl_demarches_simplifiees/tests/test_admin.py
+++ b/gsl_demarches_simplifiees/tests/test_admin.py
@@ -1,0 +1,73 @@
+from unittest import mock
+
+import pytest
+from django.contrib import admin
+
+from gsl_demarches_simplifiees.admin import DossierAdmin
+from gsl_demarches_simplifiees.models import Dossier
+from gsl_demarches_simplifiees.tests.factories import DossierFactory
+
+
+@pytest.fixture
+def dossier_admin():
+    return DossierAdmin(Dossier, admin.site)
+
+
+@pytest.mark.django_db
+def test_refresh_from_db_small_queryset_uses_high_priority(dossier_admin, rf):
+    DossierFactory.create_batch(3)
+    queryset = Dossier.objects.all()
+
+    with mock.patch(
+        "gsl_demarches_simplifiees.admin.task_refresh_dossier_from_saved_data.apply_async"
+    ) as mock_apply:
+        dossier_admin.refresh_from_db(rf.get("/"), queryset)
+
+    assert mock_apply.call_count == 3
+    for call in mock_apply.call_args_list:
+        assert call.kwargs["priority"] == 0
+
+
+@pytest.mark.django_db
+def test_refresh_from_db_mass_queryset_uses_low_priority(dossier_admin, rf):
+    DossierFactory.create_batch(10)
+    queryset = Dossier.objects.all()
+
+    with mock.patch(
+        "gsl_demarches_simplifiees.admin.task_refresh_dossier_from_saved_data.apply_async"
+    ) as mock_apply:
+        dossier_admin.refresh_from_db(rf.get("/"), queryset)
+
+    assert mock_apply.call_count == 10
+    for call in mock_apply.call_args_list:
+        assert call.kwargs["priority"] == 9
+
+
+@pytest.mark.django_db
+def test_refresh_from_ds_small_queryset_uses_high_priority(dossier_admin, rf):
+    DossierFactory.create_batch(3)
+    queryset = Dossier.objects.all()
+
+    with mock.patch(
+        "gsl_demarches_simplifiees.admin.task_save_one_dossier_from_ds.apply_async"
+    ) as mock_apply:
+        dossier_admin.refresh_from_ds(rf.get("/"), queryset)
+
+    assert mock_apply.call_count == 3
+    for call in mock_apply.call_args_list:
+        assert call.kwargs["priority"] == 0
+
+
+@pytest.mark.django_db
+def test_refresh_from_ds_mass_queryset_uses_low_priority(dossier_admin, rf):
+    DossierFactory.create_batch(10)
+    queryset = Dossier.objects.all()
+
+    with mock.patch(
+        "gsl_demarches_simplifiees.admin.task_save_one_dossier_from_ds.apply_async"
+    ) as mock_apply:
+        dossier_admin.refresh_from_ds(rf.get("/"), queryset)
+
+    assert mock_apply.call_count == 10
+    for call in mock_apply.call_args_list:
+        assert call.kwargs["priority"] == 9

--- a/gsl_demarches_simplifiees/tests/test_tasks.py
+++ b/gsl_demarches_simplifiees/tests/test_tasks.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+import pytest
+
+from gsl_demarches_simplifiees.tasks import task_refresh_every_demarche
+from gsl_demarches_simplifiees.tests.factories import DemarcheFactory
+
+
+@pytest.mark.django_db
+def test_refresh_every_demarche_uses_high_priority_for_small_batch():
+    DemarcheFactory.create_batch(3)
+
+    with mock.patch(
+        "gsl_demarches_simplifiees.tasks.task_save_demarche_from_ds.apply_async"
+    ) as mock_apply:
+        task_refresh_every_demarche()
+
+    assert mock_apply.call_count == 3
+    for call in mock_apply.call_args_list:
+        assert call.kwargs["priority"] == 0
+
+
+@pytest.mark.django_db
+def test_refresh_every_demarche_uses_low_priority_for_mass_batch():
+    DemarcheFactory.create_batch(10)
+
+    with mock.patch(
+        "gsl_demarches_simplifiees.tasks.task_save_demarche_from_ds.apply_async"
+    ) as mock_apply:
+        task_refresh_every_demarche()
+
+    assert mock_apply.call_count == 10
+    for call in mock_apply.call_args_list:
+        assert call.kwargs["priority"] == 9

--- a/gsl_notification/forms.py
+++ b/gsl_notification/forms.py
@@ -89,6 +89,9 @@ class ImportJobStartForm(forms.Form):
             s3_keys=self.cleaned_data["s3_keys"],
             remove_qr_code=self.cleaned_data["remove_qr_code"],
         )
+        # Tâche longue, déclenchée par un agent qui attend le résultat : priorité
+        # normale (défaut). La passer en haute la ferait bloquer le worker unique
+        # devant les tâches courtes non bloquantes.
         run_document_import_job.delay(str(job.pk))
         return job
 

--- a/gsl_projet/admin.py
+++ b/gsl_projet/admin.py
@@ -108,11 +108,14 @@ class ProjetAdmin(AllPermsForStaffUser, admin.ModelAdmin):
 
     @admin.action(description="Rafraîchir depuis le dossier DN")
     def refresh_from_dossier(self, request, queryset):
+        from gsl.celery import priority_for_dispatch_count
         from gsl_projet.tasks import task_create_or_update_projet_and_co_from_dossier
 
+        count = queryset.count()
         for projet in queryset.select_related("dossier_ds"):
-            task_create_or_update_projet_and_co_from_dossier.delay(
-                projet.dossier_ds.ds_number
+            task_create_or_update_projet_and_co_from_dossier.apply_async(
+                (projet.dossier_ds.ds_number,),
+                priority=priority_for_dispatch_count(count),
             )
 
     def get_deleted_objects(self, objs, request):

--- a/gsl_projet/tasks.py
+++ b/gsl_projet/tasks.py
@@ -2,6 +2,7 @@ from itertools import batched
 
 from celery import shared_task
 
+from gsl.celery import TASK_PRIORITY_LOW
 from gsl_demarches_simplifiees.models import Dossier
 from gsl_projet.models import Projet
 from gsl_projet.services.dotation_projet_services import DotationProjetService
@@ -22,14 +23,18 @@ def task_create_or_update_projets_and_co_from_all_dossiers(
     )
 
     for batch in batched(dossiers, batch_size):
-        task_create_or_update_projets_and_co_batch.delay(batch)
+        task_create_or_update_projets_and_co_batch.apply_async(
+            (batch,), priority=TASK_PRIORITY_LOW
+        )
 
 
 ### for a list
 @shared_task
 def task_create_or_update_projets_and_co_batch(dossier_numbers: tuple[int]):
     for ds_number in dossier_numbers:
-        task_create_or_update_projet_and_co_from_dossier.delay(ds_number)
+        task_create_or_update_projet_and_co_from_dossier.apply_async(
+            (ds_number,), priority=TASK_PRIORITY_LOW
+        )
 
 
 ### for one
@@ -46,7 +51,9 @@ def task_create_or_update_projet_and_co_from_dossier(
 def task_create_or_update_dotation_projets_from_all_projets(batch_size=500):
     projets = Projet.objects.active().all().values_list("pk", flat=True)
     for batch in batched(projets, batch_size):
-        task_create_or_update_dotation_projets_from_projet_batch.delay(batch)
+        task_create_or_update_dotation_projets_from_projet_batch.apply_async(
+            (batch,), priority=TASK_PRIORITY_LOW
+        )
 
 
 ### for a list
@@ -55,7 +62,9 @@ def task_create_or_update_dotation_projets_from_projet_batch(
     dossier_numbers: tuple[int],
 ):
     for ds_number in dossier_numbers:
-        task_create_or_update_dotation_projet_from_projet.delay(ds_number)
+        task_create_or_update_dotation_projet_from_projet.apply_async(
+            (ds_number,), priority=TASK_PRIORITY_LOW
+        )
 
 
 ### for one

--- a/gsl_projet/tests/test_tasks.py
+++ b/gsl_projet/tests/test_tasks.py
@@ -23,6 +23,7 @@ from gsl_projet.constants import (
 )
 from gsl_projet.models import DotationProjet
 from gsl_projet.tasks import (
+    task_create_or_update_dotation_projets_from_projet_batch,
     task_create_or_update_projet_and_co_from_dossier,
     task_create_or_update_projets_and_co_batch,
     task_create_or_update_projets_and_co_from_all_dossiers,
@@ -478,20 +479,24 @@ def test_create_or_update_projets_and_its_simulation_and_programmation_projets_f
         DossierFactory(ds_number=i, ds_state="state")
 
     with mock.patch(
-        "gsl_projet.tasks.task_create_or_update_projets_and_co_batch.delay"
+        "gsl_projet.tasks.task_create_or_update_projets_and_co_batch.apply_async"
     ) as mock_create_or_update_projets_batch:
         task_create_or_update_projets_and_co_from_all_dossiers(batch_size=5)
 
         assert mock_create_or_update_projets_batch.call_count == 2
 
-        mock_create_or_update_projets_batch.assert_any_call((0, 1, 2, 3, 4))
-        mock_create_or_update_projets_batch.assert_any_call((5, 6, 7, 8, 9))
+        mock_create_or_update_projets_batch.assert_any_call(
+            ((0, 1, 2, 3, 4),), priority=9
+        )
+        mock_create_or_update_projets_batch.assert_any_call(
+            ((5, 6, 7, 8, 9),), priority=9
+        )
 
 
 @pytest.mark.django_db
 def test_create_or_update_projets_and_its_simulation_and_programmation_projets_from_all_dossiers_with_no_dossiers():
     with mock.patch(
-        "gsl_projet.tasks.task_create_or_update_projets_and_co_batch.delay"
+        "gsl_projet.tasks.task_create_or_update_projets_and_co_batch.apply_async"
     ) as mock_delay:
         task_create_or_update_projets_and_co_from_all_dossiers(batch_size=5)
 
@@ -501,11 +506,24 @@ def test_create_or_update_projets_and_its_simulation_and_programmation_projets_f
 @pytest.mark.django_db
 def test_create_or_update_projets_batch():
     with mock.patch(
-        "gsl_projet.tasks.task_create_or_update_projet_and_co_from_dossier.delay"
+        "gsl_projet.tasks.task_create_or_update_projet_and_co_from_dossier.apply_async"
     ) as mock_delay:
         task_create_or_update_projets_and_co_batch((1, 2, 3))
         assert mock_delay.call_count == 3
 
-        mock_delay.assert_any_call(1)
-        mock_delay.assert_any_call(2)
-        mock_delay.assert_any_call(3)
+        mock_delay.assert_any_call((1,), priority=9)
+        mock_delay.assert_any_call((2,), priority=9)
+        mock_delay.assert_any_call((3,), priority=9)
+
+
+@pytest.mark.django_db
+def test_create_or_update_dotation_projets_batch():
+    with mock.patch(
+        "gsl_projet.tasks.task_create_or_update_dotation_projet_from_projet.apply_async"
+    ) as mock_delay:
+        task_create_or_update_dotation_projets_from_projet_batch((1, 2, 3))
+        assert mock_delay.call_count == 3
+
+        mock_delay.assert_any_call((1,), priority=9)
+        mock_delay.assert_any_call((2,), priority=9)
+        mock_delay.assert_any_call((3,), priority=9)

--- a/gsl_simulation/views/bulk_status_job_views.py
+++ b/gsl_simulation/views/bulk_status_job_views.py
@@ -75,6 +75,9 @@ class BulkStatusJobStartView(CreateView):
             # an active job for the same simulation between our check and save.
             # The DB-level partial unique constraint catches the duplicate.
             return self._render_already_running()
+        # Tâche longue, déclenchée par un agent qui en attend le résultat :
+        # priorité normale (défaut). En haute, elle bloquerait le worker unique
+        # devant les tâches courtes non bloquantes.
         run_bulk_status_job.delay(str(job.pk))
 
         queue_matomo_event(


### PR DESCRIPTION
## 🌮 Objectif

Prioriser les tâches Celery selon le contexte d'appel pour que les actions courtes passent devant les traitements de fond.

## 🔍 Liste des modifications

- Active la gestion des priorités Redis sur la file par défaut, passe la priorité par défaut à 5 (normale), garde `worker_prefetch_multiplier=1` pour qu'elle soit respectée
- Ajoute les constantes `TASK_PRIORITY_HIGH/NORMAL/LOW` et le helper `priority_for_dispatch_count` dans `gsl/celery.py`
- Applique un schéma à 3 niveaux décidé **au site de dispatch** (une même tâche peut être haute ou basse selon le contexte) :
  - **Haute (0)** : tâche courte non bloquante, y compris petit lot interactif (< 10), admin ou non (import d'un dossier, refresh admin de < 10 dossiers/projets, refresh de < 10 démarches)
  - **Normale (5, défaut)** : tâche longue qui bloque l'agent (`run_document_import_job`, `run_bulk_status_job`) ou compte modéré
  - **Basse (9)** : tâche admin longue (`task_init_demarche_sync`) et fan-out de masse (≥ 10 : wrappers de batch et leurs enfants, sous-tâches de sync par dossier)
- Threade la priorité en paramètre dans le helper partagé `_save_dossier_data_and_refresh_dossier_and_projet_and_co` au lieu de la coder en dur
- Documente le schéma dans `AGENTS.md`, ajoute/adapte les tests

## ⚠️ Informations supplémentaires

Côté Redis, un numéro plus bas est servi en premier (0 = max). La priorité dépend du contexte d'appel, pas de la tâche.
