### PR TITLE
Gérer le cas où go_back_link est None dans le menu principal

### DIFF
--- a/gsl_core/templates/blocks/main_menu.html
+++ b/gsl_core/templates/blocks/main_menu.html
@@ -22,7 +22,7 @@
                         <a class="fr-nav__link"
                            href="{{ projets_url }}"
                            target="_self"
-                           {% if "/projets/" in request.path or "/notification/" in request.path and "/notification/modeles/" not in request.path %}{% if "/programmation/" not in go_back_link %}aria-current="true"{% endif %}
+                           {% if "/projets/" in request.path or "/notification/" in request.path and "/notification/modeles/" not in request.path %}{% if go_back_link is None or "/programmation/" not in go_back_link %}aria-current="true"{% endif %}
                            {% endif %}>Liste des projets</a>
                     </li>
                     <li class="fr-nav__item">


### PR DESCRIPTION
## 🌮 Objectif

Corriger une erreur silencieuse dans le menu principal : la condition `"/programmation/" not in go_back_link` plantait si `go_back_link` est `None`.

## 🔍 Liste des modifications

- Ajout d'une vérification `go_back_link is None` avant le test `not in` pour court-circuiter proprement quand la variable n'est pas définie