### PR TITLE
Réinitialiser la sélection après une bulk action

### DIFF
--- a/gsl_notification/templates/gsl_notification/generated_document/multiple/modal_export_progress_body.html
+++ b/gsl_notification/templates/gsl_notification/generated_document/multiple/modal_export_progress_body.html
@@ -3,7 +3,8 @@
      hx-get="{% url 'gsl_notification:generate-documents-status' dotation job_id %}"
      hx-trigger="every 2s"
      hx-swap="outerHTML"
-     hx-target="this">
+     hx-target="this"
+     data-action="documents-generated->checkbox-selection#clearSelection">
     <div class="fr-modal__content">
         <h1 class="fr-modal__title" id="{{ modal_id }}-title">
             Générer les documents

--- a/gsl_notification/views/generate_document_for_multiple_projets_views.py
+++ b/gsl_notification/views/generate_document_for_multiple_projets_views.py
@@ -270,6 +270,7 @@ class GenerateDocumentsStatusView(DetailView):
                     "refreshed_programmation_projets": refreshed_ordered,
                 }
             )
-            return render(request, self.SUCCESS_TEMPLATE, context)
+            response = render(request, self.SUCCESS_TEMPLATE, context)
+            return trigger_client_event(response, "documents-generated")
 
         return render(request, self.ERROR_TEMPLATE, context)

--- a/gsl_programmation/static/js/checkboxSelection.js
+++ b/gsl_programmation/static/js/checkboxSelection.js
@@ -77,6 +77,13 @@ export class CheckboxSelection extends Controller {
     this._syncIdsInputs()
   }
 
+  clearSelection (event) {
+    if (event?.detail?.successful === false) return
+    this.selectedIds.clear()
+    this.rowCheckboxTargets.forEach((c) => this._setCheckbox(c, false))
+    this._refresh()
+  }
+
   pageCheckboxTargetConnected () {
     this._restoreCheckboxStates()
     this._refresh()

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -95,9 +95,9 @@
                 </div>
             </div>
         </div>
-    </div>
 
-    <div id="bulk-status-modal-host">
+        <div id="bulk-status-modal-host">
+        </div>
     </div>
 
 {% endblock content %}

--- a/gsl_simulation/templates/htmx/_bulk_status_progress_partial.html
+++ b/gsl_simulation/templates/htmx/_bulk_status_progress_partial.html
@@ -1,6 +1,9 @@
 {% load custom_pluralize simulation_filters %}
-<div id="bulk-status-progress-body"
-     {% if job.is_running %}hx-get="{% url 'simulation:bulk-status-job-progress' pk=job.pk %}" hx-trigger="every 500ms" hx-swap="outerHTML" hx-target="this"{% endif %}>
+<div id="bulk-status-progress-body" data-action="bulk-status-updated->checkbox-selection#clearSelection"
+    {% if job.is_running %}
+        hx-get="{% url 'simulation:bulk-status-job-progress' pk=job.pk %}" hx-trigger="every 500ms" hx-swap="outerHTML" hx-target="this"
+    {% endif %}
+    >
     <div class="fr-modal__header">
         {% if not job.is_running %}
             <button aria-controls="{{ modal_id }}"

--- a/gsl_simulation/templates/includes/_simulation_bulk_actions_toolbar.html
+++ b/gsl_simulation/templates/includes/_simulation_bulk_actions_toolbar.html
@@ -48,7 +48,7 @@
                                     <form method="post"
                                           hx-post="{% url 'simulation:simulation-projet-bulk-update-simulation-status' status=status_key %}"
                                           hx-swap="none"
-                                          data-action="submit->checkbox-selection#beforeSubmit">
+                                          data-action="submit->checkbox-selection#beforeSubmit bulk-status-updated->checkbox-selection#clearSelection">
                                         {% csrf_token %}
                                         <input type="hidden"
                                                name="simulation_projet_ids"

--- a/gsl_simulation/views/bulk_status_job_views.py
+++ b/gsl_simulation/views/bulk_status_job_views.py
@@ -87,7 +87,7 @@ class BulkStatusJobStartView(CreateView):
             f"{job.target_status}:{job.total}",
         )
 
-        return render(
+        response = render(
             self.request,
             "htmx/_bulk_status_progress_partial.html",
             {
@@ -96,6 +96,9 @@ class BulkStatusJobStartView(CreateView):
                 "simulation_projets_to_refresh": [],
             },
         )
+        if not job.is_running:
+            response = trigger_client_event(response, "bulk-status-updated")
+        return response
 
 
 @method_decorator(htmx_only, name="dispatch")
@@ -130,6 +133,12 @@ class BulkStatusJobProgressView(DetailView):
         context["columns"] = SIMULATION_TABLE_COLUMNS
         context["dotations"] = DOTATIONS
         return context
+
+    def render_to_response(self, context, **response_kwargs):
+        response = super().render_to_response(context, **response_kwargs)
+        if not self.object.is_running:
+            response = trigger_client_event(response, "bulk-status-updated")
+        return response
 
     def _get_simulation_projets_to_refresh(self):
         if self.object.status != BulkStatusJob.STATUS_DONE:

--- a/gsl_simulation/views/simulation_projet_views.py
+++ b/gsl_simulation/views/simulation_projet_views.py
@@ -586,8 +586,11 @@ class BulkSimulationProjetStatusUpdateView(OpenHtmxModalMixin, TemplateView):
             f"{target_status}:{len(valid_projets)}",
         )
 
-        return HttpResponseClientRedirect(
-            request.headers.get("HX-Current-URL", request.path)
+        return trigger_client_event(
+            HttpResponseClientRedirect(
+                request.headers.get("HX-Current-URL", request.path)
+            ),
+            "bulk-status-updated",
         )
 
     @staticmethod


### PR DESCRIPTION
## 🌮 Objectif

Réinitialiser la sélection de projets après une bulk action (génération de documents).

Fix du commentaire de revue sur #766.

## 🔍 Liste des modifications

- Ajoute `clearSelection()` dans le contrôleur Stimulus `CheckboxSelection` : vide `selectedIds`, décoche les cases, et supprime la clé `sessionStorage`
- Branche la méthode sur l'événement `htmx:afterRequest` du formulaire "Générer les documents" (uniquement si la requête a réussi)

## ⚠️ Informations supplémentaires

La sélection entre les pages (feature de #766) reste intacte. Seule la bulk action déclenche le reset.