### PR TITLE
Permettre un justfile.local pour les recettes personnelles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ node_modules/
 
 # Personal agent files (e.g. CLAUDE.local.md)
 *.local.md
+justfile.local

--- a/justfile
+++ b/justfile
@@ -97,3 +97,5 @@ scalingo-django-shell environment: (scalingo-django-command environment "shell")
 # Scalingo: copy a database of a review app from parent
 scalingo-load-review-app environment pr_number:
     scalingo run --app gsl-{{environment}}-pr{{ pr_number }} "bash bin/copy_db.sh && python manage.py migrate"
+
+import? 'justfile.local'


### PR DESCRIPTION
## 🌮 Objectif

Permettre à chaque développeur d'avoir ses propres recettes `just` sans les committer.

## 🔍 Liste des modifications

- Ajout de `import? 'justfile.local'` en fin de `justfile` (le `?` rend l'import optionnel — pas d'erreur si le fichier n'existe pas)
- Ajout de `justfile.local` dans `.gitignore`