### PR TITLE
Barre de tags des filtres actifs et nouvelle disposition de la barre de filtres

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,6 +376,11 @@ dossier.dossier_dotation_dsil.status = "refused"
 - **Build tools:** esbuild (bundler/minifier), stylelint (CSS linting)
 - **CSS approach:** DSFR classes + custom CSS
 
+> **Prefer DSFR utility classes over custom CSS.** Reach for DSFR's grid
+> classes (`fr-grid-row`, `fr-col-*`) and spacing utilities
+> (`fr-mt-*`, `fr-mb-*`, `fr-p-*`, etc.) before writing custom CSS. Only add
+> custom CSS when no DSFR utility covers the need.
+
 **Key patterns:**
 - Server-side HTML rendering with HTMX for AJAX updates
 - Stimulus controllers for modal/tab interactions

--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -240,3 +240,34 @@ def other_dotation_cell_value(context, column):
 @register.filter
 def perimetre_type_abbrev(perimetre_type):
     return f"{perimetre_type[:3]}."
+
+
+@register.filter
+def active_filter_tag(field):
+    """Formatted tag text for an active filter, or '' when it has no value.
+
+    Each custom widget knows how to describe itself via `active_tag_label`;
+    the plain search input falls back to the base case below."""
+    form = field.form
+    form.is_valid()
+    value = getattr(form, "cleaned_data", {}).get(field.name)
+    label = field.field.label or field.name
+    get_label = getattr(field.field.widget, "active_tag_label", None)
+    if get_label:
+        return get_label(value, label)
+    return f"{label} « {value} »" if value else ""
+
+
+@register.simple_tag(takes_context=True)
+def remove_filter_qs(context, field):
+    """href that drops only this field's GET key(s) (incl. _min/_max suffixes)."""
+    suffixes = getattr(field.field.widget, "suffixes", None)
+    if suffixes:
+        keys = [f"{field.name}_{suffix}" for suffix in suffixes]
+    else:
+        keys = [field.name]
+    qd = context["request"].GET.copy()
+    for key in keys:
+        qd.pop(key, None)
+    encoded = qd.urlencode()
+    return f"?{encoded}" if encoded else ""

--- a/gsl_programmation/tests/test_programmation_projet_filters.py
+++ b/gsl_programmation/tests/test_programmation_projet_filters.py
@@ -25,7 +25,7 @@ from gsl_programmation.tests.factories import (
 from gsl_programmation.utils.programmation_projet_filters import (
     ProgrammationProjetFilters,
 )
-from gsl_projet.constants import DOTATION_DETR
+from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL
 from gsl_projet.tests.factories import (
     DotationProjetFactory,
     ProjetFactory,
@@ -75,6 +75,16 @@ def mock_request(request_factory, user):
     request.user = user
     request.resolver_match = type(
         "MockResolverMatch", (), {"kwargs": {"dotation": DOTATION_DETR}}
+    )()
+    return request
+
+
+@pytest.fixture
+def mock_request_dsil(request_factory, user):
+    request = request_factory.get("/")
+    request.user = user
+    request.resolver_match = type(
+        "MockResolverMatch", (), {"kwargs": {"dotation": DOTATION_DSIL}}
     )()
     return request
 
@@ -900,6 +910,22 @@ class TestProgrammationProjetFilters:
         result = list(filterset.qs)
         assert prog_ecole not in result
         assert prog_mairie in result
+
+    def test_fixed_fields_show_detr_category_on_detr_page(self, mock_request):
+        """On a DETR programmation page, the DETR category sits in the fixed row
+        and the DSIL category is absent."""
+        filterset = ProgrammationProjetFilters(request=mock_request)
+        fixed_names = [field.name for field in filterset.fixed_fields]
+        assert "categorie_detr" in fixed_names
+        assert "categorie_dsil" not in fixed_names
+
+    def test_fixed_fields_show_dsil_category_on_dsil_page(self, mock_request_dsil):
+        """On a DSIL programmation page, the DSIL category sits in the fixed row
+        and the DETR category is absent."""
+        filterset = ProgrammationProjetFilters(request=mock_request_dsil)
+        fixed_names = [field.name for field in filterset.fixed_fields]
+        assert "categorie_dsil" in fixed_names
+        assert "categorie_detr" not in fixed_names
 
     def test_empty_filters(self, mock_request, enveloppe, arrondissement):
         """Test que sans filtres, tous les projets de l'enveloppe sont retournés"""

--- a/gsl_programmation/utils/programmation_projet_filters.py
+++ b/gsl_programmation/utils/programmation_projet_filters.py
@@ -35,6 +35,7 @@ from gsl_projet.utils.django_filters_custom_widget import (
 from gsl_projet.utils.projet_filters import (
     DOTATION_SOLLICITEE_CHOICES,
     OUI_NON_CHOICES,
+    FixedFilterFieldsMixin,
     LabelFromInstanceFilter,
     ProjetOrderingFilter,
     filter_boolean,
@@ -60,7 +61,16 @@ PROGRAMMATION_ORDERING_MAP = {
 }
 
 
-class ProgrammationProjetFilters(FilterSet):
+class ProgrammationProjetFilters(FixedFilterFieldsMixin, FilterSet):
+    fixed_filter_fields = (
+        "search",
+        "categorie_detr",
+        "categorie_dsil",
+        "cout",
+        "montant_demande",
+        "montant_retenu",
+    )
+
     search = CharFilter(
         label="Recherche",
         method="filter_search",
@@ -117,10 +127,12 @@ class ProgrammationProjetFilters(FilterSet):
     )
 
     territoire = LabelFromInstanceFilter(
+        label="Territoire",
         method="filter_territoire",
         queryset=Perimetre.objects.none(),
         widget=CustomCheckboxSelectMultiple(
-            display_template="includes/_filter_territoire.html"
+            display_template="includes/_filter_territoire.html",
+            label_attr="entity_name",
         ),
         label_attr="entity_name",
     )

--- a/gsl_projet/static/css/projet_list_filters.css
+++ b/gsl_projet/static/css/projet_list_filters.css
@@ -2,13 +2,7 @@
     background: var(--background-alt-blue-france);
     margin-left: calc(-50vw + 50%);
     margin-right: calc(-50vw + 50%);
-    padding: 1rem 1.5rem;
-}
-
-@media (width <= 768px) {
-    .projets-filters-layout {
-        padding: 1rem;
-    }
+  padding: 1rem 0;
 }
 
 .projets-filters-layout,
@@ -21,16 +15,6 @@
 .projets-filters-layout.projet-filters-in-parent {
   margin: 0;
   padding: 1rem;
-}
-   
-.reinit-filters {
-  place-content: end;
-}
-
-.reinit-filters > button {
-  width: 100%;
-  gap: 8px;
-  justify-content: center;
 }
 
 .filter-field .gsl-dropdown-content {
@@ -117,23 +101,6 @@
   padding-top: 6px;
 }
 
-.filter-dropdown-button-active.fr-tag {
-  overflow: hidden;
-  display: inline-block;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  max-width: 200px;
-  padding-right: 2rem;
-  position: relative;
-}
-
-.filter-dropdown-button-active.fr-tag::after {
-  position: absolute;
-  right: 1rem;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
 .filter-field > select {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -147,6 +114,13 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 100%;
+}
+
+/* In the fixed top row, keep the category dropdown (a .fr-select toggle, unlike
+   the .fr-input amount toggles) from widening when a long category is selected,
+   so the row stays on a single line. Capped to match sibling fixed fields. */
+.filters-fixed.filters-flex-row > .filter-field > .gsl-dropdown > button.fr-select {
+  max-width: 150px;
 }
 
 .territoire-type-d ~ .territoire-type-a,
@@ -176,8 +150,7 @@
   align-items: stretch;
 }
 
-.filters-flex-row > .filter-field,
-.filters-flex-row > .reinit-filters {
+.filters-flex-row > .filter-field {
   flex: 0 1 auto;
   width: auto;
   max-width: 220px;
@@ -187,15 +160,31 @@
   justify-content: space-between;
 }
 
-.filters-flex-row > .reinit-filters {
-  justify-content: flex-end;
+.filters-top-row {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.filters-top-row > .filters-fixed {
+  flex: 1 1 auto;
+}
+
+.filters-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+#filters-toggle[aria-expanded="true"]::before {
+  transform: rotate(180deg);
 }
 
 @media (width <= 768px) {
-  .filters-flex-row > .filter-field,
-  .filters-flex-row > .reinit-filters {
-    flex: 1 1 100%;
-    min-width: 0;
+  .filters-top-row {
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 
@@ -209,6 +198,13 @@
   max-width: 360px;
 }
 
+@media (width <= 1130px) {
+  .filters-flex-row > .filter-field--search {
+    flex: 1 1 190px;
+    min-width: 190px;
+  }
+}
+
 .filter-field--search .fr-search-bar {
   width: 100%;
 }
@@ -217,4 +213,8 @@
   max-height: 400px;
   scroll-behavior: auto;
   overflow: auto;
+}
+
+.filters-active-tags:empty {
+  display: none;
 }

--- a/gsl_projet/templates/includes/_filter_amount_range.html
+++ b/gsl_projet/templates/includes/_filter_amount_range.html
@@ -4,8 +4,8 @@
     <div class="gsl-dropdown fr-mt-4w">
         <button type="button"
                 class="fr-input {% if rc.has_data %}filter-dropdown-button-active{% endif %}">
-            <span class="{{ rc.icon }} fr-icon--sm blue-color fr-mr-1w"></span>
             {{ rc.label }}
+            <span class="{{ rc.icon }} fr-icon--sm blue-color fr-ml-1w"></span>
         </button>
         <div class="gsl-dropdown-content">
             <div class="amount-filter-group">

--- a/gsl_projet/templates/includes/_filter_date_range.html
+++ b/gsl_projet/templates/includes/_filter_date_range.html
@@ -4,8 +4,8 @@
     <div class="gsl-dropdown fr-mt-4w">
         <button type="button"
                 class="fr-input {% if rc.has_data %}filter-dropdown-button-active{% endif %}">
-            <span class="{{ rc.icon }} fr-icon--sm blue-color fr-mr-1w"></span>
             {{ rc.label }}
+            <span class="{{ rc.icon }} fr-icon--sm blue-color fr-ml-1w"></span>
         </button>
         <div class="gsl-dropdown-content">
             <div class="amount-filter-group">

--- a/gsl_projet/templates/includes/_filter_montant_demande.html
+++ b/gsl_projet/templates/includes/_filter_montant_demande.html
@@ -5,8 +5,8 @@
         <button type="button"
                 class="fr-input {% if rc.has_data %}filter-dropdown-button-active{% endif %}"
                 id="filter-montant-demande-button">
-            <span class="fr-icon-money-euro-circle-fill fr-icon--sm blue-color fr-mr-1w"></span>
             {{ rc.label }}
+            <span class="fr-icon-money-euro-circle-fill fr-icon--sm blue-color fr-ml-1w"></span>
         </button>
         <div class="gsl-dropdown-content">
             <div class="amount-filter-group">

--- a/gsl_projet/templates/includes/_projet_list_filters.html
+++ b/gsl_projet/templates/includes/_projet_list_filters.html
@@ -15,46 +15,88 @@
         <input type="hidden" name="order" value="{{ current_order }}">
     {% endif %}
 
-    <div class="projets-filters-layout {% if component_included_in_parent %} projet-filters-in-parent{% endif %} fr-container--fluid">
-        <div class="filters-flex-row">
-            <div class="fr-col-12 fr-col-md-4 fr-col-lg-3 reinit-filters">
-                <button class="fr-btn fr-btn--tertiary"
-                        type="submit"
-                        name="reset_filters"
-                        value="1">
-                    <span class="fr-icon-arrow-go-back-fill fr-icon--sm"></span> Réinitialiser les filtres
-                </button>
-            </div>
-            {% if filter.form.search %}
-                {% include "includes/_filter_search.html" with field=filter.form.search %}
-            {% endif %}
-            {% if current_order %}
-                {% active_sort_label columns current_order as sort_label %}
-                {% if sort_label %}
-                    <div class="filter-field">
-                        <label class="fr-label">
-                            Tri
-                        </label>
-                        <a href="{% querystring order='' %}"
-                           class="fr-tag fr-tag--dismiss filter-dropdown-button-active"
-                           aria-label="Retirer le tri">
-                            {% if current_order|first == "-" %}
-                                ↓
-                            {% else %}
-                                ↑
-                            {% endif %}
-                            {{ sort_label }}
-                        </a>
+    {% with fixed_filter_fields=filter.fixed_filter_fields %}
+
+        <div class="projets-filters-layout {% if component_included_in_parent %} projet-filters-in-parent{% endif %}">
+            <div class="fr-container">
+                <div class="fr-grid-row">
+                    <div class="fr-col-12 filters-top-row">
+                        <div class="filters-fixed filters-flex-row">
+                            {% for field in filter.fixed_fields %}
+                                {% if field.name == "search" %}
+                                    {% include "includes/_filter_search.html" with field=field %}
+                                {% else %}
+                                    {% include field.field.widget.display_template with field=field %}
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                        <div class="filters-actions">
+                            <button class="fr-btn fr-btn--secondary fr-icon-close-circle-line"
+                                    type="submit"
+                                    name="reset_filters"
+                                    value="1"
+                                    title="Réinitialiser les filtres">
+                                Réinitialiser les filtres
+                            </button>
+                            <button type="button"
+                                    id="filters-toggle"
+                                    class="fr-btn fr-btn--secondary fr-icon-arrow-down-s-line"
+                                    aria-expanded="false"
+                                    aria-controls="filters-extra"
+                                    title="Afficher tous les filtres">
+                                Afficher tous les filtres
+                            </button>
+                        </div>
                     </div>
-                {% endif %}
-            {% endif %}
-            {% for field in filter.form %}
-                {% if field.name != "order" and field.name != "search" %}
-                    {% include field.field.widget.display_template with field=field %}
-                {% endif %}
-            {% endfor %}
+                </div>
+
+                <div class="fr-grid-row fr-mt-2w">
+                    <div class="fr-col-12">
+                        <div id="filters-extra" class="filters-extra fr-collapse">
+                            <div class="filters-flex-row">
+                                {% for field in filter.form %}
+                                    {% if field.name not in fixed_filter_fields and field.name != "order" %}
+                                        {% include field.field.widget.display_template with field=field %}
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        </div>
+
+                        <ul class="filters-active-tags fr-tags-group fr-mt-2w">
+                            {% active_sort_label columns current_order as sort_label %}
+                            {% if sort_label %}
+                                <li>
+                                    <a class="fr-tag fr-tag--dismiss"
+                                       href="{% remove_filter_qs filter.form.order %}"
+                                       aria-label="Retirer le tri {{ sort_label }}">
+                                        Trié par {{ sort_label }}
+                                        {% if current_order|slice:":1" == "-" %}
+                                            ↓
+                                        {% else %}
+                                            ↑
+                                        {% endif %}
+                                    </a>
+                                </li>
+                            {% endif %}
+                            {% for field in filter.form %}
+                                {% if field.name != "order" %}
+                                    {% with text=field|active_filter_tag %}
+                                        {% if text %}
+                                            <li>
+                                                <a class="fr-tag fr-tag--dismiss"
+                                                   href="{% remove_filter_qs field %}"
+                                                   aria-label="Retirer le filtre {{ text }}">{{ text }}</a>
+                                            </li>
+                                        {% endif %}
+                                    {% endwith %}
+                                {% endif %}
+                            {% endfor %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
+    {% endwith %}
 </form>
 <script src="{% static "js/projectFilters.js" %}" defer></script>
 <script src="{% static 'js/territoireFilter.js' %}" defer></script>

--- a/gsl_projet/tests/test_django_filters_custom_widget.py
+++ b/gsl_projet/tests/test_django_filters_custom_widget.py
@@ -1,0 +1,113 @@
+"""Unit tests for the `active_tag_label` self-description added to the custom
+filter widgets. Each widget formats its own dismissible active-filter tag."""
+
+from datetime import date
+
+from gsl_projet.utils.django_filters_custom_widget import (
+    CustomCheckboxSelectMultiple,
+    DsfrDateRangeWidget,
+    DsfrRangeWidget,
+)
+
+
+class TestDsfrRangeWidgetActiveTagLabel:
+    def test_both_bounds(self):
+        widget = DsfrRangeWidget()
+        label = widget.active_tag_label(slice(1000, 5000), "Montant demandé")
+        assert label == "Montant demandé de 1 000 € à 5 000 €"
+
+    def test_only_lower_bound(self):
+        widget = DsfrRangeWidget()
+        assert widget.active_tag_label(slice(1000, None), "Coût total") == (
+            "Coût total supérieur à 1 000 €"
+        )
+
+    def test_only_upper_bound(self):
+        widget = DsfrRangeWidget()
+        assert widget.active_tag_label(slice(None, 5000), "Coût total") == (
+            "Coût total inférieur à 5 000 €"
+        )
+
+    def test_empty(self):
+        widget = DsfrRangeWidget()
+        assert widget.active_tag_label(None, "Coût total") == ""
+        assert widget.active_tag_label(slice(None, None), "Coût total") == ""
+
+
+class TestDsfrDateRangeWidgetActiveTagLabel:
+    def test_both_bounds(self):
+        widget = DsfrDateRangeWidget()
+        label = widget.active_tag_label(
+            slice(date(2024, 1, 2), date(2024, 3, 4)), "Date de dépôt"
+        )
+        assert label == "Date de dépôt du 02/01/2024 au 04/03/2024"
+
+    def test_only_lower_bound(self):
+        widget = DsfrDateRangeWidget()
+        assert (
+            widget.active_tag_label(slice(date(2024, 1, 2), None), "Date de dépôt")
+            == "Date de dépôt à partir du 02/01/2024"
+        )
+
+    def test_only_upper_bound(self):
+        widget = DsfrDateRangeWidget()
+        assert (
+            widget.active_tag_label(slice(None, date(2024, 3, 4)), "Date de dépôt")
+            == "Date de dépôt jusqu'au 04/03/2024"
+        )
+
+    def test_empty(self):
+        widget = DsfrDateRangeWidget()
+        assert widget.active_tag_label(None, "Date de dépôt") == ""
+        assert widget.active_tag_label(slice(None, None), "Date de dépôt") == ""
+
+
+class TestCustomCheckboxSelectMultipleActiveTagLabel:
+    def test_single_choice(self):
+        widget = CustomCheckboxSelectMultiple()
+        widget.choices = [("epci", "EPCI"), ("communes", "Communes")]
+        assert widget.active_tag_label(["epci"], "Demandeur") == "Demandeur : EPCI"
+
+    def test_several_choices_are_joined(self):
+        widget = CustomCheckboxSelectMultiple()
+        widget.choices = [("epci", "EPCI"), ("communes", "Communes")]
+        assert widget.active_tag_label(["epci", "communes"], "Demandeur") == (
+            "Demandeur : EPCI, Communes"
+        )
+
+    def test_model_instances_resolve_by_pk(self):
+        """Model/LabelFromInstance filters pass a queryset of instances; the
+        widget resolves each against its own pk-keyed choice labels."""
+
+        class FakeInstance:
+            def __init__(self, pk):
+                self.pk = pk
+
+        widget = CustomCheckboxSelectMultiple()
+        widget.choices = [(1, "Catégorie A"), (2, "Catégorie B")]
+        value = [FakeInstance(2)]
+        assert widget.active_tag_label(value, "Catégorie") == "Catégorie : Catégorie B"
+
+    def test_model_instances_use_label_attr_when_set(self):
+        """When `label_attr` is configured, model instances are labelled via that
+        attribute (mirroring the filter's `label_from_instance`), independently
+        of `self.choices` / `str()`."""
+
+        class FakeInstance:
+            def __init__(self, pk, entity_name):
+                self.pk = pk
+                self.entity_name = entity_name
+
+            def __str__(self):
+                return f"Département | Île-de-France - {self.entity_name}"
+
+        widget = CustomCheckboxSelectMultiple(label_attr="entity_name")
+        widget.choices = []  # nothing to resolve against
+        value = [FakeInstance(2, "Paris")]
+        assert widget.active_tag_label(value, "Territoire") == "Territoire : Paris"
+
+    def test_empty(self):
+        widget = CustomCheckboxSelectMultiple()
+        widget.choices = [("epci", "EPCI")]
+        assert widget.active_tag_label([], "Demandeur") == ""
+        assert widget.active_tag_label(None, "Demandeur") == ""

--- a/gsl_projet/tests/test_filter_tags.py
+++ b/gsl_projet/tests/test_filter_tags.py
@@ -1,0 +1,194 @@
+"""End-to-end tests for the redesigned filter bar (fixed row, extra disclosure,
+dismissible active-filter tags). Drives the three list views that share the
+`includes/_projet_list_filters.html` template through the test client."""
+
+import pytest
+from bs4 import BeautifulSoup
+from django.urls import reverse
+
+from gsl_core.tests.factories import (
+    ClientWithLoggedUserFactory,
+    CollegueFactory,
+    PerimetreDepartementalFactory,
+)
+from gsl_demarches_simplifiees.models import NaturePorteurProjet
+from gsl_demarches_simplifiees.tests.factories import NaturePorteurProjetFactory
+from gsl_programmation.tests.factories import (
+    DetrEnveloppeFactory,
+    ProgrammationProjetFactory,
+)
+from gsl_projet.tests.factories import ProjetFactory
+from gsl_simulation.tests.factories import SimulationFactory, SimulationProjetFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def perimetre():
+    return PerimetreDepartementalFactory()
+
+
+@pytest.fixture
+def user(perimetre):
+    return CollegueFactory(perimetre=perimetre)
+
+
+@pytest.fixture
+def client(user):
+    return ClientWithLoggedUserFactory(user)
+
+
+def _soup(response):
+    return BeautifulSoup(response.content.decode(), "html.parser")
+
+
+def _active_tags(soup):
+    return soup.select("ul.filters-active-tags a.fr-tag")
+
+
+def _tag_with(soup, text):
+    for tag in _active_tags(soup):
+        if text in tag.get_text(strip=True):
+            return tag
+    return None
+
+
+# --- Projets list ---
+
+
+def test_no_filter_hides_extra_panel_and_renders_no_tags(client, perimetre):
+    ProjetFactory(dossier_ds__perimetre=perimetre)
+    response = client.get(reverse("projet:list"))
+    assert response.status_code == 200
+    soup = _soup(response)
+
+    # Fixed fields always present
+    assert soup.select_one('input[name="search"]') is not None
+    assert soup.select_one("#filter-montant_demande") is not None
+
+    # Extra panel collapsed (DSFR fr-collapse), no active tags
+    extra = soup.select_one("#filters-extra")
+    assert "fr-collapse" in extra["class"]
+    assert _active_tags(soup) == []
+
+    toggle = soup.select_one("#filters-toggle")
+    assert toggle["aria-expanded"] == "false"
+
+
+def test_active_filters_render_dismissible_tags(client, perimetre):
+    ProjetFactory(dossier_ds__perimetre=perimetre)
+    response = client.get(
+        reverse("projet:list"),
+        data={
+            "search": "foo",
+            "montant_demande_min": "1000",
+            "montant_demande_max": "5000",
+            "order": "cout",
+        },
+    )
+    assert response.status_code == 200
+    soup = _soup(response)
+
+    search_tag = _tag_with(soup, "Recherche « foo »")
+    montant_tag = _tag_with(soup, "Montant demandé")
+    order_tag = _tag_with(soup, "Trié par")
+    assert search_tag is not None
+    assert montant_tag is not None
+    assert order_tag is not None
+
+    # Each tag drops only its own GET key(s), keeping the others.
+    search_href = search_tag["href"]
+    assert "search=foo" not in search_href
+    assert "montant_demande_min=1000" in search_href
+    assert "order=cout" in search_href
+
+    montant_href = montant_tag["href"]
+    assert "montant_demande_min" not in montant_href
+    assert "montant_demande_max" not in montant_href
+    assert "search=foo" in montant_href
+    assert "order=cout" in montant_href
+
+    order_href = order_tag["href"]
+    assert "order=" not in order_href
+    assert "search=foo" in order_href
+    assert "montant_demande_min=1000" in order_href
+
+
+def test_territoire_tag_shows_entity_name_not_verbose_str(client, perimetre):
+    """The territoire active tag shows the clean `entity_name` (e.g. the
+    departement name), not the verbose `Perimetre.__str__` form."""
+    ProjetFactory(dossier_ds__perimetre=perimetre)
+    response = client.get(
+        reverse("projet:list"), data={"territoire": str(perimetre.id)}
+    )
+    assert response.status_code == 200
+    soup = _soup(response)
+
+    tag = _tag_with(soup, "Territoire")
+    assert tag is not None
+    tag_text = tag.get_text(strip=True)
+    assert perimetre.entity_name in tag_text
+    # The verbose __str__ prefix must not leak into the tag.
+    assert str(perimetre) not in tag_text
+    assert "|" not in tag_text
+
+
+def test_active_extra_filter_stays_collapsed_but_shows_tag(client, perimetre):
+    """An active extra filter is surfaced as a tag, but the panel stays closed."""
+    NaturePorteurProjetFactory(label="EPCI", type=NaturePorteurProjet.EPCI)
+    ProjetFactory(dossier_ds__perimetre=perimetre)
+    response = client.get(reverse("projet:list"), data={"porteur": "epci"})
+    assert response.status_code == 200
+    soup = _soup(response)
+
+    # Panel is always collapsed on load; the active filter shows below as a tag.
+    extra = soup.select_one("#filters-extra")
+    assert "fr-collapse" in extra["class"]
+    assert soup.select_one("#filters-toggle")["aria-expanded"] == "false"
+    assert _tag_with(soup, "Demandeur") is not None
+
+
+# --- Programmation list (shared template, different filterset) ---
+
+
+def test_programmation_list_renders_fixed_fields_and_tags(client, perimetre):
+    enveloppe = DetrEnveloppeFactory(perimetre=perimetre, annee=2024)
+    ProgrammationProjetFactory(
+        dotation_projet__projet__dossier_ds__perimetre=perimetre,
+        enveloppe=enveloppe,
+    )
+    url = reverse(
+        "gsl_programmation:programmation-projet-list-dotation",
+        kwargs={"dotation": "DETR"},
+    )
+    response = client.get(url, data={"search": "bar"})
+    assert response.status_code == 200
+    soup = _soup(response)
+
+    # montant_retenu is a fixed field present on the programmation filterset
+    assert soup.select_one('input[name="search"]') is not None
+    assert soup.select_one("#filter-montant_retenu") is not None
+    assert _tag_with(soup, "Recherche « bar »") is not None
+
+
+# --- Simulation detail (shared template, montant_previsionnel replaces montant_retenu) ---
+
+
+def test_simulation_detail_fixed_row_shows_montant_previsionnel(client, perimetre):
+    enveloppe = DetrEnveloppeFactory(perimetre=perimetre)
+    simulation = SimulationFactory(enveloppe=enveloppe)
+    SimulationProjetFactory(
+        simulation=simulation,
+        dotation_projet__dotation=enveloppe.dotation,
+        dotation_projet__projet__dossier_ds__perimetre=perimetre,
+    )
+    url = reverse("simulation:simulation-detail", kwargs={"slug": simulation.slug})
+    response = client.get(url, data={"search": "baz"})
+    assert response.status_code == 200
+    soup = _soup(response)
+
+    # The fixed row surfaces montant_previsionnel in place of the absent montant_retenu
+    assert soup.select_one('input[name="search"]') is not None
+    assert soup.select_one("#filter-montant_retenu") is None
+    assert soup.select_one("#filter-montant_previsionnel") is not None
+    assert _tag_with(soup, "Recherche « baz »") is not None

--- a/gsl_projet/utils/django_filters_custom_widget.py
+++ b/gsl_projet/utils/django_filters_custom_widget.py
@@ -13,9 +13,12 @@ from gsl_simulation.models import SimulationProjet
 
 
 class CustomCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
-    def __init__(self, *args, placeholder=None, display_template=None, **kwargs):
+    def __init__(
+        self, *args, placeholder=None, display_template=None, label_attr=None, **kwargs
+    ):
         self.placeholder = placeholder
         self.display_template = display_template or "includes/_filter_multiselect.html"
+        self.label_attr = label_attr
         super().__init__(*args, **kwargs)
 
     def _get_color(self, option_value):
@@ -48,6 +51,26 @@ class CustomCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
             )
         return mark_safe("\n".join(output))
 
+    def active_tag_label(self, value, label):
+        """Tag text joining the labels of the selected choices, or '' if none.
+
+        `value` is a list of submitted values (MultipleChoiceFilter) or a
+        queryset of model instances (Model/LabelFromInstance filters). Model
+        instances are labelled via `self.label_attr` when set (mirroring the
+        filter field's own `label_from_instance`), otherwise they resolve
+        against the widget's own `str()`-keyed choice labels."""
+        if not value:
+            return ""
+        choice_dict = {str(k): v for k, v in self.choices}
+        parts = []
+        for item in value:
+            if hasattr(item, "pk") and self.label_attr:
+                parts.append(str(getattr(item, self.label_attr)))
+            else:
+                key = str(item.pk) if hasattr(item, "pk") else str(item)
+                parts.append(str(choice_dict.get(key, item)))
+        return f"{label} : {', '.join(parts)}"
+
 
 class DsfrRangeWidget(SuffixedMultiWidget):
     suffixes = ["min", "max"]
@@ -68,6 +91,21 @@ class DsfrRangeWidget(SuffixedMultiWidget):
         if value:
             return [value.start, value.stop]
         return [None, None]
+
+    def active_tag_label(self, value, label):
+        """Euro span ("de … à …" / "supérieur à …" / "inférieur à …"), or ''."""
+        from gsl_core.templatetags.gsl_filters import euro
+
+        if value is None:
+            return ""
+        start, stop = value.start, value.stop
+        if start is None and stop is None:
+            return ""
+        if start is not None and stop is not None:
+            return f"{label} de {euro(start)} à {euro(stop)}"
+        if start is not None:
+            return f"{label} supérieur à {euro(start)}"
+        return f"{label} inférieur à {euro(stop)}"
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
@@ -123,6 +161,20 @@ class DsfrDateRangeWidget(SuffixedMultiWidget):
         if value:
             return [value.start, value.stop]
         return [None, None]
+
+    def active_tag_label(self, value, label):
+        """Date span ("du … au …" / "à partir du …" / "jusqu'au …"), or ''."""
+        if value is None:
+            return ""
+        d1 = value.start.strftime("%d/%m/%Y") if value.start else None
+        d2 = value.stop.strftime("%d/%m/%Y") if value.stop else None
+        if not d1 and not d2:
+            return ""
+        if d1 and d2:
+            return f"{label} du {d1} au {d2}"
+        if d1:
+            return f"{label} à partir du {d1}"
+        return f"{label} jusqu'au {d2}"
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)

--- a/gsl_projet/utils/projet_filters.py
+++ b/gsl_projet/utils/projet_filters.py
@@ -261,7 +261,29 @@ def filter_dossier_complet(queryset, name, values):
     return queryset.filter(q)
 
 
-class ProjetFilters(FilterSet):
+class FixedFilterFieldsMixin:
+    """Filters always rendered in the top fixed row, in display order.
+    Names absent from a given FilterSet are skipped by the template."""
+
+    fixed_filter_fields = (
+        "search",
+        "categorie_detr",
+        "cout",
+        "montant_demande",
+        "montant_retenu",
+    )
+
+    @property
+    def fixed_fields(self):
+        """Bound fields for the fixed top row, in display order, skipping absent names."""
+        return [
+            self.form[name]
+            for name in self.fixed_filter_fields
+            if name in self.form.fields
+        ]
+
+
+class ProjetFilters(FixedFilterFieldsMixin, FilterSet):
     order = ProjetOrderingFilter(
         fields=ORDERING_MAP,
         empty_label="Tri",
@@ -358,10 +380,12 @@ class ProjetFilters(FilterSet):
     )
 
     territoire = LabelFromInstanceFilter(
+        label="Territoire",
         method="filter_territoire",
         queryset=Perimetre.objects.none(),
         widget=CustomCheckboxSelectMultiple(
-            display_template="includes/_filter_territoire.html"
+            display_template="includes/_filter_territoire.html",
+            label_attr="entity_name",
         ),
         label_attr="entity_name",
     )

--- a/gsl_simulation/filters.py
+++ b/gsl_simulation/filters.py
@@ -30,6 +30,7 @@ from gsl_projet.utils.projet_filters import (
     DOTATION_SOLLICITEE_CHOICES,
     ORDERING_MAP,
     OUI_NON_CHOICES,
+    FixedFilterFieldsMixin,
     LabelFromInstanceFilter,
     ProjetOrderingFilter,
     filter_boolean,
@@ -42,7 +43,18 @@ from gsl_projet.utils.utils import order_couples_tuple_by_first_value
 from gsl_simulation.models import SimulationProjet
 
 
-class SimulationProjetFilters(FilterSet):
+class SimulationProjetFilters(FixedFilterFieldsMixin, FilterSet):
+    # Simulations have no "montant retenu" (programmation only); the fixed row
+    # surfaces the "montant prévisionnel accordé" in its place.
+    fixed_filter_fields = (
+        "search",
+        "categorie_detr",
+        "categorie_dsil",
+        "cout",
+        "montant_demande",
+        "montant_previsionnel",
+    )
+
     def __init__(self, *args, slug=None, dotation=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.slug = slug or self.request.resolver_match.kwargs.get("slug")
@@ -198,10 +210,12 @@ class SimulationProjetFilters(FilterSet):
     )
 
     territoire = LabelFromInstanceFilter(
+        label="Territoire",
         method="filter_territoire",
         queryset=Perimetre.objects.none(),
         widget=CustomCheckboxSelectMultiple(
-            display_template="includes/_filter_territoire.html"
+            display_template="includes/_filter_territoire.html",
+            label_attr="entity_name",
         ),
         label_attr="entity_name",
     )

--- a/gsl_simulation/tests/test_filters.py
+++ b/gsl_simulation/tests/test_filters.py
@@ -1,0 +1,54 @@
+import pytest
+from django.test import RequestFactory
+
+from gsl_core.tests.factories import (
+    CollegueFactory,
+    PerimetreDepartementalFactory,
+)
+from gsl_projet.constants import DOTATION_DETR, DOTATION_DSIL
+from gsl_simulation.filters import SimulationProjetFilters
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def perimetre():
+    return PerimetreDepartementalFactory()
+
+
+@pytest.fixture
+def user(perimetre):
+    return CollegueFactory(perimetre=perimetre)
+
+
+@pytest.fixture
+def request_factory():
+    return RequestFactory()
+
+
+@pytest.fixture
+def mock_request(request_factory, user):
+    request = request_factory.get("/")
+    request.user = user
+    request.resolver_match = type(
+        "MockResolverMatch", (), {"kwargs": {"slug": "ma-simulation"}}
+    )()
+    return request
+
+
+def test_fixed_fields_show_detr_category_on_detr_simulation(mock_request):
+    """On a DETR simulation page, the DETR category sits in the fixed row and
+    the DSIL category is absent."""
+    filterset = SimulationProjetFilters(request=mock_request, dotation=DOTATION_DETR)
+    fixed_names = [field.name for field in filterset.fixed_fields]
+    assert "categorie_detr" in fixed_names
+    assert "categorie_dsil" not in fixed_names
+
+
+def test_fixed_fields_show_dsil_category_on_dsil_simulation(mock_request):
+    """On a DSIL simulation page, the DSIL category sits in the fixed row and
+    the DETR category is absent."""
+    filterset = SimulationProjetFilters(request=mock_request, dotation=DOTATION_DSIL)
+    fixed_names = [field.name for field in filterset.fixed_fields]
+    assert "categorie_dsil" in fixed_names
+    assert "categorie_detr" not in fixed_names


### PR DESCRIPTION
## 🌮 Objectif

Repenser la barre de filtres des listes (projets, simulations, programmation) avec des tags de filtres actifs et une disposition plus claire.

## 🔍 Liste des modifications

- Affichage des filtres appliqués sous forme de tags DSFR supprimables individuellement (chaque lien ne retire que la clé GET du filtre concerné, suffixes `_min`/`_max` compris)
- Séparation des filtres en une rangée principale fixe et une section repliable « Afficher tous les filtres », pilotée par `FixedFilterFieldsMixin` partagé entre projets, simulations et programmation
- Ajout des tags de gabarit `active_filter_tag` et `remove_filter_qs` ; chaque widget personnalisé décrit sa valeur active via `active_tag_label`
- Déplacement de l'icône des boutons déroulants à droite du libellé et simplification du CSS de la barre de filtres
- Ajout de tests (rendu des tags actifs, suppression individuelle, rangée fixe adaptée à chaque contexte)
- Note de documentation dans `AGENTS.md` : privilégier les classes utilitaires DSFR au CSS personnalisé
