### PR TITLE
Rendre le champ enveloppe readonly dans l'admin ProjetAction

### DIFF
--- a/gsl_historique/admin.py
+++ b/gsl_historique/admin.py
@@ -22,6 +22,7 @@ class ProjetActionAdmin(admin.ModelAdmin):
     search_fields = ("projet__dossier_ds__ds_number",)
     readonly_fields = (
         "projet",
+        "enveloppe",
         "action_type",
         "created_at",
         "actor",


### PR DESCRIPTION
## 🌮 Objectif

Éviter un problème de performance dans l'admin Django : le champ `enveloppe` de `ProjetActionAdmin` était éditable, ce qui chargeait toutes les enveloppes en base dans un dropdown.

## 🔍 Liste des modifications

- `gsl_historique/admin.py` : ajout de `"enveloppe"` dans `readonly_fields` de `ProjetActionAdmin`