### PR TITLE
Ajout des liens d'évitement

### DIFF
--- a/gsl/utils/context_processors.py
+++ b/gsl/utils/context_processors.py
@@ -5,7 +5,11 @@ def export_vars(request):
     data = {}
     data["ENV"] = settings.ENV
     data["MATOMO_SITE_ID"] = settings.MATOMO_SITE_ID
-    data["skiplinks"] = [{"link": "#content", "label": "Accéder au contenu"}]
+    data["skiplinks"] = [
+        {"link": "#content", "label": "Contenu"},
+        {"link": "#fr-navigation", "label": "Menu"},
+    ]
+    data["extra_skiplinks"] = []
     return data
 
 

--- a/gsl_core/static/css/gsl.css
+++ b/gsl_core/static/css/gsl.css
@@ -2,6 +2,17 @@ html {
     scroll-behavior: smooth;
 }
 
+/* Prevent layout shift when the skip links bar becomes visible.
+   DSFR switches to position:relative on :focus-within, which pushes
+   content down and causes the scroll-to-anchor to overshoot. */
+.fr-skiplinks:focus-within {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999;
+}
+
 .fr-header__service-title {
     font-size: 1.125rem;
 }

--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -80,7 +80,7 @@
     </head>
     <body hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
         {% block skiplinks %}
-            {% dsfr_skiplinks skiplinks %}
+            {% dsfr_skiplinks skiplinks|add:extra_skiplinks %}
         {% endblock skiplinks %}
 
         {% block header %}
@@ -98,7 +98,7 @@
         {% endblock messages %}
 
         <div class="fr-container fr-mt-4w fr-mb-6w">
-            <main id="content" role="main">
+            <main id="content" role="main" tabindex="-1">
                 {% block content %}
                 {% endblock content %}
             </main>

--- a/gsl_core/templates/blocks/main_menu.html
+++ b/gsl_core/templates/blocks/main_menu.html
@@ -14,6 +14,7 @@
         <nav role="navigation"
              class="fr-nav"
              id="fr-navigation"
+             tabindex="-1"
              aria-label="{{ main_menu_label }}">
             <ul class="fr-nav__list">
                 {% if request.user.is_authenticated and request.user.perimetre %}

--- a/gsl_core/view_mixins.py
+++ b/gsl_core/view_mixins.py
@@ -39,6 +39,14 @@ class OpenHtmxModalMixin:
         )
 
 
+class FilterSkiplinksMixin:
+    def get_context_data(self, **kwargs):
+        return {
+            **super().get_context_data(**kwargs),
+            "extra_skiplinks": [{"link": "#filters", "label": "Filtres"}],
+        }
+
+
 class NoFeedbackHtmxFormViewMixin:
     """
     A view to handle forms submitted via htmx, which provides no feedback to the user.

--- a/gsl_programmation/views.py
+++ b/gsl_programmation/views.py
@@ -17,6 +17,7 @@ from gsl_core.matomo_constants import (
     MATOMO_CATEGORY_SOUS_ENVELOPPE,
 )
 from gsl_core.models import Perimetre
+from gsl_core.view_mixins import FilterSkiplinksMixin
 from gsl_programmation.forms import SubEnveloppeCreateForm, SubEnveloppeUpdateForm
 from gsl_programmation.models import Enveloppe, ProgrammationProjet
 from gsl_programmation.table_columns import PROGRAMMATION_TABLE_COLUMNS
@@ -29,7 +30,7 @@ from gsl_projet.constants import (
 )
 
 
-class ProgrammationProjetListView(FilterView, ListView):
+class ProgrammationProjetListView(FilterSkiplinksMixin, FilterView, ListView):
     model = ProgrammationProjet
     filterset_class = ProgrammationProjetFilters
     template_name = "gsl_programmation/programmation_projet_list.html"

--- a/gsl_projet/templates/includes/_projet_list_filters.html
+++ b/gsl_projet/templates/includes/_projet_list_filters.html
@@ -2,7 +2,9 @@
 
 <link rel="stylesheet" href="{% static 'css/projet_list_filters.css' %}">
 
-<form method="get"
+<form id="filters"
+      tabindex="-1"
+      method="get"
       action="{{ request.path }}{% querystring %}"
       class="fr-background-alt--blue-france">
     {% comment %}

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -6,7 +6,7 @@ from django.views.generic import DetailView, ListView, UpdateView
 from django_filters.views import FilterView
 
 from gsl_core.models import Perimetre
-from gsl_core.view_mixins import SafeRedirectMixin
+from gsl_core.view_mixins import FilterSkiplinksMixin, SafeRedirectMixin
 from gsl_demarches_simplifiees.models import (
     CategorieDetr,
     CategorieDsil,
@@ -214,7 +214,7 @@ class ProjetListViewFilters(ProjetFilters):
         return qs
 
 
-class ProjetListView(FilterView, ListView):
+class ProjetListView(FilterSkiplinksMixin, FilterView, ListView):
     model = Projet
     paginate_by = 25
     filterset_class = ProjetListViewFilters

--- a/gsl_simulation/views/simulation_views.py
+++ b/gsl_simulation/views/simulation_views.py
@@ -20,7 +20,7 @@ from gsl_core.matomo_constants import (
     MATOMO_CATEGORY_SIMULATION,
 )
 from gsl_core.models import Perimetre
-from gsl_core.view_mixins import NoFeedbackHtmxFormViewMixin
+from gsl_core.view_mixins import FilterSkiplinksMixin, NoFeedbackHtmxFormViewMixin
 from gsl_programmation.services.enveloppe_service import EnveloppeService
 from gsl_projet.constants import DOTATION_DSIL, DOTATIONS
 from gsl_projet.models import DotationProjet, Projet
@@ -71,7 +71,7 @@ class SimulationListView(ListView):
         return qs
 
 
-class SimulationDetailView(SingleObjectMixin, FilterView):
+class SimulationDetailView(FilterSkiplinksMixin, SingleObjectMixin, FilterView):
     queryset = Simulation.objects.select_related(
         "enveloppe",
         "enveloppe__perimetre",


### PR DESCRIPTION
## 🌮 Objectif

Ajouter des liens d'évitement accessibles au clavier pour améliorer la navigation au clavier et l'expérience des lecteurs d'écran.

## 🔍 Liste des modifications

- **Liens permanents** (toutes les pages) : « Accès au menu principal » (`#fr-navigation`) et « Accès au contenu » (`#content`)
- **Lien contextuel** (pages avec filtres) : « Accès aux filtres du tableau » (`#filters`), via `FilterSkiplinksMixin` ajouté aux trois vues liste (`ProjetListView`, `ProgrammationProjetListView`, `SimulationDetailView`)
- `tabindex="-1"` sur les éléments cibles pour que le focus clavier parte bien de la cible après activation
- Correction d'un layout shift DSFR : le bandeau d'évitement passe en `position: fixed` lors de l'affichage pour éviter que le scroll ne dépasse la cible