### PR TITLE
SafeRedirectMixin pour les redirections POST-next/Referer

### DIFF
--- a/gsl_core/view_mixins.py
+++ b/gsl_core/view_mixins.py
@@ -1,5 +1,17 @@
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.utils.http import url_has_allowed_host_and_scheme
 from django_htmx.http import trigger_client_event
+
+
+class SafeRedirectMixin:
+    def get_safe_redirect_url(self, fallback="/"):
+        request = self.request
+        url = request.POST.get("next") or request.headers.get("Referer")
+        if url and url_has_allowed_host_and_scheme(
+            url, allowed_hosts=request.get_host(), require_https=request.is_secure()
+        ):
+            return url
+        return fallback
 
 
 class OpenHtmxModalMixin:

--- a/gsl_demarches_simplifiees/views.py
+++ b/gsl_demarches_simplifiees/views.py
@@ -5,10 +5,11 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from django.views.generic import UpdateView
 from django.views.generic.detail import SingleObjectMixin
+
+from gsl_core.view_mixins import SafeRedirectMixin
 
 from .exceptions import DsServiceException
 from .forms import DossierReporteSansPieceForm
@@ -18,7 +19,7 @@ from .models import Demarche, Dossier
 logger = logging.getLogger(__name__)
 
 
-class RefreshOneDossierView(SingleObjectMixin, View):
+class RefreshOneDossierView(SafeRedirectMixin, SingleObjectMixin, View):
     http_method_names = ["post"]
     model = Dossier
     slug_url_kwarg = "dossier_ds_number"
@@ -42,17 +43,7 @@ class RefreshOneDossierView(SingleObjectMixin, View):
                 ),
             )
 
-        url = request.POST.get("next")
-        if not url:
-            url = request.headers.get("Referer")
-
-        is_url_safe = url_has_allowed_host_and_scheme(
-            url, allowed_hosts=request.get_host(), require_https=request.is_secure()
-        )
-        if is_url_safe:
-            return redirect(url)
-
-        return redirect("/")
+        return redirect(self.get_safe_redirect_url())
 
 
 @staff_member_required

--- a/gsl_notification/views/modele_views.py
+++ b/gsl_notification/views/modele_views.py
@@ -426,18 +426,18 @@ class DeleteModeleView(DeleteView):
 
         try:
             response = super().form_valid(form)
-            type_and_article = (
-                "d’arrêté" if modele_type == ARRETE else "de lettre de notification"
-            )
-            messages.info(
-                self.request,
-                f"Le modèle {type_and_article} “{name}” a été supprimé.",
-                extra_tags="delete_modele_arrete",
-            )
         except ProtectedError as e:
             _add_error_message(self.request, len(e.protected_objects), modele_type)
             return redirect(self.get_success_url())
 
+        type_and_article = (
+            "d’arrêté" if modele_type == ARRETE else "de lettre de notification"
+        )
+        messages.info(
+            self.request,
+            f"Le modèle {type_and_article} “{name}” a été supprimé.",
+            extra_tags="delete_modele_arrete",
+        )
         return response
 
 

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -76,25 +76,16 @@ class ProjetCommentUpdateView(SafeRedirectMixin, UpdateView):
     def get_queryset(self):
         return Projet.objects.active().for_user(self.request.user)
 
+    def get_success_url(self):
+        return reverse("projet:get-projet-notes", kwargs={"projet_id": self.object.pk})
+
     def form_valid(self, form):
         self.object = form.save()
         messages.success(self.request, "Le commentaire a été enregistré avec succès.")
-        return redirect(
-            self.get_safe_redirect_url(
-                fallback=reverse(
-                    "projet:get-projet-notes", kwargs={"projet_id": self.object.pk}
-                )
-            )
-        )
+        return redirect(self.get_safe_redirect_url(fallback=self.get_success_url()))
 
     def form_invalid(self, form):
-        return redirect(
-            self.get_safe_redirect_url(
-                fallback=reverse(
-                    "projet:get-projet-notes", kwargs={"projet_id": self.object.pk}
-                )
-            )
-        )
+        return redirect(self.get_safe_redirect_url(fallback=self.get_success_url()))
 
 
 class ProjetListViewFilters(ProjetFilters):

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -2,11 +2,11 @@ from django.contrib import messages
 from django.db.models import Case, DecimalField, F, Max, Prefetch, Q, Sum, When
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic import DetailView, ListView, UpdateView
 from django_filters.views import FilterView
 
 from gsl_core.models import Perimetre
+from gsl_core.view_mixins import SafeRedirectMixin
 from gsl_demarches_simplifiees.models import (
     CategorieDetr,
     CategorieDsil,
@@ -67,7 +67,7 @@ class ProjetHistoriqueView(BaseProjetDetailView):
         return context
 
 
-class ProjetCommentUpdateView(UpdateView):
+class ProjetCommentUpdateView(SafeRedirectMixin, UpdateView):
     model = Projet
     form_class = ProjetCommentForm
     pk_url_kwarg = "projet_id"
@@ -76,21 +76,25 @@ class ProjetCommentUpdateView(UpdateView):
     def get_queryset(self):
         return Projet.objects.active().for_user(self.request.user)
 
-    def _get_redirect_url(self):
-        next_url = self.request.POST.get("next")
-        if next_url and url_has_allowed_host_and_scheme(
-            next_url, allowed_hosts=self.request.get_host()
-        ):
-            return next_url
-        return reverse("projet:get-projet-notes", kwargs={"projet_id": self.object.pk})
-
     def form_valid(self, form):
         self.object = form.save()
         messages.success(self.request, "Le commentaire a été enregistré avec succès.")
-        return redirect(self._get_redirect_url())
+        return redirect(
+            self.get_safe_redirect_url(
+                fallback=reverse(
+                    "projet:get-projet-notes", kwargs={"projet_id": self.object.pk}
+                )
+            )
+        )
 
     def form_invalid(self, form):
-        return redirect(self._get_redirect_url())
+        return redirect(
+            self.get_safe_redirect_url(
+                fallback=reverse(
+                    "projet:get-projet-notes", kwargs={"projet_id": self.object.pk}
+                )
+            )
+        )
 
 
 class ProjetListViewFilters(ProjetFilters):


### PR DESCRIPTION
## 🌮 Objectif

Extraire le pattern de redirection sécurisée (POST `next` → `Referer` → fallback) dans un `SafeRedirectMixin` réutilisable, comme suggéré en review de #754.

Fix #754 (commentaire jillro sur le redirect)

## 🔍 Liste des modifications

- **`gsl_core/view_mixins.py`** : ajout de `SafeRedirectMixin.get_safe_redirect_url(fallback="/")` — vérifie `POST["next"]` puis l'en-tête `Referer`, avec `url_has_allowed_host_and_scheme` et `require_https`
- **`gsl_demarches_simplifiees/views.py`** : `RefreshOneDossierView` utilise le mixin (suppression du code inline)
- **`gsl_projet/views.py`** : `ProjetCommentUpdateView` utilise le mixin (suppression de `_get_redirect_url`)
- **`gsl_notification/views/modele_views.py`** : correction de `DeleteModeleView.form_valid` — le message de succès et `return response` sont maintenant hors du `try` block (correction d'un `UnboundLocalError` sur `ProtectedError`)

## ⚠️ Informations supplémentaires

Les usages de `url_has_allowed_host_and_scheme` dans `gsl_core/views.py` (GET + POST `next`) et `gsl_simulation/` (GET seul, ou fonction standalone avec Referer) ont des patterns trop différents pour utiliser ce mixin sans changement de comportement non souhaité.