### PR TITLE
Page projet unifiée avec onglet Simulations

### DIFF
--- a/gsl_core/static/js/controllers/radioNavigate.js
+++ b/gsl_core/static/js/controllers/radioNavigate.js
@@ -1,0 +1,14 @@
+import { Controller } from 'stimulus'
+
+export class RadioNavigate extends Controller {
+  static values = {
+    baseUrl: String
+  }
+
+  navigate (event) {
+    const value = event.target.value
+    window.location.href = value
+      ? `${this.baseUrlValue}?dotation=${value}`
+      : this.baseUrlValue
+  }
+}

--- a/gsl_core/static/js/controllers/radioNavigate.js
+++ b/gsl_core/static/js/controllers/radioNavigate.js
@@ -1,14 +1,14 @@
 import { Controller } from 'stimulus'
 
 export class RadioNavigate extends Controller {
-  static values = {
-    baseUrl: String
-  }
-
   navigate (event) {
+    const url = new URL(window.location.href)
     const value = event.target.value
-    window.location.href = value
-      ? `${this.baseUrlValue}?dotation=${value}`
-      : this.baseUrlValue
+    if (value) {
+      url.searchParams.set('dotation', value)
+    } else {
+      url.searchParams.delete('dotation')
+    }
+    window.location.href = url.toString()
   }
 }

--- a/gsl_core/static/js/controllers/radioNavigate.js
+++ b/gsl_core/static/js/controllers/radioNavigate.js
@@ -1,7 +1,17 @@
 import { Controller } from 'stimulus'
 
 export class RadioNavigate extends Controller {
+  onKeydown (event) {
+    if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) {
+      this._skipNextChange = true
+    }
+  }
+
   navigate (event) {
+    if (this._skipNextChange) {
+      this._skipNextChange = false
+      return
+    }
     const url = new URL(window.location.href)
     const value = event.target.value
     if (value) {

--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -62,7 +62,8 @@
                     "commentArbitrage": "{% static 'js/controllers/commentArbitrage.js' %}",
                     "projetForm": "{% static 'js/controllers/projetForm.js' %}",
                     "projetNotes": "{% static 'js/controllers/projetNotes.js' %}",
-                    "projetNoteCard": "{% static 'js/controllers/projetNoteCard.js' %}"
+                    "projetNoteCard": "{% static 'js/controllers/projetNoteCard.js' %}",
+                    "radioNavigate": "{% static 'js/controllers/radioNavigate.js' %}"
                 }
             }
             </script>
@@ -138,6 +139,7 @@
             import { ProjetForm } from "projetForm"
             import { ProjetNotes } from "projetNotes"
             import { ProjetNoteCard } from "projetNoteCard"
+            import { RadioNavigate } from "radioNavigate"
 
             window.Stimulus = Application.start()
 
@@ -156,6 +158,7 @@
             Stimulus.register("projet-form", ProjetForm)
             Stimulus.register("projet-notes", ProjetNotes)
             Stimulus.register("projet-note-card", ProjetNoteCard)
+            Stimulus.register("radio-navigate", RadioNavigate)
         </script>
 
         {% block extra_js %}

--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -247,5 +247,5 @@ def dotation_badge_class(status):
     if status == "accepted":
         return "fr-badge--success"
     if status == "refused":
-        return "fr-badge--error fr-icon-close-circle-fill"
+        return "fr-badge--error"
     return f"badge-projet-status__{status}"

--- a/gsl_core/templatetags/gsl_filters.py
+++ b/gsl_core/templatetags/gsl_filters.py
@@ -247,5 +247,5 @@ def dotation_badge_class(status):
     if status == "accepted":
         return "fr-badge--success"
     if status == "refused":
-        return "fr-badge--error"
+        return "fr-badge--error fr-icon-close-circle-fill"
     return f"badge-projet-status__{status}"

--- a/gsl_projet/static/css/projet_detail.css
+++ b/gsl_projet/static/css/projet_detail.css
@@ -1,3 +1,7 @@
+.simulation-projet-card {
+  background-image: none;
+}
+
 .projet-header {
   display: flex;
   flex-direction: row;

--- a/gsl_projet/static/css/projet_detail.css
+++ b/gsl_projet/static/css/projet_detail.css
@@ -14,10 +14,6 @@
   gap: 16px;
 }
 
-#projet-panel {
-  padding: 4rem
-}
-
 .status_action_header {
   display: flex;
   align-items: center;

--- a/gsl_projet/templates/gsl_projet/projet/includes/_simulation_card.html
+++ b/gsl_projet/templates/gsl_projet/projet/includes/_simulation_card.html
@@ -1,0 +1,83 @@
+{% load gsl_filters simulation_filters %}
+<div id="simulation-card-{{ simu.pk }}" class="fr-col-12 fr-col-md-6">
+    <div class="fr-callout fr-callout--blue-ecume simulation-projet-card fr-pb-2w fr-pt-3w fr-px-3w fr-mb-4w">
+        <h3 class="fr-callout__title fr-h5 fr-mb-1w">
+            <a href="{% url "simulation:simulation-detail" slug=simu.simulation.slug %}"
+               class="fr-link">
+                {{ simu.simulation.title }}
+            </a>
+        </h3>
+
+        <div class="fr-mb-2w">
+            <span class="fr-badge fr-badge--no-icon">{{ simu.dotation }}</span>
+        </div>
+
+        <div class="fr-mb-2w">
+            {% if projet.notified_at is None %}
+                {% include "includes/_status_dropdown_buttons.html" %}
+            {% else %}
+                <span class="fr-badge badge-projet-status__{{ simu.status }}">
+                    {{ simu.get_status_display|remove_first_word }}
+                </span>
+                <span class="fr-badge fr-badge--success fr-badge--no-icon fr-ml-1w">Notifié</span>
+            {% endif %}
+        </div>
+
+        {% if projet.notified_at is None %}
+            <form id="{{ form_id }}"
+                  action="{% url "simulation:simulation-projet-card-update" pk=simu.pk %}"
+                  method="post"
+                  hx-post="{% url "simulation:simulation-projet-card-update" pk=simu.pk %}"
+                  hx-target="#simulation-card-{{ simu.pk }}"
+                  hx-swap="outerHTML"
+                  data-controller="bind-amount-fields"
+                  data-bind-amount-fields-cout-total-value="{{ dossier.finance_cout_total }}"
+                  data-action="submit->bind-amount-fields#onSubmit">
+                {% csrf_token %}
+                {{ simulation_projet_form.non_field_errors }}
+
+                <div class="fr-mb-2w">
+                    {{ simulation_projet_form.assiette.label_tag }}
+                    {{ simulation_projet_form.assiette }}
+                    {% if assiette_shared %}
+                        <p class="fr-hint-text fr-mt-1v">
+                            <span class="fr-icon-information-fill fr-icon--sm" aria-hidden="true"></span>
+                            Cette valeur est identique sur toutes les simulations de cette dotation.
+                        </p>
+                    {% endif %}
+                    {% for error in simulation_projet_form.assiette.errors %}
+                        <p class="fr-error-text">
+                            {{ error }}
+                        </p>
+                    {% endfor %}
+                </div>
+
+                <div class="fr-mb-2w">
+                    {{ simulation_projet_form.montant.label_tag }}
+                    {{ simulation_projet_form.montant }}
+                    {% for error in simulation_projet_form.montant.errors %}
+                        <p class="fr-error-text">
+                            {{ error }}
+                        </p>
+                    {% endfor %}
+                </div>
+
+                <div class="fr-mb-2w">
+                    {{ simulation_projet_form.taux.label_tag }}
+                    {{ simulation_projet_form.taux }}
+                    {% for error in simulation_projet_form.taux.errors %}
+                        <p class="fr-error-text">
+                            {{ error }}
+                        </p>
+                    {% endfor %}
+                </div>
+
+                <button class="fr-btn fr-btn--sm" type="submit" form="{{ form_id }}">
+                    Enregistrer
+                </button>
+            </form>
+        {% else %}
+            {% include "includes/projet_detail/dotation_montant_info.html" with assiette=dotation_projet.assiette montant=simu.montant taux=simu.taux %}
+        {% endif %}
+    </div>
+</div>

--- a/gsl_projet/templates/gsl_projet/projet/includes/_simulation_card.html
+++ b/gsl_projet/templates/gsl_projet/projet/includes/_simulation_card.html
@@ -34,43 +34,7 @@
                   data-bind-amount-fields-cout-total-value="{{ dossier.finance_cout_total }}"
                   data-action="submit->bind-amount-fields#onSubmit">
                 {% csrf_token %}
-                {{ simulation_projet_form.non_field_errors }}
-
-                <div class="fr-mb-2w">
-                    {{ simulation_projet_form.assiette.label_tag }}
-                    {{ simulation_projet_form.assiette }}
-                    {% if assiette_shared %}
-                        <p class="fr-hint-text fr-mt-1v">
-                            <span class="fr-icon-information-fill fr-icon--sm" aria-hidden="true"></span>
-                            Cette valeur est identique sur toutes les simulations de cette dotation.
-                        </p>
-                    {% endif %}
-                    {% for error in simulation_projet_form.assiette.errors %}
-                        <p class="fr-error-text">
-                            {{ error }}
-                        </p>
-                    {% endfor %}
-                </div>
-
-                <div class="fr-mb-2w">
-                    {{ simulation_projet_form.montant.label_tag }}
-                    {{ simulation_projet_form.montant }}
-                    {% for error in simulation_projet_form.montant.errors %}
-                        <p class="fr-error-text">
-                            {{ error }}
-                        </p>
-                    {% endfor %}
-                </div>
-
-                <div class="fr-mb-2w">
-                    {{ simulation_projet_form.taux.label_tag }}
-                    {{ simulation_projet_form.taux }}
-                    {% for error in simulation_projet_form.taux.errors %}
-                        <p class="fr-error-text">
-                            {{ error }}
-                        </p>
-                    {% endfor %}
-                </div>
+                {{ simulation_projet_form }}
 
                 <button class="fr-btn fr-btn--sm" type="submit" form="{{ form_id }}">
                     Enregistrer

--- a/gsl_projet/templates/gsl_projet/projet/includes/_simulation_card.html
+++ b/gsl_projet/templates/gsl_projet/projet/includes/_simulation_card.html
@@ -9,7 +9,7 @@
         </h3>
 
         <div class="fr-mb-2w">
-            <span class="fr-badge fr-badge--no-icon">{{ simu.dotation }}</span>
+            <span class="fr-badge fr-badge--icon-left fr-icon-money-euro-box-fill">{{ simu.dotation }}</span>
         </div>
 
         <div class="fr-mb-2w">

--- a/gsl_projet/templates/gsl_projet/projet/tab_projet.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_projet.html
@@ -44,12 +44,42 @@
                         <ul class="no-list-style">
                             {% include "includes/projet_detail/_dotation_projet_financial_informations.html" %}
                         </ul>
-                    {% endfor %}
-                {% else %}
-                    <ul class="no-list-style">
-                        {% include "includes/projet_detail/_projet_financial_informations.html" %}
-                        {% include "includes/projet_detail/_dotation_projet_financial_informations.html" with dotation_projet=projet.dotationprojet_set.first %}
-                    </ul>
+                    {% else %}
+                        <ul class="no-list-style">
+                            {% include "includes/projet_detail/_projet_financial_informations.html" %}
+                            {% include "includes/projet_detail/_dotation_projet_financial_informations.html" with dotation_projet=projet.dotationprojet_set.first %}
+                        </ul>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        <div class="fr-col-12 fr-col-xl-4">
+            {% for dotation_projet in dotation_projets %}
+                {% include "includes/projet_detail/_dotation_status_card.html" with dotation_projet=dotation_projet %}
+            {% endfor %}
+        </div>
+        {% block detr_avis_commission %}
+            <div class="fr-col-12">
+                {% if projet.can_have_a_commission_detr_avis %}
+                    {% if dotation_projet_form %}
+                        {% include "includes/forms/_detr_avis_commission_form.html" %}
+                    {% else %}
+                        <div class="fr-callout fr-background-alt--blue-france callout-without-left-border block-avis-commission-detr fr-p-2w fr-m-0">
+                            <h2 class="fr-callout__title fr-text--lg">
+                                <span class="fr-icon fr-icon-team-fill blue-color fr-mr-3v"
+                                      aria-hidden="true"></span>Avis de la commission DETR
+                            </h2>
+                            <p class="fr-callout__text">
+                                {% if projet.dotation_detr.detr_avis_commission %}
+                                    <span class="fr-icon-chat-check-fill green-color" aria-hidden="true"></span> Oui
+                                {% elif projet.dotation_detr.detr_avis_commission is False %}
+                                    <span class="fr-icon-chat-delete-fill red-color" aria-hidden="true"></span> Non
+                                {% else %}
+                                    <span class="fr-icon-message-2-fill grey-color" aria-hidden="true"></span> En cours
+                                {% endif %}
+                            </p>
+                        </div>
+                    {% endif %}
                 {% endif %}
             </div>
         </div>

--- a/gsl_projet/templates/gsl_projet/projet/tab_projet.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_projet.html
@@ -44,49 +44,19 @@
                         <ul class="no-list-style">
                             {% include "includes/projet_detail/_dotation_projet_financial_informations.html" %}
                         </ul>
-                    {% else %}
-                        <ul class="no-list-style">
-                            {% include "includes/projet_detail/_projet_financial_informations.html" %}
-                            {% include "includes/projet_detail/_dotation_projet_financial_informations.html" with dotation_projet=projet.dotationprojet_set.first %}
-                        </ul>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-        <div class="fr-col-12 fr-col-xl-4">
-            {% for dotation_projet in dotation_projets %}
-                {% include "includes/projet_detail/_dotation_status_card.html" with dotation_projet=dotation_projet %}
-            {% endfor %}
-        </div>
-        {% block detr_avis_commission %}
-            <div class="fr-col-12">
-                {% if projet.can_have_a_commission_detr_avis %}
-                    {% if dotation_projet_form %}
-                        {% include "includes/forms/_detr_avis_commission_form.html" %}
-                    {% else %}
-                        <div class="fr-callout fr-background-alt--blue-france callout-without-left-border block-avis-commission-detr fr-p-2w fr-m-0">
-                            <h2 class="fr-callout__title fr-text--lg">
-                                <span class="fr-icon fr-icon-team-fill blue-color fr-mr-3v"
-                                      aria-hidden="true"></span>Avis de la commission DETR
-                            </h2>
-                            <p class="fr-callout__text">
-                                {% if projet.dotation_detr.detr_avis_commission %}
-                                    <span class="fr-icon-chat-check-fill green-color" aria-hidden="true"></span> Oui
-                                {% elif projet.dotation_detr.detr_avis_commission is False %}
-                                    <span class="fr-icon-chat-delete-fill red-color" aria-hidden="true"></span> Non
-                                {% else %}
-                                    <span class="fr-icon-message-2-fill grey-color" aria-hidden="true"></span> En cours
-                                {% endif %}
-                            </p>
-                        </div>
-                    {% endif %}
+                    {% endfor %}
+                {% else %}
+                    <ul class="no-list-style">
+                        {% include "includes/projet_detail/_projet_financial_informations.html" %}
+                        {% include "includes/projet_detail/_dotation_projet_financial_informations.html" with dotation_projet=projet.dotationprojet_set.first %}
+                    </ul>
                 {% endif %}
             </div>
         </div>
     </div>
     <div class="fr-col-12 fr-col-xl-4">
         {% for dotation_projet in dotation_projets %}
-            {% include "includes/projet_detail/_status_and_notification_status_card.html" with dotation_projet=dotation_projet %}
+            {% include "includes/projet_detail/_dotation_status_card.html" with dotation_projet=dotation_projet %}
         {% endfor %}
     </div>
     {% block detr_avis_commission %}

--- a/gsl_projet/templates/gsl_projet/projet/tab_simulations.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_simulations.html
@@ -12,7 +12,9 @@
         {% if projet.has_double_dotations %}
             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-4w">
                 <div class="fr-col-auto">
-                    <fieldset class="fr-segmented" data-controller="radio-navigate">
+                    <fieldset class="fr-segmented"
+                              data-controller="radio-navigate"
+                              data-action="keydown->radio-navigate#onKeydown">
                         <legend class="fr-segmented__legend">
                             Dotation
                         </legend>
@@ -24,7 +26,7 @@
                                        name="dotation-filter"
                                        value=""
                                        {% if not dotation_filter %}checked{% endif %}
-                                       data-action="change->radio-navigate#navigate">
+                                       data-action="click->radio-navigate#navigate">
                                 <label class="fr-label" for="filter-toutes">
                                     Toutes
                                 </label>
@@ -36,7 +38,7 @@
                                        name="dotation-filter"
                                        value="DETR"
                                        {% if dotation_filter == 'DETR' %}checked{% endif %}
-                                       data-action="change->radio-navigate#navigate">
+                                       data-action="click->radio-navigate#navigate">
                                 <label class="fr-label" for="filter-detr">
                                     DETR
                                 </label>
@@ -48,7 +50,7 @@
                                        name="dotation-filter"
                                        value="DSIL"
                                        {% if dotation_filter == 'DSIL' %}checked{% endif %}
-                                       data-action="change->radio-navigate#navigate">
+                                       data-action="click->radio-navigate#navigate">
                                 <label class="fr-label" for="filter-dsil">
                                     DSIL
                                 </label>
@@ -60,7 +62,7 @@
         {% endif %}
         {% if simulation_projets_with_forms %}
             <div class="fr-grid-row fr-grid-row--gutters">
-                {% for simu, simulation_projet_form, form_id, assiette_shared in simulation_projets_with_forms %}
+                {% for simu, simulation_projet_form, form_id in simulation_projets_with_forms %}
                     {% with dotation_projet=simu.dotation_projet dossier=simu.dossier %}
                         {% include "gsl_projet/projet/includes/_simulation_card.html" %}
                     {% endwith %}
@@ -78,3 +80,6 @@
         {% endif %}
     </div>
 {% endblock tab_projet %}
+
+{% block modal %}
+{% endblock modal %}

--- a/gsl_projet/templates/gsl_projet/projet/tab_simulations.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_simulations.html
@@ -8,57 +8,56 @@
 {% endblock extra_css %}
 
 {% block tab_projet %}
-    {% url "projet:get-projet-simulations" projet_id=projet.id as base_simulations_url %}
     <div class="fr-container--fluid">
-        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-4w">
-            <div class="fr-col-auto">
-                <fieldset class="fr-segmented"
-                          data-controller="radio-navigate"
-                          data-radio-navigate-base-url-value="{{ base_simulations_url }}">
-                    <legend class="fr-segmented__legend">
-                        Dotation
-                    </legend>
-                    <div class="fr-segmented__elements">
-                        <div class="fr-segmented__element">
-                            <input class="fr-sr-only"
-                                   type="radio"
-                                   id="filter-toutes"
-                                   name="dotation-filter"
-                                   value=""
-                                   {% if not dotation_filter %}checked{% endif %}
-                                   data-action="change->radio-navigate#navigate">
-                            <label class="fr-label" for="filter-toutes">
-                                Toutes
-                            </label>
+        {% if projet.has_double_dotations %}
+            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-4w">
+                <div class="fr-col-auto">
+                    <fieldset class="fr-segmented" data-controller="radio-navigate">
+                        <legend class="fr-segmented__legend">
+                            Dotation
+                        </legend>
+                        <div class="fr-segmented__elements">
+                            <div class="fr-segmented__element">
+                                <input class="fr-sr-only"
+                                       type="radio"
+                                       id="filter-toutes"
+                                       name="dotation-filter"
+                                       value=""
+                                       {% if not dotation_filter %}checked{% endif %}
+                                       data-action="change->radio-navigate#navigate">
+                                <label class="fr-label" for="filter-toutes">
+                                    Toutes
+                                </label>
+                            </div>
+                            <div class="fr-segmented__element">
+                                <input class="fr-sr-only"
+                                       type="radio"
+                                       id="filter-detr"
+                                       name="dotation-filter"
+                                       value="DETR"
+                                       {% if dotation_filter == 'DETR' %}checked{% endif %}
+                                       data-action="change->radio-navigate#navigate">
+                                <label class="fr-label" for="filter-detr">
+                                    DETR
+                                </label>
+                            </div>
+                            <div class="fr-segmented__element">
+                                <input class="fr-sr-only"
+                                       type="radio"
+                                       id="filter-dsil"
+                                       name="dotation-filter"
+                                       value="DSIL"
+                                       {% if dotation_filter == 'DSIL' %}checked{% endif %}
+                                       data-action="change->radio-navigate#navigate">
+                                <label class="fr-label" for="filter-dsil">
+                                    DSIL
+                                </label>
+                            </div>
                         </div>
-                        <div class="fr-segmented__element">
-                            <input class="fr-sr-only"
-                                   type="radio"
-                                   id="filter-detr"
-                                   name="dotation-filter"
-                                   value="DETR"
-                                   {% if dotation_filter == 'DETR' %}checked{% endif %}
-                                   data-action="change->radio-navigate#navigate">
-                            <label class="fr-label" for="filter-detr">
-                                DETR
-                            </label>
-                        </div>
-                        <div class="fr-segmented__element">
-                            <input class="fr-sr-only"
-                                   type="radio"
-                                   id="filter-dsil"
-                                   name="dotation-filter"
-                                   value="DSIL"
-                                   {% if dotation_filter == 'DSIL' %}checked{% endif %}
-                                   data-action="change->radio-navigate#navigate">
-                            <label class="fr-label" for="filter-dsil">
-                                DSIL
-                            </label>
-                        </div>
-                    </div>
-                </fieldset>
+                    </fieldset>
+                </div>
             </div>
-        </div>
+        {% endif %}
         {% if simulation_projets_with_forms %}
             <div class="fr-grid-row fr-grid-row--gutters">
                 {% for simu, simulation_projet_form, form_id, assiette_shared in simulation_projets_with_forms %}

--- a/gsl_projet/templates/gsl_projet/projet/tab_simulations.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_simulations.html
@@ -1,4 +1,5 @@
 {% extends "gsl_projet/projet.html" %}
+
 {% load static gsl_filters %}
 
 {% block extra_css %}
@@ -7,20 +8,57 @@
 {% endblock extra_css %}
 
 {% block tab_projet %}
-    <div class="fr-container--fluid fr-mt-4w">
+    {% url "projet:get-projet-simulations" projet_id=projet.id as base_simulations_url %}
+    <div class="fr-container--fluid">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-4w">
             <div class="fr-col-auto">
-                <span class="fr-text--sm fr-text--bold fr-mr-2w">Dotation</span>
-                {% url "projet:get-projet-simulations" projet_id=projet.id as base_simulations_url %}
-                <a href="{{ base_simulations_url }}"
-                   class="fr-btn fr-btn--sm {% if not dotation_filter %}{% else %}fr-btn--tertiary{% endif %} fr-mr-1w">Toutes</a>
-                <a href="{{ base_simulations_url }}?dotation=DETR"
-                   class="fr-btn fr-btn--sm {% if dotation_filter == 'DETR' %}{% else %}fr-btn--tertiary{% endif %} fr-mr-1w">DETR</a>
-                <a href="{{ base_simulations_url }}?dotation=DSIL"
-                   class="fr-btn fr-btn--sm {% if dotation_filter == 'DSIL' %}{% else %}fr-btn--tertiary{% endif %}">DSIL</a>
+                <fieldset class="fr-segmented"
+                          data-controller="radio-navigate"
+                          data-radio-navigate-base-url-value="{{ base_simulations_url }}">
+                    <legend class="fr-segmented__legend">
+                        Dotation
+                    </legend>
+                    <div class="fr-segmented__elements">
+                        <div class="fr-segmented__element">
+                            <input class="fr-sr-only"
+                                   type="radio"
+                                   id="filter-toutes"
+                                   name="dotation-filter"
+                                   value=""
+                                   {% if not dotation_filter %}checked{% endif %}
+                                   data-action="change->radio-navigate#navigate">
+                            <label class="fr-label" for="filter-toutes">
+                                Toutes
+                            </label>
+                        </div>
+                        <div class="fr-segmented__element">
+                            <input class="fr-sr-only"
+                                   type="radio"
+                                   id="filter-detr"
+                                   name="dotation-filter"
+                                   value="DETR"
+                                   {% if dotation_filter == 'DETR' %}checked{% endif %}
+                                   data-action="change->radio-navigate#navigate">
+                            <label class="fr-label" for="filter-detr">
+                                DETR
+                            </label>
+                        </div>
+                        <div class="fr-segmented__element">
+                            <input class="fr-sr-only"
+                                   type="radio"
+                                   id="filter-dsil"
+                                   name="dotation-filter"
+                                   value="DSIL"
+                                   {% if dotation_filter == 'DSIL' %}checked{% endif %}
+                                   data-action="change->radio-navigate#navigate">
+                            <label class="fr-label" for="filter-dsil">
+                                DSIL
+                            </label>
+                        </div>
+                    </div>
+                </fieldset>
             </div>
         </div>
-
         {% if simulation_projets_with_forms %}
             <div class="fr-grid-row fr-grid-row--gutters">
                 {% for simu, simulation_projet_form, form_id, assiette_shared in simulation_projets_with_forms %}

--- a/gsl_projet/templates/gsl_projet/projet/tab_simulations.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_simulations.html
@@ -1,0 +1,43 @@
+{% extends "gsl_projet/projet.html" %}
+{% load static gsl_filters %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="{% static "css/projet_detail.css" %}">
+    <link rel="stylesheet" href="{% static "css/simulation_detail.css" %}">
+{% endblock extra_css %}
+
+{% block tab_projet %}
+    <div class="fr-container--fluid fr-mt-4w">
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-4w">
+            <div class="fr-col-auto">
+                <span class="fr-text--sm fr-text--bold fr-mr-2w">Dotation</span>
+                {% url "projet:get-projet-simulations" projet_id=projet.id as base_simulations_url %}
+                <a href="{{ base_simulations_url }}"
+                   class="fr-btn fr-btn--sm {% if not dotation_filter %}{% else %}fr-btn--tertiary{% endif %} fr-mr-1w">Toutes</a>
+                <a href="{{ base_simulations_url }}?dotation=DETR"
+                   class="fr-btn fr-btn--sm {% if dotation_filter == 'DETR' %}{% else %}fr-btn--tertiary{% endif %} fr-mr-1w">DETR</a>
+                <a href="{{ base_simulations_url }}?dotation=DSIL"
+                   class="fr-btn fr-btn--sm {% if dotation_filter == 'DSIL' %}{% else %}fr-btn--tertiary{% endif %}">DSIL</a>
+            </div>
+        </div>
+
+        {% if simulation_projets_with_forms %}
+            <div class="fr-grid-row fr-grid-row--gutters">
+                {% for simu, simulation_projet_form, form_id, assiette_shared in simulation_projets_with_forms %}
+                    {% with dotation_projet=simu.dotation_projet dossier=simu.dossier %}
+                        {% include "gsl_projet/projet/includes/_simulation_card.html" %}
+                    {% endwith %}
+                {% endfor %}
+            </div>
+        {% else %}
+            <div class="fr-py-8w fr-text--center">
+                <p class="fr-text--lg fr-text--bold">
+                    Aucune simulation pour ce projet
+                </p>
+                <p class="fr-text--sm fr-hint-text">
+                    Les simulations apparaîtront ici une fois que ce projet aura été ajouté à une simulation.
+                </p>
+            </div>
+        {% endif %}
+    </div>
+{% endblock tab_projet %}

--- a/gsl_projet/templates/gsl_projet/projet/tabs.html
+++ b/gsl_projet/templates/gsl_projet/projet/tabs.html
@@ -12,6 +12,12 @@
                {% if request.path == notes_url %}aria-selected="true"{% endif %}
                class="fr-tabs__tab fr-icon-edit-line fr-tabs__tab--icon-left">Notes</a>
         </li>
+        <li>
+            {% url "projet:get-projet-simulations" projet_id=projet.id as simulations_url %}
+            <a href="{{ simulations_url }}{% querystring %}"
+               {% if request.path == simulations_url %}aria-selected="true"{% endif %}
+               class="fr-tabs__tab fr-icon-bar-chart-box-line fr-tabs__tab--icon-left">Simulations</a>
+        </li>
         {% if projet.can_display_notification_tab %}
             <li>
                 {% url 'gsl_notification:documents' projet.id as notifications_url %}

--- a/gsl_projet/templates/gsl_projet/projet/tabs.html
+++ b/gsl_projet/templates/gsl_projet/projet/tabs.html
@@ -16,7 +16,7 @@
             {% url "projet:get-projet-simulations" projet_id=projet.id as simulations_url %}
             <a href="{{ simulations_url }}{% querystring %}"
                {% if request.path == simulations_url %}aria-selected="true"{% endif %}
-               class="fr-tabs__tab fr-icon-bar-chart-box-line fr-tabs__tab--icon-left">Simulations</a>
+               class="fr-tabs__tab fr-icon-money-euro-circle-fill fr-tabs__tab--icon-left">Simulations</a>
         </li>
         {% if projet.can_display_notification_tab %}
             <li>

--- a/gsl_projet/templates/includes/projet_detail/_dotation_status_card.html
+++ b/gsl_projet/templates/includes/projet_detail/_dotation_status_card.html
@@ -9,30 +9,31 @@
         </h2>
     </div>
     {% block status_action_content %}
-        <p class="fr-badge {{ dotation_projet.status|dotation_badge_class }}">
-            {{ dotation_projet.get_status_display|remove_first_word }}
-        </p>
     {% endblock status_action_content %}
 
-    {% block notification_status_message %}
-        {% if projet.display_notification_message %}
-            <div class="fr-callout__text notification_status_message fr-mb-2w">
+    <div class="fr-callout__text notification_status_message fr-mb-2w">
+        <span class="fr-badge {{ dotation_projet.status|dotation_badge_class }} fr-mr-1w">
+            {{ dotation_projet.get_status_display|remove_first_word }}
+        </span>
+
+        {% block notification_status_message %}
+            {% if projet.display_notification_message %}
                 {% if projet.to_notify %}
-                    <p class="fr-badge fr-badge--no-icon">
+                    <span class="fr-badge fr-badge--no-icon">
                         À notifier
-                    </p>
+                    </span>
                 {% elif projet.notified_at %}
-                    <p class="fr-badge fr-badge--success fr-badge--no-icon">
+                    <span class="fr-badge fr-badge--success fr-badge--no-icon">
                         Notifié
-                    </p>
+                    </span>
                 {% else %}
-                    <p class="fr-badge fr-badge--info fr-badge--no-icon">
+                    <span class="fr-badge fr-badge--info fr-badge--no-icon">
                         En attente de la décision {{ projet.dotation_not_treated }}
-                    </p>
+                    </span>
                 {% endif %}
-            </div>
-        {% endif %}
-    {% endblock notification_status_message %}
+            {% endif %}
+        {% endblock notification_status_message %}
+    </div>
 
     {% block notification_action_content %}
         {% if display_notify_button|default_if_none:True and projet.display_notification_button %}

--- a/gsl_projet/tests/views/test_projet_detail.py
+++ b/gsl_projet/tests/views/test_projet_detail.py
@@ -23,7 +23,7 @@ from gsl_projet.tests.factories import DotationProjetFactory, ProjetFactory
 pytestmark = pytest.mark.django_db()
 
 
-def test_projet_detail_page_has_no_dotation_status_card_when_all_dotation_projet_have_processing_status():
+def test_projet_detail_page_has_no_notification_button_when_all_dotation_projet_have_processing_status():
     perimetre = PerimetreArrondissementFactory()
     user = CollegueFactory(perimetre=perimetre)
     projet = ProjetFactory(dossier_ds__perimetre=perimetre)
@@ -35,7 +35,6 @@ def test_projet_detail_page_has_no_dotation_status_card_when_all_dotation_projet
     response = ClientWithLoggedUserFactory(user=user).get(url)
     assert response.status_code == 200
     assert response.context["projet"].all_dotations_have_processing_status is True
-    assert "notification_status_message" not in response.content.decode()
     assert "Notifier le demandeur" not in response.content.decode(), (
         "Notify button is never displayed in projet page from main tab #1"
     )
@@ -274,7 +273,6 @@ def test_unified_projet_page_hides_decision_card_and_notification_tab_for_proces
     response = ClientWithLoggedUserFactory(user=user).get(url)
     assert response.status_code == 200
     content = response.content.decode()
-    assert "notification_status_message" not in content
     assert "Notifications du demandeur" not in content
 
 

--- a/gsl_projet/tests/views/test_projet_detail.py
+++ b/gsl_projet/tests/views/test_projet_detail.py
@@ -23,7 +23,7 @@ from gsl_projet.tests.factories import DotationProjetFactory, ProjetFactory
 pytestmark = pytest.mark.django_db()
 
 
-def test_projet_detail_page_has_no_status_and_notification_status_card_when_all_dotation_projet_have_processing_status():
+def test_projet_detail_page_has_no_dotation_status_card_when_all_dotation_projet_have_processing_status():
     perimetre = PerimetreArrondissementFactory()
     user = CollegueFactory(perimetre=perimetre)
     projet = ProjetFactory(dossier_ds__perimetre=perimetre)
@@ -44,7 +44,7 @@ def test_projet_detail_page_has_no_status_and_notification_status_card_when_all_
 @pytest.mark.parametrize(
     "status", (PROJET_STATUS_ACCEPTED, PROJET_STATUS_REFUSED, PROJET_STATUS_DISMISSED)
 )
-def test_projet_detail_page_has_status_and_notification_status_card_with_not_processing_simple_dotation(
+def test_projet_detail_page_has_dotation_status_card_with_not_processing_simple_dotation(
     status,
 ):
     perimetre = PerimetreArrondissementFactory()
@@ -78,7 +78,7 @@ def test_projet_detail_page_has_status_and_notification_status_card_with_not_pro
         (PROJET_STATUS_DISMISSED, PROJET_STATUS_PROCESSING),
     ),
 )
-def test_projet_detail_page_has_status_and_notification_status_card_with_not_processing_double_dotations(
+def test_projet_detail_page_has_dotation_status_card_with_not_processing_double_dotations(
     dotation_status_1, dotation_status_2
 ):
     perimetre = PerimetreArrondissementFactory()

--- a/gsl_projet/urls.py
+++ b/gsl_projet/urls.py
@@ -52,6 +52,11 @@ urlpatterns = [
         name="note-delete",
     ),
     path(
+        "voir/<int:projet_id>/simulations/",
+        views.ProjetSimulationsView.as_view(),
+        name="get-projet-simulations",
+    ),
+    path(
         "voir/<int:projet_id>/historique/",
         views.ProjetHistoriqueView.as_view(),
         name="get-projet-historique",

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -41,6 +41,8 @@ from gsl_projet.utils.projet_filters import (
 )
 from gsl_projet.utils.projet_page import PROJET_MENU, get_projet_go_back_context
 from gsl_projet.utils.utils import get_comment_cards
+from gsl_simulation.forms import SimulationProjetForm
+from gsl_simulation.models import SimulationProjet
 
 from .models import Projet
 from .table_columns import PROJET_TABLE_COLUMNS, SANS_PIECES_SKIP_KEYS
@@ -84,6 +86,48 @@ class BaseProjetDetailView(DetailView):
             context["dotation_projet_form"] = DotationProjetForm(instance=detr_dotation)
             context["dotation_projet"] = detr_dotation
         context["projet_note_form"] = ProjetNoteForm()
+        return context
+
+
+class ProjetSimulationsView(BaseProjetDetailView):
+    template_name = "gsl_projet/projet/tab_simulations.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        projet = self.object
+        all_qs = SimulationProjet.objects.filter(
+            dotation_projet__projet=projet
+        ).select_related(
+            "simulation",
+            "simulation__enveloppe",
+            "dotation_projet",
+            "dotation_projet__projet",
+            "dotation_projet__projet__dossier_ds",
+        )
+
+        dp_sp_counts: dict[int, int] = {}
+        for sp in all_qs:
+            dp_sp_counts[sp.dotation_projet_id] = (
+                dp_sp_counts.get(sp.dotation_projet_id, 0) + 1
+            )
+
+        dotation_filter = self.request.GET.get("dotation", "")
+        filtered_qs = all_qs.order_by("-simulation__created_at")
+        if dotation_filter in ("DETR", "DSIL"):
+            filtered_qs = filtered_qs.filter(dotation_projet__dotation=dotation_filter)
+
+        simulation_projets_with_forms = []
+        for sp in filtered_qs:
+            form_id = f"simulation-card-form-{sp.pk}"
+            form = SimulationProjetForm(instance=sp)
+            for field in ("assiette", "montant", "taux"):
+                if field in form.fields:
+                    form.fields[field].widget.attrs["form"] = form_id
+            assiette_shared = dp_sp_counts.get(sp.dotation_projet_id, 1) > 1
+            simulation_projets_with_forms.append((sp, form, form_id, assiette_shared))
+
+        context["simulation_projets_with_forms"] = simulation_projets_with_forms
+        context["dotation_filter"] = dotation_filter
         return context
 
 

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -60,32 +60,8 @@ class BaseProjetDetailView(DetailView):
         return Projet.objects.for_user(self.request.user)
 
     def get_context_data(self, **kwargs):
-        projet = self.object
         context = super().get_context_data(**kwargs)
-        projet_form = ProjetForm(instance=projet)
-        dotation_field = projet_form.fields.get("dotations")
-        context.update(
-            {
-                "title": projet.dossier_ds.projet_intitule,
-                "dossier": projet.dossier_ds,
-                "menu_dict": PROJET_MENU,
-                "projet_notes": projet.notes.all(),
-                "dotation_projets": projet.dotationprojet_set.order_by(
-                    "dotation"
-                ).all(),
-                "comment_cards": get_comment_cards(projet),
-                "projet_form": projet_form,
-                "initial_dotations": (
-                    json.dumps(dotation_field.initial) if dotation_field else "[]"
-                ),
-                **get_projet_go_back_context(self.request),
-            }
-        )
-        detr_dotation = projet.dotation_detr
-        if detr_dotation:
-            context["dotation_projet_form"] = DotationProjetForm(instance=detr_dotation)
-            context["dotation_projet"] = detr_dotation
-        context["projet_note_form"] = ProjetNoteForm()
+        context.update(_build_projet_page_context(self.object, self.request))
         return context
 
 
@@ -172,11 +148,10 @@ def _redirect_to_referer_or_projet(request, projet):
     return redirect("projet:get-projet", projet_id=projet.pk)
 
 
-class ProjetUpdateView(UpdateView):
-    model = Projet
+class ProjetUpdateView(BaseProjetDetailView, UpdateView):
     form_class = ProjetForm
-    pk_url_kwarg = "projet_id"
     http_method_names = ["post"]
+    template_name = "gsl_projet/projet.html"
 
     def get_queryset(self):
         return Projet.objects.active().for_user(self.request.user)
@@ -185,6 +160,12 @@ class ProjetUpdateView(UpdateView):
         kwargs = super().get_form_kwargs()
         kwargs["user"] = self.request.user
         return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        if "form" in kwargs:
+            context["projet_form"] = kwargs["form"]
+        return context
 
     def form_valid(self, form):
         try:
@@ -198,25 +179,36 @@ class ProjetUpdateView(UpdateView):
                 self.request,
                 f"Une erreur est survenue lors de la mise à jour sur Démarche Numérique. {e}",
             )
-        return _redirect_to_referer_or_projet(self.request, self.object)
+        return redirect("projet:get-projet", projet_id=self.object.pk)
 
     def form_invalid(self, form):
         messages.error(
             self.request,
             "Une erreur s'est produite lors de la soumission du formulaire.",
         )
-        return _redirect_to_referer_or_projet(self.request, self.object)
+        for error in form.non_field_errors():
+            messages.error(self.request, error)
+        return self.render_to_response(self.get_context_data(form=form))
 
 
 class DotationProjetUpdateView(UpdateView):
     model = DotationProjet
     form_class = DotationProjetForm
     http_method_names = ["post"]
+    template_name = "gsl_projet/projet.html"
 
     def get_queryset(self):
         return DotationProjet.objects.filter(
             projet__in=Projet.objects.active().for_user(self.request.user)
         )
+
+    def get_context_data(self, **kwargs):
+        dotation_projet = self.object
+        context = _build_projet_page_context(dotation_projet.projet, self.request)
+        if "form" in kwargs:
+            context["dotation_projet_form"] = kwargs["form"]
+            context["dotation_projet"] = dotation_projet
+        return context
 
     def form_valid(self, form):
         form.save()
@@ -231,7 +223,34 @@ class DotationProjetUpdateView(UpdateView):
             self.request,
             "Une erreur s'est produite lors de la soumission du formulaire.",
         )
+        for error in form.non_field_errors():
+            messages.error(self.request, error)
         return _redirect_to_referer_or_projet(self.request, self.object.projet)
+
+
+def _build_projet_page_context(projet, request):
+    projet_form = ProjetForm(instance=projet)
+    dotation_field = projet_form.fields.get("dotations")
+    context = {
+        "projet": projet,
+        "title": projet.dossier_ds.projet_intitule,
+        "dossier": projet.dossier_ds,
+        "menu_dict": PROJET_MENU,
+        "projet_notes": projet.notes.all(),
+        "dotation_projets": projet.dotationprojet_set.order_by("dotation").all(),
+        "comment_cards": get_comment_cards(projet),
+        "projet_form": projet_form,
+        "initial_dotations": (
+            json.dumps(dotation_field.initial) if dotation_field else "[]"
+        ),
+        **get_projet_go_back_context(request),
+    }
+    detr_dotation = projet.dotation_detr
+    if detr_dotation:
+        context["dotation_projet_form"] = DotationProjetForm(instance=detr_dotation)
+        context["dotation_projet"] = detr_dotation
+    context["projet_note_form"] = ProjetNoteForm()
+    return context
 
 
 class ProjetNoteCreateView(CreateView):

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -99,8 +99,7 @@ class ProjetSimulationsView(BaseProjetDetailView):
             for field in ("assiette", "montant", "taux"):
                 if field in form.fields:
                     form.fields[field].widget.attrs["form"] = form_id
-            assiette_shared = dp_sp_counts.get(sp.dotation_projet_id, 1) > 1
-            simulation_projets_with_forms.append((sp, form, form_id, assiette_shared))
+            simulation_projets_with_forms.append((sp, form, form_id))
 
         context["simulation_projets_with_forms"] = simulation_projets_with_forms
         context["dotation_filter"] = dotation_filter

--- a/gsl_simulation/forms.py
+++ b/gsl_simulation/forms.py
@@ -80,6 +80,7 @@ class SimulationRenameForm(DsfrBaseForm, ModelForm):
 class SimulationProjetForm(ModelForm, DsfrBaseForm):
     assiette = forms.DecimalField(
         label="Montant des dépenses éligibles retenues (€)",
+        help_text="Cette valeur est identique sur toutes les simulations de cette dotation.",
         max_digits=12,
         decimal_places=2,
         min_value=0,
@@ -133,7 +134,7 @@ class SimulationProjetForm(ModelForm, DsfrBaseForm):
 
     class Meta:
         model = SimulationProjet
-        fields = ["montant"]
+        fields = ["assiette", "montant", "taux"]
 
     def __init__(self, *args, user=None, **kwargs):
         super().__init__(*args, **kwargs)

--- a/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_projet.html
+++ b/gsl_simulation/templates/gsl_simulation/tab_simulation_projet/tab_projet.html
@@ -22,7 +22,7 @@
 {% endblock detr_avis_commission %}
 
 {% block status_action %}
-    {% include "includes/_status_and_notification_status_card.html" %}
+    {% include "includes/_dotation_status_card.html" %}
 {% endblock status_action %}
 
 {% block projet_areas_and_contracts %}

--- a/gsl_simulation/templates/htmx/programmation_status_change_modal.html
+++ b/gsl_simulation/templates/htmx/programmation_status_change_modal.html
@@ -1,6 +1,9 @@
 {% extends "htmx/_base_htmx_modal.html" %}
 {% load simulation_filters %}
 
+{% block dialog_close_behavior %}
+{% endblock dialog_close_behavior %}
+
 {% block button_label %}
     {{ new_simulation_status|status_to_label }}
 {% endblock button_label %}

--- a/gsl_simulation/templates/includes/_dotation_status_card.html
+++ b/gsl_simulation/templates/includes/_dotation_status_card.html
@@ -1,4 +1,4 @@
-{% extends "includes/projet_detail/_status_and_notification_status_card.html" %}
+{% extends "includes/projet_detail/_dotation_status_card.html" %}
 
 {% block title %}
     Décision de financement du projet {{ dotation_projet.dotation }}

--- a/gsl_simulation/templates/includes/forms/_detr_avis_commission_form.html
+++ b/gsl_simulation/templates/includes/forms/_detr_avis_commission_form.html
@@ -18,6 +18,15 @@
                     <span class="fr-icon-message-2-fill grey-color" aria-hidden="true"></span>
                 {% endif %}
                 {{ dotation_projet_form.detr_avis_commission }}
+                {% if dotation_projet_form.errors.detr_avis_commission %}
+                    <div class="fr-messages-group" aria-live="assertive">
+                        {% for err in dotation_projet_form.errors.detr_avis_commission %}
+                            <p class="fr-message fr-message--error">
+                                {{ err }}
+                            </p>
+                        {% endfor %}
+                    </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/gsl_simulation/tests/test_urls.py
+++ b/gsl_simulation/tests/test_urls.py
@@ -265,10 +265,9 @@ def test_patch_status_simulation_projet_url_with_htmx(
         "gsl_demarches_simplifiees.services.DsService.update_ds_annotations_for_one_dotation"
     ) as mock_ds_update:
         mock_ds_update.return_value = None
-        response = client_with_cote_d_or_user_logged.post(
-            url, headers=htmx_headers, follow=True
-        )
+        response = client_with_cote_d_or_user_logged.post(url, headers=htmx_headers)
     assert response.status_code == 200
+    assert "HX-Redirect" in response.headers
 
     cote_dorien_simulation_projet.refresh_from_db()
     assert cote_dorien_simulation_projet.status == SimulationProjet.STATUS_ACCEPTED
@@ -447,7 +446,6 @@ def test_regional_user_can_patch_projet_if_simulation_projet_is_associated_to_ds
             url,
             data,
             headers={"HX-Request": "true", "HX-Request-URL": page_url},
-            follow=True,
         )
     assert response.status_code == 200
 

--- a/gsl_simulation/tests/views/test_bulk_status_update.py
+++ b/gsl_simulation/tests/views/test_bulk_status_update.py
@@ -79,7 +79,7 @@ def test_bulk_status_update_marks_all_selected_rows(
     )
 
     assert response.status_code == 200
-    assert response.headers.get("HX-Refresh") == "true"
+    assert "HX-Redirect" in response.headers
     for sp in (sp1, sp2, sp3):
         sp.refresh_from_db()
         assert sp.status == SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED
@@ -135,7 +135,7 @@ def test_bulk_status_update_to_refused_or_dismissed_commits_directly(
     )
 
     assert response.status_code == 200
-    assert response.headers.get("HX-Refresh") == "true"
+    assert "HX-Redirect" in response.headers
     sp.refresh_from_db()
     assert sp.status == target_status
 
@@ -173,7 +173,7 @@ def test_bulk_status_update_switches_between_refused_and_dismissed(
     )
 
     assert response.status_code == 200
-    assert response.headers.get("HX-Refresh") == "true"
+    assert "HX-Redirect" in response.headers
     sp.refresh_from_db()
     assert sp.status == target_status
 
@@ -384,7 +384,7 @@ def test_preflight_without_ds_id_but_no_dn_target_commits_directly(
     )
 
     assert response.status_code == 200
-    assert response.headers.get("HX-Refresh") == "true"
+    assert "HX-Redirect" in response.headers
     sp.refresh_from_db()
     assert sp.status == SimulationProjet.STATUS_PROVISIONALLY_REFUSED
 

--- a/gsl_simulation/tests/views/test_patch_simulation_projet.py
+++ b/gsl_simulation/tests/views/test_patch_simulation_projet.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.contrib.messages import INFO, SUCCESS, get_messages
-from django.test.html import parse_html
 from django.urls import reverse
 
 from gsl_core.tests.factories import (
@@ -96,7 +95,6 @@ def test_patch_status_simulation_projet_with_accepted_value_with_htmx(
         mock_update_ds_annotations_for_one_dotation.return_value = None
         response = client_with_user_logged.post(
             url,
-            follow=True,
             headers={"HX-Request": "true", "HX-Request-URL": page_url},
         )
 
@@ -106,12 +104,9 @@ def test_patch_status_simulation_projet_with_accepted_value_with_htmx(
     )
 
     assert response.status_code == 200
+    assert "HX-Redirect" in response.headers
     assert updated_simulation_projet.status == SimulationProjet.STATUS_ACCEPTED
     assert dotation_projet.status == PROJET_STATUS_ACCEPTED
-    assert "1 projet accepté" in parse_html(response.content.decode())
-    assert "0 projet refusé" in parse_html(response.content.decode())
-    assert "0 projet notifié" in parse_html(response.content.decode())
-    assert 'id="total-amount-granted">1\xa0000\xa0€</span>' in response.content.decode()
 
 
 data_test = (
@@ -163,7 +158,7 @@ def test_patch_status_simulation_projet_gives_message(
         args=[simulation_projet.id, status],
     )
     response = client_with_user_logged.post(
-        url, headers={"HX-Request": "true", "HX-Request-URL": page_url}, follow=True
+        url, headers={"HX-Request": "true", "HX-Request-URL": page_url}
     )
 
     if status == SimulationProjet.STATUS_ACCEPTED:

--- a/gsl_simulation/tests/views/test_simulation_projet_view.py
+++ b/gsl_simulation/tests/views/test_simulation_projet_view.py
@@ -191,16 +191,16 @@ def test_dotation_status_card_is_displayed_with_the_correct_title(
         (PROJET_STATUS_ACCEPTED, SimulationProjet.STATUS_ACCEPTED, True),
         (PROJET_STATUS_REFUSED, SimulationProjet.STATUS_REFUSED, True),
         (PROJET_STATUS_DISMISSED, SimulationProjet.STATUS_DISMISSED, True),
-        (PROJET_STATUS_PROCESSING, SimulationProjet.STATUS_PROCESSING, False),
+        (PROJET_STATUS_PROCESSING, SimulationProjet.STATUS_PROCESSING, True),
         (
             PROJET_STATUS_PROCESSING,
             SimulationProjet.STATUS_PROVISIONALLY_ACCEPTED,
-            False,
+            True,
         ),
         (
             PROJET_STATUS_PROCESSING,
             SimulationProjet.STATUS_PROVISIONALLY_REFUSED,
-            False,
+            True,
         ),
     ),
 )
@@ -264,7 +264,7 @@ DOTATION_PROJET_STATUS_TO_SIMULATION_PROJET_STATUS = {
         (PROJET_STATUS_PROCESSING, PROJET_STATUS_ACCEPTED, True),
         (PROJET_STATUS_PROCESSING, PROJET_STATUS_REFUSED, True),
         (PROJET_STATUS_PROCESSING, PROJET_STATUS_DISMISSED, True),
-        (PROJET_STATUS_PROCESSING, PROJET_STATUS_PROCESSING, False),
+        (PROJET_STATUS_PROCESSING, PROJET_STATUS_PROCESSING, True),
     ),
 )
 def test_dotation_status_card_displays_the_notification_status_or_not_with_double_dotations(
@@ -445,7 +445,7 @@ def test_dotation_status_card_displays_the_correct_notification_status_message_d
         assert projet.display_notification_message is False
         assert (
             'div class="fr-callout__text notification_status_message'
-            not in response.content.decode()
+            in response.content.decode()
         )
         return
 

--- a/gsl_simulation/tests/views/test_simulation_projet_view.py
+++ b/gsl_simulation/tests/views/test_simulation_projet_view.py
@@ -159,7 +159,7 @@ def test_get_other_dotation_montants_with_none_assiette():
 
 
 @pytest.mark.parametrize("dotation", (DOTATION_DSIL, DOTATION_DETR))
-def test_status_and_notification_status_card_is_displayed_with_the_correct_title(
+def test_dotation_status_card_is_displayed_with_the_correct_title(
     dotation,
 ):
     perimetre = PerimetreArrondissementFactory()
@@ -204,7 +204,7 @@ def test_status_and_notification_status_card_is_displayed_with_the_correct_title
         ),
     ),
 )
-def test_status_and_notification_status_card_displays_the_notification_status_or_not_with_simple_dotation(
+def test_dotation_status_card_displays_the_notification_status_or_not_with_simple_dotation(
     dotation_status,
     simulation_projet_status,
     must_be_displayed,
@@ -267,7 +267,7 @@ DOTATION_PROJET_STATUS_TO_SIMULATION_PROJET_STATUS = {
         (PROJET_STATUS_PROCESSING, PROJET_STATUS_PROCESSING, False),
     ),
 )
-def test_status_and_notification_status_card_displays_the_notification_status_or_not_with_double_dotations(
+def test_dotation_status_card_displays_the_notification_status_or_not_with_double_dotations(
     dotation_1_status, dotation_2_status, must_be_displayed
 ):
     perimetre = PerimetreArrondissementFactory()
@@ -333,7 +333,7 @@ def test_status_and_notification_status_card_displays_the_notification_status_or
         ),
     ),
 )
-def test_status_and_notification_status_card_displays_the_correct_notification_status_message(
+def test_dotation_status_card_displays_the_correct_notification_status_message(
     dotation_1_status, dotation_2_status, notification_status_message
 ):
     perimetre = PerimetreArrondissementFactory()
@@ -399,7 +399,7 @@ def test_status_and_notification_status_card_displays_the_correct_notification_s
         (datetime.now(timezone.utc), "Notifié"),
     ),
 )
-def test_status_and_notification_status_card_displays_the_correct_notification_status_message_depending_on_the_notified_at_date(
+def test_dotation_status_card_displays_the_correct_notification_status_message_depending_on_the_notified_at_date(
     dotation_1_status, dotation_2_status, notified_at, notification_status_message
 ):
     perimetre = PerimetreArrondissementFactory()
@@ -472,7 +472,7 @@ def test_status_and_notification_status_card_displays_the_correct_notification_s
         (PROJET_STATUS_DISMISSED, True),
     ),
 )
-def test_status_and_notification_status_card_displays_notification_button_simple_dotation_when_the_projet_has_not_been_notified(
+def test_dotation_status_card_displays_notification_button_simple_dotation_when_the_projet_has_not_been_notified(
     dotation_status, is_button_displayed
 ):
     perimetre = PerimetreArrondissementFactory()
@@ -518,7 +518,7 @@ def test_status_and_notification_status_card_displays_notification_button_simple
         (PROJET_STATUS_PROCESSING),
     ),
 )
-def test_status_and_notification_status_card_does_not_display_notification_button_simple_dotation_when_the_projet_has_been_notified(
+def test_dotation_status_card_does_not_display_notification_button_simple_dotation_when_the_projet_has_been_notified(
     dotation_status,
 ):
     """
@@ -576,7 +576,7 @@ def test_status_and_notification_status_card_does_not_display_notification_butto
         (PROJET_STATUS_PROCESSING, PROJET_STATUS_PROCESSING, False),
     ),
 )
-def test_status_and_notification_status_card_displays_notification_button_double_dotation_when_the_projet_has_not_been_notified(
+def test_dotation_status_card_displays_notification_button_double_dotation_when_the_projet_has_not_been_notified(
     dotation_status_1, dotation_status_2, is_button_displayed
 ):
     perimetre = PerimetreArrondissementFactory()
@@ -637,7 +637,7 @@ def test_status_and_notification_status_card_displays_notification_button_double
         (PROJET_STATUS_PROCESSING, PROJET_STATUS_DISMISSED),
     ),
 )
-def test_status_and_notification_status_card_does_not_display_notification_button_double_dotation_when_the_projet_has_been_notified(
+def test_dotation_status_card_does_not_display_notification_button_double_dotation_when_the_projet_has_been_notified(
     dotation_status_1,
     dotation_status_2,
 ):

--- a/gsl_simulation/urls.py
+++ b/gsl_simulation/urls.py
@@ -25,6 +25,7 @@ from gsl_simulation.views.simulation_projet_views import (
     ProgrammationStatusUpdateView,
     ProjetFormView,
     RefreshSimulationRowView,
+    SimulationProjetCardUpdateView,
     SimulationProjetDetailView,
     SimulationProjetStatusUpdateView,
     patch_dotation_projet,
@@ -85,6 +86,11 @@ urlpatterns = [
         "projet-detail/<int:pk>/historique/",
         SimulationProjetHistoriqueView.as_view(),
         name="simulation-projet-historique",
+    ),
+    path(
+        "<int:pk>/carte/modifier/",
+        SimulationProjetCardUpdateView.as_view(),
+        name="simulation-projet-card-update",
     ),
     path(
         "edit-assiette/<int:pk>/",

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -4,12 +4,13 @@ from django.contrib import messages
 from django.db import transaction
 from django.http import Http404 as DjangoHttp404
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, TemplateView, UpdateView
 from django.views.generic.edit import BaseUpdateView
-from django_htmx.http import HttpResponseClientRefresh
+from django_htmx.http import HttpResponseClientRedirect, HttpResponseClientRefresh
 
 from gsl_core.decorators import htmx_only
 from gsl_core.exceptions import Http404
@@ -582,7 +583,12 @@ class SimulationProjetCardUpdateView(UpdateView):
         except DsServiceException as e:
             form.add_error(None, str(e))
             return self.form_invalid(form)
-        return HttpResponseClientRefresh()
+        simu = self.object
+        url = reverse(
+            "projet:get-projet-simulations",
+            kwargs={"projet_id": simu.dotation_projet.projet_id},
+        )
+        return HttpResponseClientRedirect(url)
 
     def form_invalid(self, form):
         simu = self.object

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import parse_qs, urlparse
 
 from django.contrib import messages
 from django.db import transaction
@@ -588,6 +589,14 @@ class SimulationProjetCardUpdateView(UpdateView):
             "projet:get-projet-simulations",
             kwargs={"projet_id": simu.dotation_projet.projet_id},
         )
+        current_url = self.request.headers.get("HX-Current-URL", "")
+        if current_url:
+            dotation = parse_qs(urlparse(current_url).query).get("dotation", [""])[0]
+            if dotation in ("DETR", "DSIL"):
+                url = f"{url}?dotation={dotation}"
+        # HttpResponseClientRefresh (window.location.reload) can serve a cached
+        # response and leave sibling cards with a shared assiette out of date.
+        # A redirect forces a full navigation with no cache reuse.
         return HttpResponseClientRedirect(url)
 
     def form_invalid(self, form):

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -563,6 +563,57 @@ class SimulationProjetStatusUpdateView(OpenHtmxModalMixin, UpdateView):
         return HttpResponseClientRefresh()
 
 
+class SimulationProjetCardUpdateView(UpdateView):
+    model = SimulationProjet
+    form_class = SimulationProjetForm
+    http_method_names = ["post"]
+
+    def get_queryset(self):
+        return SimulationProjet.objects.active().in_user_perimeter(self.request.user)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        return kwargs
+
+    def form_valid(self, form):
+        try:
+            form.save()
+        except DsServiceException as e:
+            form.add_error(None, str(e))
+            return self.form_invalid(form)
+        return HttpResponseClientRefresh()
+
+    def form_invalid(self, form):
+        simu = self.object
+        if not self.request.headers.get("HX-Request"):
+            messages.error(self.request, "Erreur dans le formulaire de simulation.")
+            return redirect("projet:get-projet-simulations", projet_id=simu.projet.pk)
+        form_id = f"simulation-card-form-{simu.pk}"
+        for field in ("assiette", "montant", "taux"):
+            if field in form.fields:
+                form.fields[field].widget.attrs["form"] = form_id
+        assiette_shared = (
+            SimulationProjet.objects.filter(
+                dotation_projet=simu.dotation_projet
+            ).count()
+            > 1
+        )
+        return render(
+            self.request,
+            "gsl_projet/projet/includes/_simulation_card.html",
+            {
+                "simu": simu,
+                "simulation_projet_form": form,
+                "form_id": form_id,
+                "assiette_shared": assiette_shared,
+                "dotation_projet": simu.dotation_projet,
+                "dossier": simu.dossier,
+                "projet": simu.projet,
+            },
+        )
+
+
 @method_decorator(htmx_only, name="dispatch")
 @method_decorator(require_POST, name="dispatch")
 class BulkSimulationProjetStatusUpdateView(OpenHtmxModalMixin, TemplateView):

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -562,7 +562,12 @@ class SimulationProjetStatusUpdateView(OpenHtmxModalMixin, UpdateView):
                 self.request,
                 f"{str(e)}",
             )
-        return HttpResponseClientRefresh()
+        # HttpResponseClientRefresh (window.location.reload) can serve a cached
+        # response and leave sibling cards with a shared assiette out of date.
+        # A redirect forces a full navigation with no cache reuse.
+        return HttpResponseClientRedirect(
+            self.request.headers.get("HX-Current-URL", self.request.path)
+        )
 
 
 class SimulationProjetCardUpdateView(UpdateView):
@@ -608,12 +613,7 @@ class SimulationProjetCardUpdateView(UpdateView):
         for field in ("assiette", "montant", "taux"):
             if field in form.fields:
                 form.fields[field].widget.attrs["form"] = form_id
-        assiette_shared = (
-            SimulationProjet.objects.filter(
-                dotation_projet=simu.dotation_projet
-            ).count()
-            > 1
-        )
+
         return render(
             self.request,
             "gsl_projet/projet/includes/_simulation_card.html",
@@ -621,7 +621,6 @@ class SimulationProjetCardUpdateView(UpdateView):
                 "simu": simu,
                 "simulation_projet_form": form,
                 "form_id": form_id,
-                "assiette_shared": assiette_shared,
                 "dotation_projet": simu.dotation_projet,
                 "dossier": simu.dossier,
                 "projet": simu.projet,
@@ -763,7 +762,9 @@ class BulkSimulationProjetStatusUpdateView(OpenHtmxModalMixin, TemplateView):
             f"{target_status}:{len(valid_projets)}",
         )
 
-        return HttpResponseClientRefresh()
+        return HttpResponseClientRedirect(
+            request.headers.get("HX-Current-URL", request.path)
+        )
 
     @staticmethod
     def _needs_ds_confirmation(target_status, simulation_projets):
@@ -837,7 +838,9 @@ class ProgrammationStatusUpdateView(OpenHtmxModalMixin, UpdateView):
                 self.request,
                 str(e),
             )
-            return HttpResponseClientRefresh()  # we reload the page without the modal
+            return HttpResponseClientRedirect(
+                self.request.headers.get("HX-Current-URL", self.request.path)
+            )  # we reload the page without the modal
 
     def get_object(self, queryset=None) -> SimulationProjet:
         obj = super().get_object(queryset)
@@ -953,6 +956,6 @@ class ProgrammationStatusUpdateView(OpenHtmxModalMixin, UpdateView):
             MATOMO_ACTION_CHANGEMENT_STATUT_CONFIRME,
             f"{self.kwargs['status']}",
         )
-        return (
-            HttpResponseClientRefresh()
-        )  # we reload the page without the modal and with the success message
+        return HttpResponseClientRedirect(
+            self.request.headers.get("HX-Current-URL", self.request.path)
+        )  # redirect (not refresh) to avoid serving a cached response


### PR DESCRIPTION
## 🌮 Objectif

Ajouter un onglet **Simulations** dans la page projet unifiée, permettant de consulter et modifier les SimulationProjets liés à un projet directement depuis sa fiche.

## 🔍 Liste des modifications

- **Onglet Simulations** ajouté dans `tabs.html` (entre Notes et Notifications)
- **`ProjetSimulationsView`** : liste tous les `SimulationProjet` du projet, avec filtre DETR/DSIL via query param
- **Carte par SimulationProjet** (`_simulation_card.html`) :
  - Titre de la simulation (lien vers la simulation) + badge dotation
  - Dropdown de statut avec modales de confirmation (réutilise l'infrastructure HTMX existante)
  - Formulaire financier éditable (assiette, montant, taux) tant que le projet n'est pas notifié
  - Notice "valeur identique sur toutes les simulations" sur l'assiette si partagée
  - Affichage read-only si projet notifié
- **`SimulationProjetCardUpdateView`** : gère le POST du formulaire de carte (refresh page si succès, swap HTMX de la carte si erreur)
- **CSS** : `.simulation-projet-card { background-image: none }` pour supprimer le gradient DSFR sur les cartes