### PR TITLE
Masquer la colonne actions et améliorer l'affichage du tableau des enveloppes

### DIFF
--- a/gsl_core/templates/includes/_enveloppe_summary.html
+++ b/gsl_core/templates/includes/_enveloppe_summary.html
@@ -40,17 +40,7 @@
                                     </div>
                                 </div>
                             </th>
-                            <th>
-                                <div>
-                                    <div class="icon">
-                                        <span class="fr-icon-map-pin-2-fill fr-icon--sm"></span>
-                                    </div>
-                                    <div class="text">
-                                        Nom territoire
-                                    </div>
-                                </div>
-                            </th>
-                            <th>
+                            <th class="col--130px">
                                 <div>
                                     <div class="icon">
                                         <span class="fr-icon-coin-fill fr-icon--sm"></span>
@@ -60,7 +50,7 @@
                                     </div>
                                 </div>
                             </th>
-                            <th>
+                            <th class="col--130px">
                                 <div>
                                     <div class="icon">
                                         <span class="fr-icon-coin-fill fr-icon--sm"></span>
@@ -77,6 +67,16 @@
                                     </div>
                                     <div class="text">
                                         Montant accepté
+                                    </div>
+                                </div>
+                            </th>
+                            <th>
+                                <div>
+                                    <div class="icon">
+                                        <span class="fr-icon-scales-3-fill fr-icon--sm"></span>
+                                    </div>
+                                    <div class="text">
+                                        Reste à attribuer
                                     </div>
                                 </div>
                             </th>
@@ -103,7 +103,7 @@
                             <th>
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-folder-2-fill fr-icon--sm"></span>
+                                        <span class="fr-icon-account-circle-fill fr-icon--sm"></span>
                                     </div>
                                     <div class="text">
                                         Demandeurs
@@ -120,21 +120,22 @@
                                     </div>
                                 </div>
                             </th>
-                            <th>
-                            </th>
+                            {% if not hide_actions %}
+                                <th>
+                                </th>
+                            {% endif %}
                         </tr>
                     </thead>
                     <tbody>
                         {% for enveloppe in enveloppes %}
-                            {% include "includes/_enveloppe_summary_line.html" with level=1 %}
+                            {% include "includes/_enveloppe_summary_line.html" with level=1 hide_actions=hide_actions %}
                             {% if enveloppes_with_children %}
                                 {% for sous_enveloppe in enveloppe.ordered_sous_enveloppes %}
-                                    {% include "includes/_enveloppe_summary_line.html" with enveloppe=sous_enveloppe level=2 %}
-
+                                    {% include "includes/_enveloppe_summary_line.html" with enveloppe=sous_enveloppe level=2 hide_actions=hide_actions %}
                                 {% endfor %}
                             {% endif %}
                         {% empty %}
-                            {% include "includes/_enveloppe_summary_line.html" %}
+                            {% include "includes/_enveloppe_summary_line.html" with hide_actions=hide_actions %}
                         {% endfor %}
                     </tbody>
                 </table>

--- a/gsl_core/templates/includes/_enveloppe_summary_line.html
+++ b/gsl_core/templates/includes/_enveloppe_summary_line.html
@@ -4,113 +4,114 @@
     {% if oob_swap %}hx-swap-oob="outerHTML"{% endif %}
     class="{% if level == 2 %}sous-enveloppe{% else %}fr-text--bold{% endif %}">
     <td>
-        {% if enveloppe.is_deleguee %}
-            <div class="sub">
-            </div>
+        {% if level == 2 %}
+            <i class="fr-icon-corner-down-right-fill" aria-hidden="true"></i>
         {% endif %}
         <b>{{ enveloppe.dotation }}</b>
     </td>
     <td>
-        {{ enveloppe.perimetre.type }}
+        {{ enveloppe.perimetre.type|perimetre_type_abbrev }} {{ enveloppe.perimetre.entity_name }}
     </td>
-    <td>
-        {{ enveloppe.perimetre.entity_name }}
-    </td>
-    <td>
+    <td class="align-right">
         {{ enveloppe.montant | euro }}
     </td>
-    <td class="color-green-archipel">
+    <td class="color-green-archipel align-right">
         {{ enveloppe.montant_asked | euro }}
     </td>
-    <td class="color-green-bourgeon">
+    <td class="color-green-bourgeon align-right">
         {{ enveloppe.accepted_montant | euro }}
     </td>
-    <td class="color-success fr-text--sm">
+    <td class="align-right">
+        {{ enveloppe.reste_a_attribuer | euro }}
+    </td>
+    <td class="color-success fr-text--sm align-center">
         {{ enveloppe.validated_projets_count }}
     </td>
-    <td class="color-error fr-text--sm">
+    <td class="color-error fr-text--sm align-center">
         {{ enveloppe.refused_projets_count }}
     </td>
-    <td class="color-blue fr-text--sm">
+    <td class="fr-text--sm align-center">
         {{ enveloppe.demandeurs_count }}
     </td>
-    <td class="color-blue fr-text--sm">
+    <td class="fr-text--sm align-center">
         {{ enveloppe.projets_count }}
     </td>
-    <td class="fr-text--sm">
-        {% if enveloppe.is_deleguee %}
-            <div class="fr-nav fr-translate">
-                <div class="fr-nav__item">
-                    <button class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-icon-more-line"
-                            aria-controls="enveloppe-menu-{{ enveloppe.id }}"
-                            aria-expanded="false"
-                            aria-label="Modifier ou supprimer">
-                    </button>
-                    <div class="fr-menu fr-collapse" id="enveloppe-menu-{{ enveloppe.id }}">
-                        <ul class="fr-menu__list">
-                            <li>
-                                <a class="fr-nav__link fr-icon-settings-5-fill fr-icon--sm"
-                                   href="{% url 'gsl_projet:enveloppe-update' enveloppe.id %}">Modifier</a>
-                            </li>
-                            <li>
-                                <button class="fr-nav__link fr-icon-delete-bin-fill fr-icon--sm"
-                                        aria-controls="enveloppe-delete-modal-{{ enveloppe.id }}"
-                                        type="button"
-                                        data-fr-opened="false">
-                                    Supprimer
-                                </button>
-                            </li>
-                        </ul>
+    {% if not hide_actions %}
+        <td class="fr-text--sm">
+            {% if enveloppe.is_deleguee %}
+                <div class="fr-nav fr-translate">
+                    <div class="fr-nav__item">
+                        <button class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-icon-more-line"
+                                aria-controls="enveloppe-menu-{{ enveloppe.id }}"
+                                aria-expanded="false"
+                                aria-label="Modifier ou supprimer">
+                        </button>
+                        <div class="fr-menu fr-collapse" id="enveloppe-menu-{{ enveloppe.id }}">
+                            <ul class="fr-menu__list">
+                                <li>
+                                    <a class="fr-nav__link fr-icon-settings-5-fill fr-icon--sm"
+                                       href="{% url 'gsl_projet:enveloppe-update' enveloppe.id %}">Modifier</a>
+                                </li>
+                                <li>
+                                    <button class="fr-nav__link fr-icon-delete-bin-fill fr-icon--sm"
+                                            aria-controls="enveloppe-delete-modal-{{ enveloppe.id }}"
+                                            type="button"
+                                            data-fr-opened="false">
+                                        Supprimer
+                                    </button>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <form method="post"
-                  action="{% url 'gsl_projet:enveloppe-delete' enveloppe.id %}"
-                  data-controller="form-utils"
-                  data-action="submit->form-utils#disableButtons">
-                {% csrf_token %}
-                <dialog id="enveloppe-delete-modal-{{ enveloppe.id }}"
-                        class="fr-modal confirmation-modal fr-text--regular enveloppe-delete-modal">
-                    <div class="fr-container fr-container--fluid fr-container-md">
-                        <div class="fr-grid-row fr-grid-row--center">
-                            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6 confirmation-modal-container">
-                                <div class="fr-modal__body">
-                                    <div class="fr-modal__header">
-                                        <button aria-controls="enveloppe-delete-modal-{{ enveloppe.id }}"
-                                                title="Fermer"
-                                                type="button"
-                                                class="fr-btn--close fr-btn close-modal">
-                                            Fermer
-                                        </button>
-                                    </div>
-                                    <div class="fr-modal__content">
-                                        <h1 class="fr-modal__title ">
-                                            <span class="fr-icon-delete-fill fr-icon--lg" aria-hidden="true"></span>
-                                            <span class="modal-title">Suppression d'une sous-enveloppe {{ enveloppe.dotation }}</span>
-                                        </h1>
-                                        <p class="modal-body">
-                                            Souhaitez-vous supprimer la sous-enveloppe de
-                                            dotation {{ enveloppe.dotation }}
-                                            pour {{ enveloppe.perimetre }}&nbsp;?
-                                        </p>
-                                    </div>
-                                    <div class="fr-modal__footer confirmation-modal-footer">
-                                        <button class="fr-btn fr-btn--secondary close-modal"
-                                                aria-controls="enveloppe-delete-modal-{{ enveloppe.id }}"
-                                                type="button">
-                                            Annuler
-                                        </button>
+                <form method="post"
+                      action="{% url 'gsl_projet:enveloppe-delete' enveloppe.id %}"
+                      data-controller="form-utils"
+                      data-action="submit->form-utils#disableButtons">
+                    {% csrf_token %}
+                    <dialog id="enveloppe-delete-modal-{{ enveloppe.id }}"
+                            class="fr-modal confirmation-modal fr-text--regular enveloppe-delete-modal">
+                        <div class="fr-container fr-container--fluid fr-container-md">
+                            <div class="fr-grid-row fr-grid-row--center">
+                                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6 confirmation-modal-container">
+                                    <div class="fr-modal__body">
+                                        <div class="fr-modal__header">
+                                            <button aria-controls="enveloppe-delete-modal-{{ enveloppe.id }}"
+                                                    title="Fermer"
+                                                    type="button"
+                                                    class="fr-btn--close fr-btn close-modal">
+                                                Fermer
+                                            </button>
+                                        </div>
+                                        <div class="fr-modal__content">
+                                            <h1 class="fr-modal__title ">
+                                                <span class="fr-icon-delete-fill fr-icon--lg" aria-hidden="true"></span>
+                                                <span class="modal-title">Suppression d'une sous-enveloppe {{ enveloppe.dotation }}</span>
+                                            </h1>
+                                            <p class="modal-body">
+                                                Souhaitez-vous supprimer la sous-enveloppe de
+                                                dotation {{ enveloppe.dotation }}
+                                                pour {{ enveloppe.perimetre }}&nbsp;?
+                                            </p>
+                                        </div>
+                                        <div class="fr-modal__footer confirmation-modal-footer">
+                                            <button class="fr-btn fr-btn--secondary close-modal"
+                                                    aria-controls="enveloppe-delete-modal-{{ enveloppe.id }}"
+                                                    type="button">
+                                                Annuler
+                                            </button>
 
-                                        <button class="fr-btn fr-btn--primary confirm">
-                                            Confirmer
-                                        </button>
+                                            <button class="fr-btn fr-btn--primary confirm">
+                                                Confirmer
+                                            </button>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </dialog>
-            </form>
-        {% endif %}
-    </td>
+                    </dialog>
+                </form>
+            {% endif %}
+        </td>
+    {% endif %}
 </tr>

--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -235,3 +235,8 @@ def column_cell_value(context, column):
 @register.simple_tag(takes_context=True)
 def other_dotation_cell_value(context, column):
     return column.other_dotation_getter(context)
+
+
+@register.filter
+def perimetre_type_abbrev(perimetre_type):
+    return f"{perimetre_type[:3]}."

--- a/gsl_programmation/models.py
+++ b/gsl_programmation/models.py
@@ -137,6 +137,10 @@ class Enveloppe(BaseModel):
         )
 
     @property
+    def reste_a_attribuer(self):
+        return self.montant - self.accepted_montant
+
+    @property
     def validated_projets_count(self):
         return self.enveloppe_projets_processed.filter(
             status=ProgrammationProjet.STATUS_ACCEPTED
@@ -157,6 +161,10 @@ class Enveloppe(BaseModel):
     @property
     def projets_count(self):
         return self.enveloppe_projets_included.count()
+
+    @property
+    def is_arrondissement(self):
+        return self.perimetre.type == Perimetre.TYPE_ARRONDISSEMENT
 
     def clean(self):
         if self.dotation == DOTATION_DETR:  # scope "département"

--- a/gsl_programmation/static/css/enveloppe_summary.css
+++ b/gsl_programmation/static/css/enveloppe_summary.css
@@ -32,19 +32,12 @@
   }
 }
 
-.enveloppe-summary thead {
-  color: var(--text-title-blue-france);
-}
-
 .enveloppe-summary tbody {
   font-size: calc(1rem * 12 / 16) !important;
 }
 
 .enveloppe-summary th {
   border-top: 1px solid var(--border-default-grey);
-}
-
-.enveloppe-summary th:not(:last-child) {
   line-height: 1rem;
   vertical-align: middle;
 }
@@ -56,7 +49,14 @@
   justify-content: center;
   flex-flow: column wrap;
   white-space: normal;
+}
+
+.enveloppe-summary .align-center {
   text-align: center;
+}
+
+.enveloppe-summary .align-right {
+  text-align: right;
 }
 
 .enveloppe-summary th .text {
@@ -76,14 +76,15 @@
   flex-shrink: 0; /* Prevents icon from shrinking */
 }
 
+.enveloppe-summary th.col--130px {
+  width: 130px;
+}
+
 
 .enveloppe-summary tr {
   border-bottom: 2px solid var(--border-default-grey);
 }
 
-.enveloppe-summary tbody tr td {
-  text-align: center;
-}
 
 .enveloppe-summary .color-icon-success::before,
 .enveloppe-summary .color-success {
@@ -121,11 +122,6 @@
 
 .enveloppe-summary .fr-menu .fr-nav__link::before {
   margin-right: 0.5rem;
-}
-
-.enveloppe-summary tr.sous-enveloppe td:not(:last-child) {
-  position: relative;
-  left: 1rem;
 }
 
 .enveloppe-summary tr.sous-enveloppe .sub {

--- a/gsl_programmation/templates/gsl_programmation/programmation_projet_list.html
+++ b/gsl_programmation/templates/gsl_programmation/programmation_projet_list.html
@@ -22,7 +22,7 @@
         </p>
     </div>
 
-    {% include "includes/_enveloppe_summary.html" %}
+    {% include "includes/_enveloppe_summary.html" with hide_actions=True %}
     {% include "includes/_projet_list_filters.html" %}
 
     <div id="programmation-table-wrapper"

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -33,7 +33,7 @@
             {% endfor %}
         </div>
     </div>
-    {% include "includes/_enveloppe_summary.html" %}
+    {% include "includes/_enveloppe_summary.html" with hide_actions=True %}
     {% include "includes/_projet_list_filters.html" %}
 
     <div id="simulation-table-wrapper" data-controller="checkbox-selection">


### PR DESCRIPTION
## 🌮 Objectif

Améliorer le tableau de résumé des enveloppes sur les pages programmation et simulation.

## 🔍 Liste des modifications

- Ajout d'un paramètre `hide_actions` sur `_enveloppe_summary` pour masquer la colonne d'actions (utilisé sur les pages programmation et simulation où les actions modifier/supprimer n'ont pas leur place)
- Ajout de `width: 130px` (sans `min-width`) sur 2 colonnes du header pour réduire sa hauteur (texte sur 2 lignes au lieu de 3) sans déclencher de scroll horizontal
- Propriété `reste_a_attribuer` sur `Enveloppe`
- Propriété `is_arrondissement` sur `Enveloppe`
- Filtre `perimetre_type_abbrev` pour afficher le type de périmètre en abrégé
- Corrections d'alignement dans les cellules (droite pour les montants, centre pour les compteurs)