### PR TITLE
Journaliser les événements de sécurité

### DIFF
--- a/gsl/settings.py
+++ b/gsl/settings.py
@@ -336,6 +336,11 @@ LOGGING = {
             "level": LIBRARIES_LOGGING_LEVEL,
             "propagate": False,
         },
+        "gsl.security": {
+            "handlers": ["console", "sentry"],
+            "level": "INFO",
+            "propagate": False,
+        },
     },
 }
 

--- a/gsl_core/middlewares.py
+++ b/gsl_core/middlewares.py
@@ -1,9 +1,12 @@
 import json
+import logging
 from urllib.parse import urlencode
 
 from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import reverse
+
+security_logger = logging.getLogger("gsl.security")
 
 
 class MatomoHtmxMiddleware:
@@ -116,6 +119,11 @@ class CheckPerimeterMiddleware:
         if user.is_authenticated:
             has_perimeter = user.perimetre
             if not has_perimeter and request.path not in excluded_paths:
+                security_logger.warning(
+                    "security_event=no_perimeter user_id=%s path=%s",
+                    user.pk,
+                    request.path,
+                )
                 return redirect("no-perimeter")
 
         response = self.get_response(request)

--- a/gsl_core/tests/test_middlewares.py
+++ b/gsl_core/tests/test_middlewares.py
@@ -15,7 +15,7 @@ def req():
 
 def make_user(is_authenticated=True, is_staff=False, perimetre=None):
     return SimpleNamespace(
-        is_authenticated=is_authenticated, is_staff=is_staff, perimetre=perimetre
+        pk=1, is_authenticated=is_authenticated, is_staff=is_staff, perimetre=perimetre
     )
 
 

--- a/gsl_core/views.py
+++ b/gsl_core/views.py
@@ -1,4 +1,5 @@
 import io
+import logging
 
 import segno
 from django.conf import settings
@@ -7,6 +8,8 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from django_otp import login as otp_login
 from django_otp.plugins.otp_totp.models import TOTPDevice
+
+security_logger = logging.getLogger("gsl.security")
 
 
 def _generate_qr_svg(device):
@@ -45,6 +48,9 @@ class OTPSetupView(View):
             device.confirmed = True
             device.save()
             otp_login(request, device)
+            security_logger.info(
+                "security_event=otp_setup_confirmed user_id=%s", request.user.pk
+            )
             return redirect("/")
 
         qr_svg = _generate_qr_svg(device)
@@ -101,8 +107,14 @@ class OTPVerifyView(View):
         device = TOTPDevice.objects.filter(user=request.user, confirmed=True).first()
         if device and device.verify_token(token):
             otp_login(request, device)
+            security_logger.info(
+                "security_event=otp_verify_success user_id=%s", request.user.pk
+            )
             return redirect(next_url)
 
+        security_logger.warning(
+            "security_event=otp_verify_failure user_id=%s", request.user.pk
+        )
         return render(
             request,
             "gsl_core/otp_verify.html",

--- a/gsl_oidc/apps.py
+++ b/gsl_oidc/apps.py
@@ -1,6 +1,32 @@
+import logging
+
 from django.apps import AppConfig
+
+security_logger = logging.getLogger("gsl.security")
 
 
 class GslOidcConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "gsl_oidc"
+
+    def ready(self):
+        from django.contrib.auth.signals import user_logged_in, user_logged_out
+
+        user_logged_in.connect(_on_login)
+        user_logged_out.connect(_on_logout)
+
+
+def _on_login(sender, request, user, **kwargs):
+    security_logger.info(
+        "security_event=login_success user_id=%s ip=%s",
+        user.pk,
+        request.META.get("REMOTE_ADDR"),
+    )
+
+
+def _on_logout(sender, request, user, **kwargs):
+    security_logger.info(
+        "security_event=logout user_id=%s ip=%s",
+        getattr(user, "pk", "anonymous"),
+        request.META.get("REMOTE_ADDR"),
+    )


### PR DESCRIPTION
## 🌮 Objectif

Journaliser les événements de sécurité clés afin de pouvoir les auditer et les monitorer via Sentry.

## 🔍 Liste des modifications

- Ajout du logger `gsl.security` (handlers `console` + `sentry`) dans `settings.py`
- **Authentification** (`gsl_oidc/apps.py`) : `login_success`, `logout` via les signaux Django
- **OTP** (`gsl_core/views.py`) : `otp_setup_confirmed`, `otp_verify_success`, `otp_verify_failure`
- **Périmètre** (`gsl_core/middlewares.py`) : `no_perimeter` quand un utilisateur authentifié n'a pas de périmètre

## ⚠️ Informations supplémentaires

Format des logs : `security_event=<event> user_id=<id> [ip=<ip>]`