### PR TITLE
Limiter chaque token du proxy DS à une requête simultanée

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -430,6 +430,11 @@ DS_INIT_SYNC_LOCK_TIMEOUT = int(
     os.getenv("DS_INIT_SYNC_LOCK_TIMEOUT", 6 * 60 * 60)
 )  # 6 h
 
+# TTL du verrou « une requête à la fois » par token proxy DS (secondes).
+# Filet de sécurité si un worker meurt sans libérer le verrou : doit rester
+# au-dessus de la durée max d'un forward DS (_DS_TIMEOUT = 5 + 55s).
+DS_PROXY_TOKEN_LOCK_TIMEOUT = int(os.getenv("DS_PROXY_TOKEN_LOCK_TIMEOUT", 90))
+
 
 # Storage
 AWS_ACCESS_KEY_ID = os.getenv("SCALEWAY_S3_KEY")

--- a/gsl_ds_proxy/locks.py
+++ b/gsl_ds_proxy/locks.py
@@ -1,0 +1,33 @@
+import logging
+
+import redis
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def acquire_token_lock(token_id):
+    """Verrou Redis non bloquant : une requête proxy en vol par token.
+
+    Retourne l'objet lock si acquis, None s'il est déjà détenu (une autre
+    requête du même token tourne déjà).
+    """
+    client = redis.Redis.from_url(settings.CELERY_BROKER_URL)
+    lock = client.lock(
+        f"ds-proxy:token:{token_id}",
+        timeout=settings.DS_PROXY_TOKEN_LOCK_TIMEOUT,
+    )
+    return lock if lock.acquire(blocking=False) else None
+
+
+def release_token_lock(lock, token_id):
+    try:
+        lock.release()
+    except redis.exceptions.LockError:
+        # TTL expiré avant la fin du forward : le verrou ne nous appartient
+        # plus. On laisse passer (try étroit, type ciblé).
+        logger.warning(
+            "DS proxy token lock for token %s expired before release "
+            "(request longer than DS_PROXY_TOKEN_LOCK_TIMEOUT?)",
+            token_id,
+        )

--- a/gsl_ds_proxy/tests/test_locks.py
+++ b/gsl_ds_proxy/tests/test_locks.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+
+import redis
+from django.test import override_settings
+
+from gsl_ds_proxy.locks import acquire_token_lock, release_token_lock
+
+
+@override_settings(DS_PROXY_TOKEN_LOCK_TIMEOUT=90)
+@patch("gsl_ds_proxy.locks.redis.Redis.from_url")
+def test_acquire_returns_lock_when_free(mock_from_url):
+    lock = MagicMock()
+    lock.acquire.return_value = True
+    client = MagicMock()
+    client.lock.return_value = lock
+    mock_from_url.return_value = client
+
+    result = acquire_token_lock(7)
+
+    assert result is lock
+    client.lock.assert_called_once_with("ds-proxy:token:7", timeout=90)
+    lock.acquire.assert_called_once_with(blocking=False)
+
+
+@patch("gsl_ds_proxy.locks.redis.Redis.from_url")
+def test_acquire_returns_none_when_held(mock_from_url):
+    lock = MagicMock()
+    lock.acquire.return_value = False
+    client = MagicMock()
+    client.lock.return_value = lock
+    mock_from_url.return_value = client
+
+    assert acquire_token_lock(7) is None
+
+
+@patch("gsl_ds_proxy.locks.redis.Redis.from_url")
+def test_distinct_tokens_use_distinct_keys(mock_from_url):
+    client = MagicMock()
+    client.lock.return_value.acquire.return_value = True
+    mock_from_url.return_value = client
+
+    acquire_token_lock(1)
+    acquire_token_lock(2)
+
+    keys = [call.args[0] for call in client.lock.call_args_list]
+    assert keys == ["ds-proxy:token:1", "ds-proxy:token:2"]
+
+
+def test_release_calls_lock_release():
+    lock = MagicMock()
+    release_token_lock(lock, 7)
+    lock.release.assert_called_once_with()
+
+
+def test_release_swallows_lock_error_when_ttl_expired():
+    lock = MagicMock()
+    lock.release.side_effect = redis.exceptions.LockError("not owned")
+
+    # Must not raise: the TTL expired and the lock is no longer ours.
+    release_token_lock(lock, 7)
+
+    lock.release.assert_called_once_with()

--- a/gsl_ds_proxy/tests/test_views.py
+++ b/gsl_ds_proxy/tests/test_views.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
 
@@ -27,6 +27,18 @@ class GraphqlProxyViewTest(TestCase):
         )
         self.url = "/ds-proxy/graphql/"
         self.headers = {"HTTP_AUTHORIZATION": f"Bearer {self.token.plaintext_key}"}
+
+        # The per-token Redis lock is exercised on its own in
+        # GraphqlProxyTokenLockTest; here we neutralise it (always acquired,
+        # no-op release) so the rest of the suite doesn't need a live Redis.
+        acquire_patcher = patch(
+            "gsl_ds_proxy.views.acquire_token_lock", return_value=MagicMock()
+        )
+        self.mock_acquire = acquire_patcher.start()
+        self.addCleanup(acquire_patcher.stop)
+        release_patcher = patch("gsl_ds_proxy.views.release_token_lock")
+        self.mock_release = release_patcher.start()
+        self.addCleanup(release_patcher.stop)
 
     def _get_demarche_payload(self, demarche_number=None):
         return {
@@ -1239,3 +1251,131 @@ class GraphqlProxyViewTest(TestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(self._request_log_records(cm.records), [])
+
+
+@override_settings(DS_API_TOKEN="test-ds-token", DS_API_URL="https://ds.test/graphql")
+class GraphqlProxyTokenLockTest(TestCase):
+    """One in-flight request per token, enforced by the Redis lock.
+
+    The lock layer (`acquire_token_lock` / `release_token_lock`) is mocked here
+    just like `requests.post` is, so the suite doesn't need a live Redis. The
+    locks module itself is unit-tested in test_locks.py.
+    """
+
+    def setUp(self):
+        self.demarche = DemarcheFactory(ds_number=123)
+        self.token = ProxyTokenFactory(
+            demarche=self.demarche,
+            groupe_instructeur_ds_id="GROUPE-1",
+        )
+        self.url = "/ds-proxy/graphql/"
+        self.headers = {"HTTP_AUTHORIZATION": f"Bearer {self.token.plaintext_key}"}
+
+    def _post(self, data, **extra_headers):
+        headers = {**self.headers, **extra_headers}
+        return self.client.post(
+            self.url,
+            data=json.dumps(data),
+            content_type="application/json",
+            **headers,
+        )
+
+    def _get_demarche_payload(self):
+        return {
+            "query": "query getDemarche { demarche { number } }",
+            "operationName": "getDemarche",
+            "variables": {"demarcheNumber": self.demarche.ds_number},
+        }
+
+    def _mock_ds_success(self, mock_post):
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.raise_for_status.return_value = None
+        mock_post.return_value.json.return_value = {
+            "data": {
+                "demarche": {
+                    "number": self.demarche.ds_number,
+                    "dossiers": {"nodes": []},
+                }
+            }
+        }
+
+    @patch("gsl_ds_proxy.views.release_token_lock")
+    @patch("gsl_ds_proxy.views.acquire_token_lock", return_value=None)
+    def test_concurrent_request_rejected_with_429(self, mock_acquire, mock_release):
+        # acquire returns None => a request from this token is already in flight.
+        response = self._post(self._get_demarche_payload())
+
+        self.assertEqual(response.status_code, 429)
+        body = json.loads(response.content)
+        self.assertEqual(
+            body["errors"][0]["message"],
+            "Une seule requête à la fois est autorisée par token. "
+            "Une requête est déjà en cours pour ce token, attendez sa fin "
+            "avant d'en envoyer une autre.",
+        )
+        self.assertTrue(body["errors"][0]["extensions"]["requestId"])
+        # No worker work happened and there is nothing to release.
+        mock_release.assert_not_called()
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    @patch("gsl_ds_proxy.views.release_token_lock")
+    @patch("gsl_ds_proxy.views.acquire_token_lock")
+    def test_lock_released_after_successful_request(
+        self, mock_acquire, mock_release, mock_post
+    ):
+        fake_lock = MagicMock()
+        mock_acquire.return_value = fake_lock
+        self._mock_ds_success(mock_post)
+
+        response = self._post(self._get_demarche_payload())
+        self.assertEqual(response.status_code, 200)
+        _read_stream(response)
+
+        mock_release.assert_called_once_with(fake_lock, self.token.id)
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    @patch("gsl_ds_proxy.views.release_token_lock")
+    @patch("gsl_ds_proxy.views.acquire_token_lock")
+    def test_lock_released_after_ds_error(self, mock_acquire, mock_release, mock_post):
+        import requests as req
+
+        fake_lock = MagicMock()
+        mock_acquire.return_value = fake_lock
+        mock_post.side_effect = req.exceptions.Timeout()
+
+        response = self._post(self._get_demarche_payload())
+        self.assertEqual(response.status_code, 200)
+        # Drain the stream so the generator (and its finally) runs to the end.
+        _read_stream(response)
+
+        mock_release.assert_called_once_with(fake_lock, self.token.id)
+
+    @patch("gsl_ds_proxy.views.requests.post")
+    @patch("gsl_ds_proxy.views.release_token_lock")
+    @patch("gsl_ds_proxy.views.acquire_token_lock")
+    def test_distinct_tokens_acquire_independent_locks(
+        self, mock_acquire, mock_release, mock_post
+    ):
+        # Each token gets its own lock keyed on its id, so they never block
+        # one another even on the same démarche.
+        other_token = ProxyTokenFactory(
+            demarche=self.demarche,
+            groupe_instructeur_ds_id="GROUPE-2",
+        )
+        mock_acquire.return_value = MagicMock()
+        self._mock_ds_success(mock_post)
+
+        self._read_ok(self._post(self._get_demarche_payload()))
+        self._read_ok(
+            self._post(
+                self._get_demarche_payload(),
+                HTTP_AUTHORIZATION=f"Bearer {other_token.plaintext_key}",
+            )
+        )
+
+        acquired_token_ids = [call.args[0] for call in mock_acquire.call_args_list]
+        self.assertEqual(acquired_token_ids, [self.token.id, other_token.id])
+
+    def _read_ok(self, response):
+        self.assertEqual(response.status_code, 200)
+        _read_stream(response)

--- a/gsl_ds_proxy/views.py
+++ b/gsl_ds_proxy/views.py
@@ -12,6 +12,7 @@ from graphql import GraphQLError, OperationType, parse
 from graphql.language.ast import FieldNode, OperationDefinitionNode
 
 from gsl_ds_proxy.filters import filter_response
+from gsl_ds_proxy.locks import acquire_token_lock, release_token_lock
 from gsl_ds_proxy.models import ProxyToken
 from gsl_ds_proxy.query_guard import validate_demarche_selections
 
@@ -358,6 +359,19 @@ def graphql_proxy(request):
             f"Champ démarche non autorisé : `{forbidden_field}`.", 403, request_id
         )
 
+    # One in-flight request per token: acquire the lock just before the
+    # expensive DS forward. A second concurrent request from the same token is
+    # rejected immediately (429) instead of holding a second worker hostage.
+    lock = acquire_token_lock(proxy_token.id)
+    if lock is None:
+        return _error_response(
+            "Une seule requête à la fois est autorisée par token. "
+            "Une requête est déjà en cours pour ce token, attendez sa fin "
+            "avant d'en envoyer une autre.",
+            429,
+            request_id,
+        )
+
     allowed_groupe_ds_id = proxy_token.groupe_instructeur_ds_id
     stream = _stream_ds_response(
         proxy_token,
@@ -367,6 +381,7 @@ def graphql_proxy(request):
         variables,
         allowed_groupe_ds_id,
         request_id,
+        lock,
     )
     return StreamingHttpResponse(stream, content_type="application/json", status=200)
 
@@ -379,70 +394,80 @@ def _stream_ds_response(
     variables,
     allowed_groupe_ds_id,
     request_id,
+    lock,
 ):
-    # Send a single whitespace byte immediately to close Scalingo's
-    # 30s-to-first-byte window. Leading whitespace is valid JSON.
-    yield b" "
+    # The lock acquired in the view is released here in a finally so every exit
+    # path frees it: DS error return, verbatim forward, scope error, ok — and
+    # also if the client disconnects (Django closes the iterator, which raises
+    # GeneratorExit and triggers the finally).
+    try:
+        # Send a single whitespace byte immediately to close Scalingo's
+        # 30s-to-first-byte window. Leading whitespace is valid JSON.
+        yield b" "
 
-    response_data, error_message, elapsed_ms = _forward_to_ds(
-        query, variables, operation_name, proxy_token, request_id
-    )
-    if error_message is not None:
-        yield _graphql_error_bytes(error_message, request_id)
-        return
+        response_data, error_message, elapsed_ms = _forward_to_ds(
+            query, variables, operation_name, proxy_token, request_id
+        )
+        if error_message is not None:
+            yield _graphql_error_bytes(error_message, request_id)
+            return
 
-    def _log_request(*, outcome, filtered=None):
-        original = _count_dossiers(response_data, root_field)
-        extra = {
-            "request_id": request_id,
-            "proxy_token_id": proxy_token.id,
-            "demarche_number": proxy_token.demarche.ds_number,
-            "operation_name": operation_name,
-            "root_field": root_field,
-            "elapsed_ms": elapsed_ms,
-            "ds_errors_count": len(response_data.get("errors") or []),
-            "outcome": outcome,
-        }
-        if original is not None:
-            post = _count_dossiers(filtered, root_field) if filtered is not None else 0
-            extra["ds_results_count"] = original
-            extra["filtered_out_count"] = original - post
-        logger.info("DS proxy: request", extra=extra)
+        def _log_request(*, outcome, filtered=None):
+            original = _count_dossiers(response_data, root_field)
+            extra = {
+                "request_id": request_id,
+                "proxy_token_id": proxy_token.id,
+                "demarche_number": proxy_token.demarche.ds_number,
+                "operation_name": operation_name,
+                "root_field": root_field,
+                "elapsed_ms": elapsed_ms,
+                "ds_errors_count": len(response_data.get("errors") or []),
+                "outcome": outcome,
+            }
+            if original is not None:
+                post = (
+                    _count_dossiers(filtered, root_field) if filtered is not None else 0
+                )
+                extra["ds_results_count"] = original
+                extra["filtered_out_count"] = original - post
+            logger.info("DS proxy: request", extra=extra)
 
-    # If DS itself reported errors and returned no scopable data, forward the
-    # upstream response verbatim so the caller can see the real error. There is
-    # nothing to scope-check (data is null/absent), so no risk of leaking
-    # out-of-scope data. We prepend a marker error carrying our request_id so
-    # the partner can correlate with our server logs.
-    if response_data.get("errors") and not _scoped_field_present(
-        root_field, response_data
-    ):
-        forwarded = dict(response_data)
-        forwarded["errors"] = [
-            _error_entry("Erreur Démarches Simplifiées transmise.", request_id),
-            *response_data["errors"],
-        ]
-        _log_request(outcome="verbatim_forward", filtered=response_data)
-        yield json.dumps(forwarded).encode()
-        return
+        # If DS itself reported errors and returned no scopable data, forward
+        # the upstream response verbatim so the caller can see the real error.
+        # There is nothing to scope-check (data is null/absent), so no risk of
+        # leaking out-of-scope data. We prepend a marker error carrying our
+        # request_id so the partner can correlate with our server logs.
+        if response_data.get("errors") and not _scoped_field_present(
+            root_field, response_data
+        ):
+            forwarded = dict(response_data)
+            forwarded["errors"] = [
+                _error_entry("Erreur Démarches Simplifiées transmise.", request_id),
+                *response_data["errors"],
+            ]
+            _log_request(outcome="verbatim_forward", filtered=response_data)
+            yield json.dumps(forwarded).encode()
+            return
 
-    scope_error = _check_response_allowed(proxy_token, root_field, response_data)
-    if scope_error is not None:
-        # Preserve any upstream DS errors so the caller still sees what DS
-        # signalled (e.g. partial Timeout on PersonneMorale.entreprise rows)
-        # alongside our own scope rejection.
-        upstream_errors = response_data.get("errors") or []
-        payload = {
-            "data": None,
-            "errors": [*upstream_errors, _error_entry(scope_error, request_id)],
-        }
-        _log_request(outcome="scope_error")
-        yield json.dumps(payload).encode()
-        return
+        scope_error = _check_response_allowed(proxy_token, root_field, response_data)
+        if scope_error is not None:
+            # Preserve any upstream DS errors so the caller still sees what DS
+            # signalled (e.g. partial Timeout on PersonneMorale.entreprise rows)
+            # alongside our own scope rejection.
+            upstream_errors = response_data.get("errors") or []
+            payload = {
+                "data": None,
+                "errors": [*upstream_errors, _error_entry(scope_error, request_id)],
+            }
+            _log_request(outcome="scope_error")
+            yield json.dumps(payload).encode()
+            return
 
-    filtered = filter_response(response_data, allowed_groupe_ds_id)
-    _log_request(outcome="ok", filtered=filtered)
-    yield json.dumps(filtered).encode()
+        filtered = filter_response(response_data, allowed_groupe_ds_id)
+        _log_request(outcome="ok", filtered=filtered)
+        yield json.dumps(filtered).encode()
+    finally:
+        release_token_lock(lock, proxy_token.id)
 
 
 graphql_proxy.login_required = False


### PR DESCRIPTION
## 🌮 Objectif

Plafonner chaque token du proxy DS à une seule requête en vol à la fois.

## 🔍 Liste des modifications

- Verrou Redis non bloquant par `ProxyToken` (`gsl_ds_proxy/locks.py`), calqué sur le motif existant `demarche_sync_lock`
- Acquisition du verrou dans la vue, juste avant le forward DS : une deuxième requête concurrente du même token est rejetée immédiatement en **HTTP 429**, sans occuper un second worker
- Libération du verrou dans le `finally` du générateur de streaming, couvrant tous les chemins de sortie (erreur DS, forward verbatim, scope error, succès) ainsi que la déconnexion du client
- TTL `DS_PROXY_TOKEN_LOCK_TIMEOUT` (90s par défaut) comme filet de sécurité si un worker meurt sans libérer le verrou
- Deux tokens différents restent indépendants, même sur la même démarche
- Tests : rejet concurrent en 429, libération après succès et après erreur DS, indépendance des tokens, et tests unitaires du module de verrou

## ⚠️ Informations supplémentaires

Nouvelle variable d'environnement optionnelle : `DS_PROXY_TOKEN_LOCK_TIMEOUT` (défaut 90s, doit rester au-dessus de la durée max d'un forward DS, soit 5 + 55s).
