### PR TITLE
Initialiser l'assiette d'un DotationProjet à finance_cout_total par défaut

### DIFF
--- a/gsl_demarches_simplifiees/tests/test_forms.py
+++ b/gsl_demarches_simplifiees/tests/test_forms.py
@@ -214,6 +214,33 @@ class TestDossierReporteSansPieceForm:
         assert DOTATION_DETR in saved_dossier.demande_dispositif_sollicite
         assert DOTATION_DSIL in saved_dossier.demande_dispositif_sollicite
 
+    def test_form_save_creates_dotation_projet_with_assiette_from_finance_cout_total(
+        self,
+    ):
+        dossier = DossierFactory(
+            demande_dispositif_sollicite="",
+            finance_cout_total=None,
+            annotations_assiette_detr=None,
+        )
+        ProjetFactory(dossier_ds=dossier)
+
+        form_data = {
+            "demande_dispositif_sollicite": [DOTATION_DETR],
+            "finance_cout_total": "100000.00",
+            "demande_montant": "50000.00",
+        }
+        form = DossierReporteSansPieceForm(data=form_data, instance=dossier)
+        assert form.is_valid(), form.errors
+
+        form.save()
+
+        from gsl_projet.models import DotationProjet
+
+        dp = DotationProjet.objects.get(
+            projet__dossier_ds=dossier, dotation=DOTATION_DETR
+        )
+        assert dp.assiette == Decimal("100000.00")
+
 
 class TestDossierReporteSansPieceFormCategories:
     @pytest.fixture

--- a/gsl_programmation/tests/models/test_programmation_projet.py
+++ b/gsl_programmation/tests/models/test_programmation_projet.py
@@ -87,7 +87,7 @@ def test_programmation_projet_cant_have_a_montant_higher_than_projet_cout_total(
         pp = ProgrammationProjetFactory(dotation_projet=dotation_projet, montant=101)
         pp.full_clean()
     assert (
-        "Le montant de la programmation ne peut pas être supérieur au coût total du projet pour cette dotation."
+        "Le montant de la programmation ne peut pas être supérieur à l'assiette du projet pour cette dotation."
         in exc_info.value.message_dict.get("montant")[0]
     )
 

--- a/gsl_projet/migrations/0037_backfill_dotation_projet_assiette.py
+++ b/gsl_projet/migrations/0037_backfill_dotation_projet_assiette.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+
+DOTATION_DETR = "DETR"
+DOTATION_DSIL = "DSIL"
+
+
+def backfill_assiette(apps, schema_editor):
+    DotationProjet = apps.get_model("gsl_projet", "DotationProjet")
+
+    for dp in DotationProjet.objects.filter(assiette__isnull=True).select_related(
+        "projet__dossier_ds"
+    ):
+        dossier = dp.projet.dossier_ds
+
+        if dp.dotation == DOTATION_DETR:
+            assiette = dossier.annotations_assiette_detr
+        elif dp.dotation == DOTATION_DSIL:
+            assiette = dossier.annotations_assiette_dsil
+        else:
+            assiette = None
+
+        if assiette is None:
+            assiette = dossier.finance_cout_total
+
+        if assiette is not None:
+            dp.assiette = assiette
+            dp.save(update_fields=["assiette"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("gsl_projet", "0036_remove_projet_demandeur_delete_demandeur"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_assiette, migrations.RunPython.noop),
+    ]

--- a/gsl_projet/models.py
+++ b/gsl_projet/models.py
@@ -647,6 +647,20 @@ class DotationProjet(BaseModel):
                     f"La catégorie DETR « {categorie.libelle} » n'appartient pas au même département que le projet."
                 )
 
+    def save(self, *args, **kwargs):
+        if self._state.adding and self.assiette is None:
+            dossier = self.dossier_ds
+            if self.dotation == DOTATION_DETR:
+                annotation_assiette = dossier.annotations_assiette_detr
+            else:
+                annotation_assiette = dossier.annotations_assiette_dsil
+            self.assiette = (
+                annotation_assiette
+                if annotation_assiette is not None
+                else dossier.finance_cout_total
+            )
+        super().save(*args, **kwargs)
+
     @property
     def dossier_ds(self):
         return self.projet.dossier_ds

--- a/gsl_projet/services/dotation_projet_services.py
+++ b/gsl_projet/services/dotation_projet_services.py
@@ -181,20 +181,15 @@ class DotationProjetService:
         detr_avis_commission = cls._get_detr_avis_commission(
             dotation, projet.dossier_ds
         )
-        log_level = (
-            logging.WARNING
-            if projet.dossier_ds.ds_state == Dossier.STATE_ACCEPTE
-            else logging.INFO
-        )
-        assiette = cls._get_assiette_from_dossier(
-            projet.dossier_ds, dotation, log_level
-        )
-        return DotationProjet.objects.create(
-            projet=projet,
-            dotation=dotation,
-            detr_avis_commission=detr_avis_commission,
-            assiette=assiette,
-        )
+        assiette = cls._get_assiette_from_annotations(projet.dossier_ds, dotation)
+        kwargs = {
+            "projet": projet,
+            "dotation": dotation,
+            "detr_avis_commission": detr_avis_commission,
+        }
+        if assiette is not None:
+            kwargs["assiette"] = assiette
+        return DotationProjet.objects.create(**kwargs)
 
     ## -------------------------- Update Dotation Projets --------------------------
 
@@ -290,7 +285,7 @@ class DotationProjetService:
             dotation=dotation,
         )
 
-        assiette = cls._get_assiette_from_dossier(projet.dossier_ds, dotation)
+        assiette = cls._get_assiette_from_annotations(projet.dossier_ds, dotation)
         if assiette is not None:  # we only update if we have an info
             dotation_projet.assiette = assiette
 
@@ -491,45 +486,35 @@ class DotationProjetService:
         from gsl_historique.models import ProjetAction
 
         for dotation_projet in projet.dotationprojet_set.all():
-            assiette = cls._get_assiette_from_dossier(
+            assiette = cls._get_assiette_from_annotations(
                 projet.dossier_ds, dotation_projet.dotation
             )
-            if assiette is not None:
-                if dotation_projet.assiette != assiette:
-                    ProjetAction.objects.create(
-                        projet=projet,
-                        action_type=ProjetAction.TYPE_ASSIETTE_MODIFIED,
-                        actor=None,
-                        source=ProjetAction.SOURCE_DN,
-                        dotation=dotation_projet.dotation,
-                        euro_field_value=assiette,
-                    )
-                dotation_projet.assiette = assiette
+            if assiette is None:
+                continue
+
+            if dotation_projet.assiette != assiette:
+                ProjetAction.objects.create(
+                    projet=projet,
+                    action_type=ProjetAction.TYPE_ASSIETTE_MODIFIED,
+                    actor=None,
+                    source=ProjetAction.SOURCE_DN,
+                    dotation=dotation_projet.dotation,
+                    euro_field_value=assiette,
+                )
+
+            dotation_projet.assiette = assiette
             dotation_projet.save()
 
     @classmethod
-    def _get_assiette_from_dossier(
+    def _get_assiette_from_annotations(
         cls,
         dossier: Dossier,
         dotation: POSSIBLE_DOTATIONS,
-        log_level: int = logging.WARNING,
     ) -> float | None:
         if dotation == DOTATION_DETR:
-            assiette = dossier.annotations_assiette_detr
-        elif dotation == DOTATION_DSIL:
-            assiette = dossier.annotations_assiette_dsil
+            return dossier.annotations_assiette_detr
 
-        if assiette is None:
-            logger.log(
-                log_level,
-                "Assiette is missing in dossier annotations",
-                extra={
-                    "dossier_ds_number": dossier.ds_number,
-                    "dotation": dotation,
-                },
-            )
-            return None
-        return assiette
+        return dossier.annotations_assiette_dsil
 
     @classmethod
     def _get_montant_from_dossier(cls, dossier: Dossier, dotation: POSSIBLE_DOTATIONS):

--- a/gsl_projet/tests/models/test_dotation_projet.py
+++ b/gsl_projet/tests/models/test_dotation_projet.py
@@ -779,3 +779,69 @@ def test_categorie_detr_dotation_constraint():
         "Les catégories DETR ne doivent être renseignées que pour les projets DETR"
         in str(excinfo.value)
     )
+
+
+# -- save() default assiette --
+
+
+def test_dotation_projet_assiette_defaults_to_finance_cout_total_when_no_annotation():
+    dp = DotationProjetFactory(
+        dotation=DOTATION_DETR,
+        assiette=None,
+        projet__dossier_ds__finance_cout_total=50_000,
+        projet__dossier_ds__annotations_assiette_detr=None,
+    )
+    assert dp.assiette == 50_000
+
+
+def test_dotation_projet_assiette_uses_detr_annotation_when_set():
+    dp = DotationProjetFactory(
+        dotation=DOTATION_DETR,
+        assiette=None,
+        projet__dossier_ds__finance_cout_total=50_000,
+        projet__dossier_ds__annotations_assiette_detr=30_000,
+    )
+    assert dp.assiette == 30_000
+
+
+def test_dotation_projet_assiette_uses_dsil_annotation_when_set():
+    dp = DotationProjetFactory(
+        dotation=DOTATION_DSIL,
+        assiette=None,
+        projet__dossier_ds__finance_cout_total=50_000,
+        projet__dossier_ds__annotations_assiette_dsil=20_000,
+    )
+    assert dp.assiette == 20_000
+
+
+def test_dotation_projet_assiette_explicit_value_kept():
+    dp = DotationProjetFactory(
+        assiette=30_000,
+        projet__dossier_ds__finance_cout_total=50_000,
+    )
+    assert dp.assiette == 30_000
+
+
+def test_dotation_projet_assiette_stays_none_when_no_cout_total_and_no_annotation():
+    dp = DotationProjetFactory(
+        dotation=DOTATION_DETR,
+        assiette=None,
+        projet__dossier_ds__finance_cout_total=None,
+        projet__dossier_ds__annotations_assiette_detr=None,
+    )
+    assert dp.assiette is None
+
+
+def test_dotation_projet_save_update_does_not_reset_assiette():
+    dp = DotationProjetFactory(
+        dotation=DOTATION_DETR,
+        assiette=None,
+        projet__dossier_ds__finance_cout_total=50_000,
+        projet__dossier_ds__annotations_assiette_detr=None,
+    )
+    assert dp.assiette == 50_000
+
+    dp.assiette = None
+    dp.save()
+    dp.refresh_from_db()
+    assert dp.assiette is None

--- a/gsl_projet/tests/services/dotation_projet/test_initialize.py
+++ b/gsl_projet/tests/services/dotation_projet/test_initialize.py
@@ -132,7 +132,7 @@ def test_initialize_dotation_projets_from_projet_accepted_with_empty_annotations
     assert detr_dp.programmation_projet.status == PROJET_STATUS_ACCEPTED
 
     # Check log message, level and extra
-    assert len(caplog.records) == 3
+    assert len(caplog.records) == 2
 
     record = caplog.records[0]
     assert (
@@ -146,12 +146,6 @@ def test_initialize_dotation_projets_from_projet_accepted_with_empty_annotations
     assert getattr(record, "field", None) == "annotations_dotation"
 
     record = caplog.records[1]
-    assert record.message == "Assiette is missing in dossier annotations"
-    assert record.levelname == "WARNING"
-    assert getattr(record, "dossier_ds_number", None) == projet.dossier_ds.ds_number
-    assert getattr(record, "dotation", None) == DOTATION_DETR
-
-    record = caplog.records[2]
     assert record.message == "Montant is missing in dossier annotations"
     assert record.levelname == "WARNING"
     assert getattr(record, "dossier_ds_number", None) == projet.dossier_ds.ds_number

--- a/gsl_projet/tests/services/dotation_projet/test_update.py
+++ b/gsl_projet/tests/services/dotation_projet/test_update.py
@@ -731,10 +731,10 @@ def test_update_assiette_from_dossier_does_not_create_action_when_assiette_uncha
 
 
 @pytest.mark.django_db
-def test_update_assiette_from_dossier_creates_action_when_assiette_was_none():
+def test_update_assiette_from_dossier_creates_action_when_assiette_changed():
     dotation_projet = DotationProjetFactory(
         dotation=DOTATION_DETR,
-        assiette=None,
+        assiette=10_000,
         projet__dossier_ds__annotations_assiette_detr=15_000,
     )
 

--- a/gsl_projet/tests/services/dotation_projet/test_update.py
+++ b/gsl_projet/tests/services/dotation_projet/test_update.py
@@ -356,14 +356,8 @@ def test_update_dotation_projets_from_projet_accepted_with_empty_annotations_dot
     detr_dp = DotationProjet.objects.get(projet=projet, dotation=DOTATION_DETR)
     assert detr_dp.status == PROJET_STATUS_PROCESSING
 
-    assert len(caplog.records) == 2
+    assert len(caplog.records) == 1
     record = caplog.records[0]
-    assert record.message == "Assiette is missing in dossier annotations"
-    assert record.levelname == "INFO", (
-        "Log level should be INFO because the dossier is in EN_INSTRUCTION during initialization"
-    )
-
-    record = caplog.records[1]
     assert (
         record.message
         == "No dotations found in annotations_dotation for accepted dossier during update"

--- a/gsl_projet/tests/services/dotation_projet/test_utils.py
+++ b/gsl_projet/tests/services/dotation_projet/test_utils.py
@@ -191,22 +191,18 @@ def test_get_dotations_from_field(field, value, expected_dotation):
 
 @pytest.mark.django_db
 @freeze_time("2025-05-06")
-def test_get_assiette_from_dossier_handles_missing_assiette(caplog):
-    """Test _get_assiette_from_dossier handles missing assiette"""
+def test_get_assiette_from_annotations_handles_missing_assiette(caplog):
+    """Test _get_assiette_from_annotations handles missing assiette"""
     projet = ProjetFactory(
         dossier_ds__annotations_assiette_detr=None,
         dossier_ds__annotations_assiette_dsil=None,
     )
 
-    assiette_detr = dps._get_assiette_from_dossier(projet.dossier_ds, DOTATION_DETR)
+    assiette_detr = dps._get_assiette_from_annotations(projet.dossier_ds, DOTATION_DETR)
     assert assiette_detr is None
 
-    assiette_dsil = dps._get_assiette_from_dossier(projet.dossier_ds, DOTATION_DSIL)
+    assiette_dsil = dps._get_assiette_from_annotations(projet.dossier_ds, DOTATION_DSIL)
     assert assiette_dsil is None
-
-    # Check that warnings were logged
-    assert len(caplog.records) == 2
-    assert "Assiette is missing" in caplog.records[0].message
 
 
 # -- get_montant_from_dossier --

--- a/gsl_projet/tests/test_tasks.py
+++ b/gsl_projet/tests/test_tasks.py
@@ -134,7 +134,7 @@ def test_task_create_or_update_projet_and_co_from_dossier_with_construction_one(
     assert dotation_projets.count() == 1
     dotation_projet = dotation_projets.first()  # always exists
     assert dotation_projet.dotation == DOTATION_DETR
-    assert dotation_projet.assiette is None
+    assert dotation_projet.assiette == 4_000
     assert dotation_projet.status == PROJET_STATUS_ACCEPTED  # always exists
 
     for simulation_projet in dotation_projet.simulationprojet_set.all():
@@ -192,7 +192,7 @@ def test_task_create_or_update_projet_and_co_from_dossier_with_instruction_one_a
     assert dotation_projets.count() == 1
     dotation_projet = dotation_projets.first()
     assert dotation_projet.dotation == DOTATION_DETR
-    assert dotation_projet.assiette is None
+    assert dotation_projet.assiette == 4_000
     assert dotation_projet.status == PROJET_STATUS_ACCEPTED
 
     for simulation_projet in dotation_projet.simulationprojet_set.all():
@@ -252,7 +252,7 @@ def test_task_create_or_update_projet_and_co_from_dossier_with_instruction_one_a
     assert dotation_projets.count() == 1
     dotation_projet = dotation_projets.first()
     assert dotation_projet.dotation == DOTATION_DETR
-    assert dotation_projet.assiette is None
+    assert dotation_projet.assiette == 4_000
     assert dotation_projet.status == PROJET_STATUS_ACCEPTED
 
     for simulation_projet in dotation_projet.simulationprojet_set.all():

--- a/gsl_simulation/tests/test_models.py
+++ b/gsl_simulation/tests/test_models.py
@@ -146,7 +146,7 @@ def test_simulation_projet_cant_have_a_montant_higher_than_projet_cout_total():
         )
         sp.clean()
     assert (
-        "Le montant doit être inférieur ou égal au coût total du projet."
+        "Le montant doit être inférieur ou égal à l'assiette du projet pour cette dotation."
         in exc_info.value.messages
     )
 


### PR DESCRIPTION
## 🌮 Objectif

Donner à chaque `DotationProjet` une assiette raisonnée dès sa création, sans attendre que les annotations DS soient renseignées.

## 🔍 Liste des modifications

- `DotationProjet.save()` : à la création, si `assiette` est `None`, l'initialise en priorité à l'annotation DN correspondante (`annotations_assiette_detr` ou `annotations_assiette_dsil` selon la dotation), et en fallback à `dossier_ds.finance_cout_total` (reste `None` si les deux sont absents)
- `_get_assiette_from_dossier` → renommé `_get_assiette_from_annotations` pour clarifier que la méthode lit uniquement les annotations DN (plus de log de warning quand l'annotation est absente)
- `_create_dotation_projet` : n'envoie plus `assiette=None` explicitement ; laisse le `save()` du modèle appliquer le défaut
- `_update_assiette_from_dossier` : ne met à jour l'assiette que si une annotation est renseignée (comportement inchangé, code simplifié)
- Migration de backfill : applique la même logique (annotation → finance_cout_total) aux `DotationProjet` existants sans assiette
- Tests : correction des assertions caplog obsolètes + nouveaux tests couvrant les cas annotation DETR, annotation DSIL et fallback finance_cout_total