### PR TITLE
Ajout d'une ligne de commande pour importer les données du COG

### DIFF
--- a/gsl_core/management/commands/import_cog.py
+++ b/gsl_core/management/commands/import_cog.py
@@ -1,0 +1,113 @@
+import csv
+import io
+import logging
+
+import requests
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from gsl_core.models import Arrondissement, Commune, Departement, Region
+
+logger = logging.getLogger(__name__)
+
+COG_MILLESIME = 2026
+COG_BASE_URL = "https://www.insee.fr/fr/statistiques/fichier/8740222"
+
+
+class Command(BaseCommand):
+    """
+    python manage.py import_cog
+    """
+
+    help = (
+        f"Import from INSEE Code Officiel Géographique {COG_MILLESIME} "
+        "(régions, départements, arrondissements, communes)"
+    )
+
+    def fetch_csv(self, filename):
+        url = f"{COG_BASE_URL}/{filename}"
+        self.stdout.write(f"Téléchargement de {url}…")
+        response = requests.get(url, timeout=60)
+        if response.status_code != 200:
+            raise CommandError(
+                f"Impossible de télécharger {url} ({response.status_code})"
+            )
+        response.encoding = "utf-8"
+        return csv.DictReader(io.StringIO(response.text))
+
+    def report(self, verbose_name, created, updated):
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{verbose_name} : {created} création(s), {updated} mise(s) à jour"
+            )
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        self.import_regions()
+        self.import_departements()
+        self.import_arrondissements()
+        self.import_communes()
+        self.stdout.write(self.style.SUCCESS("Terminé."))
+
+    def import_regions(self):
+        created, updated = 0, 0
+        for row in self.fetch_csv(f"v_region_{COG_MILLESIME}.csv"):
+            _, is_created = Region.objects.update_or_create(
+                insee_code=row["REG"],
+                defaults={"name": row["LIBELLE"]},
+            )
+            created += is_created
+            updated += not is_created
+        self.report("Régions", created, updated)
+
+    def import_departements(self):
+        created, updated = 0, 0
+        for row in self.fetch_csv(f"v_departement_{COG_MILLESIME}.csv"):
+            _, is_created = Departement.objects.update_or_create(
+                insee_code=row["DEP"],
+                defaults={
+                    "name": row["LIBELLE"],
+                    "region_id": row["REG"],
+                },
+            )
+            created += is_created
+            updated += not is_created
+        self.report("Départements", created, updated)
+
+    def import_arrondissements(self):
+        created, updated = 0, 0
+        for row in self.fetch_csv(f"v_arrondissement_{COG_MILLESIME}.csv"):
+            _, is_created = Arrondissement.objects.update_or_create(
+                insee_code=row["ARR"],
+                defaults={
+                    "name": row["LIBELLE"],
+                    "departement_id": row["DEP"],
+                },
+            )
+            created += is_created
+            updated += not is_created
+        self.report("Arrondissements", created, updated)
+
+    def import_communes(self):
+        created, updated = 0, 0
+        skipped = 0
+        for row in self.fetch_csv(f"v_commune_{COG_MILLESIME}.csv"):
+            # Only keep "communes de plein exercice", and skip "communes déléguées",
+            # "communes associées", arrondissements (PLM)
+            if row["TYPECOM"] != "COM":
+                skipped += 1
+                continue
+            _, is_created = Commune.objects.update_or_create(
+                insee_code=row["COM"],
+                defaults={
+                    "name": row["LIBELLE"],
+                    "departement_id": row["DEP"],
+                    "arrondissement_id": row["ARR"] or None,
+                },
+            )
+            created += is_created
+            updated += not is_created
+        self.report("Communes", created, updated)
+        if skipped:
+            self.stdout.write(f"{skipped} ligne(s) ignorée(s) (COMD, COMA, ARM)")

--- a/gsl_core/tests/test_commands.py
+++ b/gsl_core/tests/test_commands.py
@@ -1,9 +1,11 @@
 import logging
 
 import pytest
+import responses
 from django.core.management import call_command
 
-from gsl_core.models import Arrondissement, Departement, Perimetre, Region
+from gsl_core.management.commands.import_cog import COG_BASE_URL, COG_MILLESIME
+from gsl_core.models import Arrondissement, Commune, Departement, Perimetre, Region
 from gsl_core.tests.factories import (
     ArrondissementFactory,
     PerimetreArrondissementFactory,
@@ -28,3 +30,86 @@ def test_create_perimetres(caplog):
     assert perimetres.count() == 30
 
     assert "Et voilà le travail, 29 périmètres ont été créés" in caplog.text
+
+
+def mock_cog_csv(filename, content):
+    responses.get(
+        f"{COG_BASE_URL}/{filename}",
+        body=content.strip(),
+        content_type="text/csv",
+    )
+
+
+def mock_cog_files():
+    mock_cog_csv(
+        f"v_region_{COG_MILLESIME}.csv",
+        """
+"REG","CHEFLIEU","TNCC","NCC","NCCENR","LIBELLE"
+"84","69123","1","AUVERGNE RHONE ALPES","Auvergne-Rhône-Alpes","Auvergne-Rhône-Alpes"
+""",
+    )
+    mock_cog_csv(
+        f"v_departement_{COG_MILLESIME}.csv",
+        """
+"DEP","REG","CHEFLIEU","TNCC","NCC","NCCENR","LIBELLE"
+"01","84","01053","5","AIN","Ain","Ain"
+""",
+    )
+    mock_cog_csv(
+        f"v_arrondissement_{COG_MILLESIME}.csv",
+        """
+"ARR","DEP","REG","CHEFLIEU","TNCC","NCC","NCCENR","LIBELLE"
+"011","01","84","01034","0","BELLEY","Belley","Belley"
+""",
+    )
+    mock_cog_csv(
+        f"v_commune_{COG_MILLESIME}.csv",
+        """
+"TYPECOM","COM","REG","DEP","CTCD","ARR","TNCC","NCC","NCCENR","LIBELLE","CAN","COMPARENT"
+"COM","01004","84","01","01D","011","1","AMBERIEU EN BUGEY","Ambérieu-en-Bugey","Ambérieu-en-Bugey","0101",""
+"COMD","01015","","","","","1","ARBIGNIEU","Arbignieu","Arbignieu","","01015"
+""",
+    )
+
+
+@pytest.mark.django_db
+@responses.activate
+def test_import_cog():
+    mock_cog_files()
+
+    call_command("import_cog")
+
+    region = Region.objects.get()
+    assert region.insee_code == "84"
+    assert region.name == "Auvergne-Rhône-Alpes"
+
+    departement = Departement.objects.get()
+    assert departement.insee_code == "01"
+    assert departement.name == "Ain"
+    assert departement.region == region
+
+    arrondissement = Arrondissement.objects.get()
+    assert arrondissement.insee_code == "011"
+    assert arrondissement.name == "Belley"
+    assert arrondissement.departement == departement
+
+    # The commune déléguée (COMD) is skipped.
+    commune = Commune.objects.get()
+    assert commune.insee_code == "01004"
+    assert commune.name == "Ambérieu-en-Bugey"
+    assert commune.departement == departement
+    assert commune.arrondissement == arrondissement
+
+
+@pytest.mark.django_db
+@responses.activate
+def test_import_cog_is_idempotent():
+    mock_cog_files()
+    call_command("import_cog")
+
+    mock_cog_files()
+    Commune.objects.update(name="Ancien nom")
+    call_command("import_cog")
+
+    assert Commune.objects.count() == 1
+    assert Commune.objects.get().name == "Ambérieu-en-Bugey"


### PR DESCRIPTION
Idée: avoir juste une ligne à lancer plutôt que de devoir diviser un fichier et l'importer en plusieurs fois via l'admin.

```
python manage.py import_cog
```

Question:
- est-ce qu'on a quand même besoin de l'mporter dans l'admin ?
- qu'est-ce qu'on veut faire avec les communes qui ont fusionné ou défusionné d'une année sur l'autre (autre PR)

