### PR TITLE
Augmenter le timeout Gunicorn à 120s pour la génération de documents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,6 @@ SCALEWAY_S3_REGION=
 # SMTP_URL=
 # DEFAULT_FROM_EMAIL=turgot-alerts@turgot.beta.gouv.fr
 # ADMIN_ALERT_RECIPIENTS=ops@example.fr,admin@example.fr
+
+# Timeout Gunicorn en secondes (30 par défaut ; augmenter en prod si la génération de documents est lente)
+# GUNICORN_TIMEOUT=120

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-gunicorn gsl.wsgi --log-file - --timeout 120
+gunicorn gsl.wsgi --log-file - --timeout "${GUNICORN_TIMEOUT:-30}"

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-gunicorn gsl.wsgi --log-file -
+gunicorn gsl.wsgi --log-file - --timeout 120


### PR DESCRIPTION
## 🌮 Objectif

Stopper les `SystemExit` Sentry et les blocages infinis lors de la génération par lot de documents PDF.

[Erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/286467/?environment=prod&query=is%3Aunresolved&referrer=issue-stream&sort=date)

## 🔍 Liste des modifications

- `bin/start.sh` : ajout de `--timeout "\${GUNICORN_TIMEOUT:-30}"` à la commande Gunicorn
- `.env.example` : documentation de la variable `GUNICORN_TIMEOUT`

## ⚠️ Informations supplémentaires

**Cause racine :** Gunicorn utilise un timeout de 30 s par défaut. La génération PDF par lot (WeasyPrint × N projets) dépasse cette limite → Gunicorn kill le worker avec `SIGTERM` → Python lève `SystemExit` → l'utilisateur voit le spinner indéfiniment.

**Action requise en production :** ajouter la variable d'environnement `GUNICORN_TIMEOUT=120` dans Scalingo (ou la valeur souhaitée). Sans cette variable, le timeout reste à 30 s (comportement actuel).

Cette PR est un **stopgap** : elle rend le timeout configurable et couvre la majorité des cas en prod. Une PR de fond (PR #764) suivra pour déléguer la génération PDF à Celery (tâche async + polling HTMX), ce qui supprimera la dépendance au timeout Gunicorn.