### PR TITLE
Active la compression WhiteNoise (gzip + Brotli) des fichiers statiques

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -153,7 +153,7 @@ STORAGES = {
         "OPTIONS": {},
     },
     "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
     },
 }
 


### PR DESCRIPTION
## 🌮 Objectif

Activer la compression gzip + Brotli des fichiers statiques par WhiteNoise.

## 🔍 Liste des modifications

- Remplace le backend `staticfiles` `ManifestStaticFilesStorage` (Django) par `CompressedManifestStaticFilesStorage` (WhiteNoise) dans `gsl/settings.py`.

## ⚠️ Informations supplémentaires

WhiteNoise écrit désormais les variantes `.gz` et `.br` à côté de chaque asset pendant `collectstatic` (lancé automatiquement au build Scalingo). À l'exécution, WhiteNoise sert le fichier pré-compressé correspondant à l'`Accept-Encoding` du client (`.br` > `.gz` > brut), au lieu de laisser le routeur Scalingo gzipper à la volée à chaque requête. Bénéfice principal : Brotli servi aux clients qui le supportent, et compression déplacée du chemin par-requête vers le build.

Le backend hérite de `ManifestStaticFilesStorage`, donc le hashing / manifest (et le contournement SRI DSFR) reste identique. Les prérequis sont déjà en place (`whitenoise==6.12.0`, `brotli==1.2.0`).

À vérifier en staging : confirmer que le routeur Scalingo ne réécrit pas / ne supprime pas l'en-tête `Content-Encoding` posé par WhiteNoise (sinon le bénéfice Brotli serait perdu). Tester avec `DEBUG=False` car WhiteNoise ne sert pas le pré-compressé en mode debug.