### PR TITLE
Protéger les emojis avec aria-hidden partout

### DIFF
--- a/gsl_core/templates/blocks/header.html
+++ b/gsl_core/templates/blocks/header.html
@@ -26,7 +26,8 @@
                                 title="Menu utilisateur"
                                 type="button"
                                 class="fr-btn fr-icon-user-fill">
-                            {{ user }} <span class="fr-ml-1w fr-icon--sm fr-icon-arrow-down-s-line"></span>
+                            {{ user }} <span class="fr-ml-1w fr-icon--sm fr-icon-arrow-down-s-line"
+       aria-hidden="true"></span>
                         </button>
 
                         <div class="fr-collapse fr-menu" id="user-menu">

--- a/gsl_core/templates/blocks/main_menu.html
+++ b/gsl_core/templates/blocks/main_menu.html
@@ -101,7 +101,7 @@
                 {% endif %}
                 {% if request.user.is_staff %}
                     <li class="fr-nav__item">
-                        <a class="fr-nav__link" href="{% url "admin:index" %}">⚙️ Back-office ⚙️</a>
+                        <a class="fr-nav__link" href="{% url "admin:index" %}"><span class="fr-mr-1v" aria-hidden="true">⚙️</span> Back-office <span class="fr-ml-1v" aria-hidden="true">⚙️</span></a>
                     </li>
                 {% endif %}
             </ul>

--- a/gsl_core/templates/gsl_core/table_cells/_default_header.html
+++ b/gsl_core/templates/gsl_core/table_cells/_default_header.html
@@ -5,10 +5,15 @@
     {% with column|sort_url_param:current_order as next_order %}
         {% with column|aria_sort:current_order as sort_state %}
             <a href="{% querystring order=next_order %}"
-               aria-label="Trier par {{ column.label }}"
                title="Trier par {{ column.label }}">
                 {{ column.label }}
-                <i class="fr-icon--sm {% if sort_state == 'ascending' %}fr-icon-arrow-up-s-fill{% elif sort_state == 'descending' %}fr-icon-arrow-down-s-fill{% else %}fr-icon-arrow-up-down-line{% endif %}"></i>
+                {% if sort_state == 'ascending' %}
+                    <span class="fr-sr-only">(ascendant)</span>
+                {% elif sort_state == 'descending' %}
+                    <span class="fr-sr-only">(descendant)</span>
+                {% endif %}
+                <i class="fr-icon--sm {% if sort_state == 'ascending' %}fr-icon-arrow-up-s-fill{% elif sort_state == 'descending' %}fr-icon-arrow-down-s-fill{% else %}fr-icon-arrow-up-down-line{% endif %}"
+                   aria-hidden="true"></i>
             </a>
         {% endwith %}
     {% endwith %}

--- a/gsl_core/templates/includes/_enveloppe_summary.html
+++ b/gsl_core/templates/includes/_enveloppe_summary.html
@@ -23,7 +23,7 @@
                             <th>
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-mail-fill fr-icon--sm icon"></span>
+                                        <span class="fr-icon-mail-fill fr-icon--sm icon" aria-hidden="true"></span>
                                     </div>
                                     <div class="text">
                                         Dotation
@@ -33,7 +33,7 @@
                             <th>
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-road-map-fill fr-icon--sm"></span>
+                                        <span class="fr-icon-road-map-fill fr-icon--sm" aria-hidden="true"></span>
                                     </div>
                                     <div class="text">
                                         Territoire
@@ -43,7 +43,7 @@
                             <th class="col--130px">
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-coin-fill fr-icon--sm"></span>
+                                        <span class="fr-icon-coin-fill fr-icon--sm" aria-hidden="true"></span>
                                     </div>
                                     <div class="text">
                                         Enveloppe de dotation
@@ -53,7 +53,7 @@
                             <th class="col--130px">
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-coin-fill fr-icon--sm"></span>
+                                        <span class="fr-icon-coin-fill fr-icon--sm" aria-hidden="true"></span>
                                     </div>
                                     <div class="text">
                                         Montant total demandé
@@ -63,7 +63,7 @@
                             <th>
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-money-euro-circle-fill fr-icon--sm"></span>
+                                        <span class="fr-icon-money-euro-circle-fill fr-icon--sm" aria-hidden="true"></span>
                                     </div>
                                     <div class="text">
                                         Montant accepté
@@ -73,7 +73,7 @@
                             <th>
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-scales-3-fill fr-icon--sm"></span>
+                                        <span class="fr-icon-scales-3-fill fr-icon--sm" aria-hidden="true"></span>
                                     </div>
                                     <div class="text">
                                         Reste à attribuer
@@ -83,7 +83,8 @@
                             <th>
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-success-fill fr-icon--sm color-icon-success"></span>
+                                        <span class="fr-icon-success-fill fr-icon--sm color-icon-success"
+                                              aria-hidden="true"></span>
                                     </div>
                                     <div class="text">
                                         Projets acceptés
@@ -93,7 +94,8 @@
                             <th>
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-close-circle-fill fr-icon--sm color-icon-error"></span>
+                                        <span class="fr-icon-close-circle-fill fr-icon--sm color-icon-error"
+                                              aria-hidden="true"></span>
                                     </div>
                                     <div class="text">
                                         Projets refusés
@@ -103,7 +105,7 @@
                             <th>
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-account-circle-fill fr-icon--sm"></span>
+                                        <span class="fr-icon-account-circle-fill fr-icon--sm" aria-hidden="true"></span>
                                     </div>
                                     <div class="text">
                                         Demandeurs
@@ -113,7 +115,7 @@
                             <th>
                                 <div>
                                     <div class="icon">
-                                        <span class="fr-icon-folder-2-fill fr-icon--sm"></span>
+                                        <span class="fr-icon-folder-2-fill fr-icon--sm" aria-hidden="true"></span>
                                     </div>
                                     <div class="text">
                                         Projets déposés

--- a/gsl_notification/templates/gsl_notification/modal/notify_refused_dismissed.html
+++ b/gsl_notification/templates/gsl_notification/modal/notify_refused_dismissed.html
@@ -26,7 +26,7 @@
 
 {% block content %}
     <h1 class="fr-modal__title" id="{{ modal_id }}-title">
-        <i class="fr-icon-mail-line"></i>
+        <i class="fr-icon-mail-line" aria-hidden="true"></i>
         Notifier sur Démarche Numérique
         {% if projet.has_double_dotations %}
             {# djlint:off #}

--- a/gsl_notification/templates/gsl_notification/modele/list.html
+++ b/gsl_notification/templates/gsl_notification/modele/list.html
@@ -37,7 +37,7 @@
 {% endblock content %}
 
 {% block modal %}
-    {% ui_confirmation_modal modal_id="delete-modele-arrete" title="Suppression du modèle d’arrêté" text="Êtes-vous sûr de vouloir supprimer ce modèle ?<br><b>⚠️ Les autres utilisateurs ayant accès à ce modèle ne pourront plus l’utiliser ni le voir.</b>" form="delete-modele-arrete-form" action_text="Supprimer" %}
+    {% ui_confirmation_modal modal_id="delete-modele-arrete" title="Suppression du modèle d’arrêté" text="Êtes-vous sûr de vouloir supprimer ce modèle ?<br><b>Les autres utilisateurs ayant accès à ce modèle ne pourront plus l’utiliser ni le voir.</b>" form="delete-modele-arrete-form" action_text="Supprimer" %}
     <form method="post" id="delete-modele-arrete-form">
         {% csrf_token %}
     </form>

--- a/gsl_notification/templates/includes/_not_instructeur_modal.html
+++ b/gsl_notification/templates/includes/_not_instructeur_modal.html
@@ -13,7 +13,7 @@
                 <div class="fr-modal__content">
                     <h1 class="fr-modal__title fr-text-default--error"
                         id="{{ modal_id }}-title">
-                        <i class="fr-icon-group-fill"></i>
+                        <i class="fr-icon-group-fill" aria-hidden="true"></i>
                         Vous ne faites pas partie du groupe d'instructeurs de ce dossier
                     </h1>
                     <p>

--- a/gsl_programmation/table_columns.py
+++ b/gsl_programmation/table_columns.py
@@ -124,8 +124,13 @@ def _get_other_dotation_statut(context):
         return ""
     return format_html(
         '<div class="gsl-projet-table__status-notified">{}</div>',
-        simu.get_status_display(),
+        _wrap_emoji(simu.get_status_display()),
     )
+
+
+def _wrap_emoji(display_str):
+    emoji, text = display_str.split(" ", 1)
+    return format_html('<span aria-hidden="true">{}</span> {}', emoji, text)
 
 
 COLUMN_ASSIETTE = Column(
@@ -167,7 +172,7 @@ COLUMN_DOCUMENTS = Column(
 COLUMN_STATUT = Column(
     key="statut",
     label="Statut",
-    getter=lambda ctx: ctx["programmation_projet"].get_status_display(),
+    getter=lambda ctx: _wrap_emoji(ctx["programmation_projet"].get_status_display()),
     other_dotation_getter=_get_other_dotation_statut,
     sticky=StickyPosition.RIGHT_1,
 )

--- a/gsl_projet/templates/includes/_filter_amount_range.html
+++ b/gsl_projet/templates/includes/_filter_amount_range.html
@@ -5,7 +5,8 @@
         <button type="button"
                 class="fr-input {% if rc.has_data %}filter-dropdown-button-active{% endif %}">
             {{ rc.label }}
-            <span class="{{ rc.icon }} fr-icon--sm blue-color fr-ml-1w"></span>
+            <span class="{{ rc.icon }} fr-icon--sm blue-color fr-ml-1w"
+                  aria-hidden="true"></span>
         </button>
         <div class="gsl-dropdown-content">
             <div class="amount-filter-group">

--- a/gsl_projet/templates/includes/_filter_montant_demande.html
+++ b/gsl_projet/templates/includes/_filter_montant_demande.html
@@ -6,7 +6,8 @@
                 class="fr-input {% if rc.has_data %}filter-dropdown-button-active{% endif %}"
                 id="filter-montant-demande-button">
             {{ rc.label }}
-            <span class="fr-icon-money-euro-circle-fill fr-icon--sm blue-color fr-ml-1w"></span>
+            <span class="fr-icon-money-euro-circle-fill fr-icon--sm blue-color fr-ml-1w"
+                  aria-hidden="true"></span>
         </button>
         <div class="gsl-dropdown-content">
             <div class="amount-filter-group">

--- a/gsl_simulation/table_columns.py
+++ b/gsl_simulation/table_columns.py
@@ -90,8 +90,13 @@ def _get_simu_other_dotation_statut(context):
         return ""
     return format_html(
         '<div class="gsl-projet-table__status-notified">{}</div>',
-        simu.get_status_display(),
+        _wrap_emoji(simu.get_status_display()),
     )
+
+
+def _wrap_emoji(display_str):
+    emoji, text = display_str.split(" ", 1)
+    return format_html('<span aria-hidden="true">{}</span> {}', emoji, text)
 
 
 COLUMN_ASSIETTE = Column(

--- a/gsl_simulation/templates/gsl_simulation/simulation_detail.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_detail.html
@@ -20,7 +20,8 @@
                 aria-haspopup="menu"
                 aria-expanded="false">
             Exporter le tableau
-            <span class="fr-icon-arrow-down-s-line fr-btn--icon-right"></span>
+            <span class="fr-icon-arrow-down-s-line fr-btn--icon-right"
+                  aria-hidden="true"></span>
         </button>
         <div class="gsl-dropdown-content fr-p-0 export-btn-container" role="menu">
             {% for export_type in export_types %}

--- a/gsl_simulation/templates/gsl_simulation/simulation_list.html
+++ b/gsl_simulation/templates/gsl_simulation/simulation_list.html
@@ -17,7 +17,7 @@
     {% else %}
         <div class="add-simulation-button-container">
             <a href="{% url 'gsl_simulation:simulation-form' %}"
-               class="fr-btn fr-mr-1w fr-pl-3v"><i class="fr-icon-add-line"></i> Nouvelle simulation</a>
+               class="fr-btn fr-mr-1w fr-pl-3v"><i class="fr-icon-add-line" aria-hidden="true"></i> Nouvelle simulation</a>
         </div>
         <ul class="simulation-cards-list no-list-style">
             {% for simulation in object_list %}
@@ -55,7 +55,7 @@
                             <div class="fr-sr-only">
                                 Voir la simulation {{ simulation.title }}
                             </div>
-                            <i class="fr-icon-arrow-right-line"></i>
+                            <i class="fr-icon-arrow-right-line" aria-hidden="true"></i>
                         </a>
                     </div>
                 </li>

--- a/gsl_simulation/templates/gsl_simulation/table_cells/statut.html
+++ b/gsl_simulation/templates/gsl_simulation/table_cells/statut.html
@@ -1,6 +1,7 @@
 <div class="gsl-projet-table__status-notified">
     {% if dotation_projet.programmation_projet.notified_at %}
-        {{ simu.get_status_display }}
+        {% load simulation_filters %}
+        {{ simu.get_status_display|split_symbol_and_status|safe }}
     {% else %}
         {% include "includes/_status_dropdown_buttons.html" with table=True %}
     {% endif %}

--- a/gsl_simulation/templates/htmx/bulk_status_confirm_modal.html
+++ b/gsl_simulation/templates/htmx/bulk_status_confirm_modal.html
@@ -46,7 +46,7 @@ Context:
                             </h1>
                             <p>
                                 Vous allez passer {{ simulation_projets|length }} projet{{ simulation_projets|length|custom_pluralize }} au statut
-                                <strong>{{ target_status|status_to_label|safe }}</strong>.
+                                <strong>{{ target_status|status_to_label|split_symbol_and_status|safe }}</strong>.
                             </p>
                             <p>
                                 Cette opération effectue une mise à jour sur Démarches Numériques.

--- a/gsl_simulation/templates/htmx/bulk_status_preflight_modal.html
+++ b/gsl_simulation/templates/htmx/bulk_status_preflight_modal.html
@@ -38,7 +38,7 @@ Context:
                             <div class="fr-modal__content">
                                 <h1 class="fr-modal__title" id="{{ modal_id }}-title">
                                     <span class="fr-icon-arrow-right-line fr-icon--lg" aria-hidden="true"></span>
-                                    Modifier à «&nbsp;{{ target_status|status_to_label|safe }}&nbsp;» {{ valid_count }} sur {{ valid_count|add:blocker_count }} projet{{ valid_count|add:blocker_count|custom_pluralize }}
+                                    Modifier à «&nbsp;{{ target_status|status_to_label|split_symbol_and_status|safe }}&nbsp;» {{ valid_count }} sur {{ valid_count|add:blocker_count }} projet{{ valid_count|add:blocker_count|custom_pluralize }}
                                 </h1>
                                 <div class="fr-alert fr-alert--warning fr-mt-2w" role="alert">
                                     <h3 class="fr-alert__title">

--- a/gsl_simulation/templates/htmx/go_back_to_simulation_state_modal.html
+++ b/gsl_simulation/templates/htmx/go_back_to_simulation_state_modal.html
@@ -12,7 +12,7 @@
     {% endblock button %}
 {% else %}
     {% block button_label %}
-        {{ new_simulation_status|status_to_label }}
+        {{ new_simulation_status|status_to_label|split_symbol_and_status|safe }}
     {% endblock button_label %}
 {% endif %}
 

--- a/gsl_simulation/templates/htmx/not_instructeur_error.html
+++ b/gsl_simulation/templates/htmx/not_instructeur_error.html
@@ -7,7 +7,7 @@
 {% block content %}
     <h1 class="fr-modal__title fr-text-default--error"
         id="{{ modal_id }}-title">
-        <i class="fr-icon-group-fill"></i>
+        <i class="fr-icon-group-fill" aria-hidden="true"></i>
         Vous ne faites pas partie du groupe d'instructeurs de ce dossier
     </h1>
     <p>

--- a/gsl_simulation/templates/htmx/not_instructeur_error.html
+++ b/gsl_simulation/templates/htmx/not_instructeur_error.html
@@ -2,7 +2,7 @@
 {% load simulation_filters %}
 
 {% block button_label %}
-    {{ new_simulation_status|status_to_label }}
+    {{ new_simulation_status|status_to_label|split_symbol_and_status|safe }}
 {% endblock button_label %}
 {% block content %}
     <h1 class="fr-modal__title fr-text-default--error"

--- a/gsl_simulation/templates/htmx/programmation_status_change_modal.html
+++ b/gsl_simulation/templates/htmx/programmation_status_change_modal.html
@@ -2,7 +2,7 @@
 {% load simulation_filters %}
 
 {% block button_label %}
-    {{ new_simulation_status|status_to_label }}
+    {{ new_simulation_status|status_to_label|split_symbol_and_status|safe }}
 {% endblock button_label %}
 
 {% block content %}

--- a/gsl_simulation/templates/includes/_status_dropdown_buttons.html
+++ b/gsl_simulation/templates/includes/_status_dropdown_buttons.html
@@ -1,11 +1,11 @@
-{% load simulation_filters %}
+{% load simulation_filters gsl_filters %}
 <div class="fr-nav fr-translate gsl-projet-table__status-select gsl-projet-table__status-select--{{ simu.status }}">
     <div class="fr-nav__item{% if table %} fr-nav__item--align-right{% endif %}">
         <button class="fr-select fr-btn--{% if table %}sm{% else %}lg{% endif %} fr-dropdown__button"
                 aria-expanded="false"
                 aria-controls="status-dropdown-{{ simu.pk }}"
-                aria-label="{{ simu.get_status_display }}. Changer le statut du projet">
-            {{ simu.get_status_display }}
+                aria-label="{{ simu.get_status_display|remove_first_word }}. Changer le statut du projet">
+            {{ simu.get_status_display|split_symbol_and_status|safe }}
         </button>
         <div class="fr-collapse fr-menu"
              aria-label="Options de statut"

--- a/gsl_simulation/templatetags/simulation_filters.py
+++ b/gsl_simulation/templatetags/simulation_filters.py
@@ -109,6 +109,7 @@ def status_to_fr_color(status):
 
 @register.filter(name="split_symbol_and_status")
 def split_symbol_and_status(symbol_and_status):
-    symbol = symbol_and_status[0]
-    status = symbol_and_status[2:]
+    parts = symbol_and_status.split(" ", 1)
+    symbol = parts[0]
+    status = parts[1] if len(parts) > 1 else ""
     return f"<span aria-hidden='true'>{symbol}</span> {status}"


### PR DESCRIPTION
## 🌮 Objectif

Corriger l'accessibilité des emojis présents dans les labels de statut : sans `aria-hidden`, les lecteurs d'écran annoncent l'emoji verbalement (ex : « case à cocher verte Accepté »).

## 🔍 Liste des modifications

- **`simulation_filters.py`** — fix bug multi-codepoints dans `split_symbol_and_status` : découpage sur l'espace plutôt que sur l'index du premier caractère (⛔️, ✔️, ✖️ ont un variation selector U+FE0F qui décalait tout)
- **`statut.html`** — cellule tableau simulation : `get_status_display` pipé via `split_symbol_and_status|safe`
- **`_status_dropdown_buttons.html`** — `aria-label` du bouton nettoyé avec `remove_first_word` (pas d'emoji annoncé), texte visible protégé avec `split_symbol_and_status|safe`
- **`table_columns.py`** — ajout du helper `_wrap_emoji` (utilise `format_html` → retourne un `SafeString`), appliqué au getter de `COLUMN_STATUT` et à `_get_other_dotation_statut`
- **5 modales htmx** (`programmation_status_change_modal`, `not_instructeur_error`, `go_back_to_simulation_state_modal`, `bulk_status_confirm_modal`, `bulk_status_preflight_modal`) — `status_to_label` pipé via `split_symbol_and_status|safe`
- **`main_menu.html`** — les ⚙️ codés en dur entourés de `<span aria-hidden="true">`
- **`modele/list.html`** — emoji ⚠️ supprimé du texte passé à `ui_confirmation_modal` (argument rendu sans `|safe`, impossible de protéger l'emoji avec du HTML)