### PR TITLE
Utilise htmx pour le formulaire assiette_dotation de la page projet

### DIFF
--- a/gsl_core/static/js/controllers/autoDismiss.js
+++ b/gsl_core/static/js/controllers/autoDismiss.js
@@ -1,0 +1,14 @@
+import { Controller } from 'stimulus'
+
+// Removes its element after a short delay. Handy for transient htmx feedback
+// (e.g. a success badge) that should not stay on the page.
+export class AutoDismiss extends Controller {
+  connect () {
+    const delay = parseInt(this.element.dataset.autoDismissDelay || '3000', 10)
+    this.timeout = setTimeout(() => this.element.remove(), delay)
+  }
+
+  disconnect () {
+    clearTimeout(this.timeout)
+  }
+}

--- a/gsl_core/static/js/controllers/formatMontant.js
+++ b/gsl_core/static/js/controllers/formatMontant.js
@@ -11,12 +11,6 @@ export class FormatMontant extends Controller {
     this._format(event.target)
   }
 
-  unformat () {
-    this.fieldTargets.forEach(field => {
-      field.value = field.value.replace(/\s/g, '').replace(',', '.')
-    })
-  }
-
   _format (field) {
     const n = parseFloat(field.value.replace(',', '.').replace(/\s/g, ''))
     if (!isNaN(n)) {

--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -65,7 +65,8 @@
                     "projetNotes": "{% static 'js/controllers/projetNotes.js' %}",
                     "projetNoteCard": "{% static 'js/controllers/projetNoteCard.js' %}",
                     "radioNavigate": "{% static 'js/controllers/radioNavigate.js' %}",
-                    "formatMontant": "{% static 'js/controllers/formatMontant.js' %}"
+                    "formatMontant": "{% static 'js/controllers/formatMontant.js' %}",
+                    "autoDismiss": "{% static 'js/controllers/autoDismiss.js' %}"
                 }
             }
             </script>
@@ -126,24 +127,25 @@
         <script src="{% static "js/sticky_table_headers.js" %}" defer></script>
         <script type="module" nonce="{{ csp_nonce }}">
             import { Application } from "stimulus"
-            import { DoubleDotation } from "doubleDotation"
-            import { Modal } from "modal"
-            import { DocumentImport } from "documentImport"
-            import { TipTapEditor } from "tiptapEditor"
-            import { ModeleArreteForm } from "modeleArreteForm"
-            import { DeleteNotificationDocumentModal } from "deleteNotificationDocumentModal"
-            import { QrCodeToggle } from "qrCodeToggle"
-            import { SkipDocumentToggle } from "skipDocumentToggle"
-            import { CheckboxSelection } from "checkboxSelection"
+            import { AutoDismiss } from "autoDismiss"
             import { BindAmountFields } from "bindAmountFields"
-            import { FormUtils } from "formUtils"
-            import { DotationDropdown } from "dotationDropdown"
+            import { CheckboxSelection } from "checkboxSelection"
             import { CommentArbitrage } from "commentArbitrage"
-            import { ProjetForm } from "projetForm"
-            import { ProjetNotes } from "projetNotes"
-            import { ProjetNoteCard } from "projetNoteCard"
-            import { RadioNavigate } from "radioNavigate"
+            import { DeleteNotificationDocumentModal } from "deleteNotificationDocumentModal"
+            import { DocumentImport } from "documentImport"
+            import { DotationDropdown } from "dotationDropdown"
+            import { DoubleDotation } from "doubleDotation"
             import { FormatMontant } from "formatMontant"
+            import { FormUtils } from "formUtils"
+            import { Modal } from "modal"
+            import { ModeleArreteForm } from "modeleArreteForm"
+            import { ProjetForm } from "projetForm"
+            import { ProjetNoteCard } from "projetNoteCard"
+            import { ProjetNotes } from "projetNotes"
+            import { QrCodeToggle } from "qrCodeToggle"
+            import { RadioNavigate } from "radioNavigate"
+            import { SkipDocumentToggle } from "skipDocumentToggle"
+            import { TipTapEditor } from "tiptapEditor"
 
             window.Stimulus = Application.start()
 
@@ -165,6 +167,7 @@
             Stimulus.register("projet-note-card", ProjetNoteCard)
             Stimulus.register("radio-navigate", RadioNavigate)
             Stimulus.register("format-montant", FormatMontant)
+            Stimulus.register("auto-dismiss", AutoDismiss)
         </script>
 
         {% block extra_js %}
@@ -172,11 +175,9 @@
 
         {% if MATOMO_SITE_ID and matomo_pending_events %}
             <script nonce="{{ csp_nonce }}">
-                window.addEventListener("DOMContentLoaded", function() {
-                    var _paq = (window._paq = window._paq || []);
-                    {% for event in matomo_pending_events %}
-                        _paq.push(["trackEvent", "{{ event.category|escapejs }}", "{{ event.action|escapejs }}", "{{ event.name|escapejs }}"]);
-                    {% endfor %}
+                window.addEventListener("DOMContentLoaded", () => {
+                    var _paq = (window._paq = window._paq || []);% for event in matomo_pending_events %
+                        _paq.push(["trackEvent", "{{ event.category|escapejs }}", "{{ event.action|escapejs }}", "{{ event.name|escapejs }}"]);% endfor %
                 });
             </script>
         {% endif %}

--- a/gsl_projet/forms.py
+++ b/gsl_projet/forms.py
@@ -381,8 +381,15 @@ class DotationProjetForm(ModelForm):
         ]
 
 
+class FrenchDecimalField(forms.DecimalField):
+    def to_python(self, value):
+        if isinstance(value, str):
+            value = "".join(value.split()).replace(",", ".")
+        return super().to_python(value)
+
+
 class DotationProjetAssietteForm(ModelForm, DsfrBaseForm):
-    assiette = forms.DecimalField(
+    assiette = FrenchDecimalField(
         label="Montant des dépenses éligibles retenues (€)",
         required=True,
         help_text=" Cette valeur est identique sur toutes les simulations de cette dotation.",
@@ -390,6 +397,7 @@ class DotationProjetAssietteForm(ModelForm, DsfrBaseForm):
             attrs={
                 "class": "fr-input",
                 "inputmode": "numeric",
+                "data-controller": "format-montant",
                 "data-format-montant-target": "field",
                 "data-action": "change->format-montant#format",
             }

--- a/gsl_projet/templates/gsl_projet/projet/tab_projet.html
+++ b/gsl_projet/templates/gsl_projet/projet/tab_projet.html
@@ -1,5 +1,5 @@
 {% load dsfr_tags %}
-{% load static gsl_filters %}
+{% load static gsl_filters projet_tags %}
 
 <div class="fr-grid-row fr-grid-row--gutters fr-mb-3w"
      data-controller="projet-form">
@@ -402,9 +402,9 @@
                             ({{ dossier.taux_demande|percent:3 }} du coût total)
                         </p>
                     </div>
-                    {% for item in dotation_projet_items %}
-                        {% if item.dp.status == 'processing' and not projet.notified_at %}
-                            {% include "includes/forms/_assiette_dotation_projet_form.html" %}
+                    {% for dp in dotation_projets %}
+                        {% if dp.status == 'processing' and not projet.notified_at %}
+                            {% assiette_dotation_form dp %}
                         {% else %}
                             {% include "includes/projet_detail/_dotation_projet_readonly_block.html" %}
                         {% endif %}

--- a/gsl_projet/templates/includes/forms/_assiette_dotation_projet_form.html
+++ b/gsl_projet/templates/includes/forms/_assiette_dotation_projet_form.html
@@ -1,15 +1,20 @@
 <form method="post"
-      action="{% url 'gsl_projet:patch-dotation-projet-assiette' item.dp.pk %}"
-      data-controller="format-montant"
-      data-action="submit->format-montant#unformat">
+      hx-post="{% url 'gsl_projet:patch-dotation-projet-assiette' dotation_projet.pk %}"
+      hx-target="this"
+      hx-swap="outerHTML">
     {% csrf_token %}
     <div class="fr-callout fr-background-alt--blue-france fr-ml-0 fr-mt-2w">
         <h5 class="fr-callout__title">
-            {{ item.dp.dotation }}
+            {{ dotation_projet.dotation }}
         </h5>
-        {{ item.form }}
+        {{ form }}
     </div>
     <button class="fr-btn fr-btn--secondary" type="submit">
         Enregistrer
     </button>
+    {% if saved %}
+        <span class="fr-badge fr-badge--success"
+              role="status"
+              data-controller="auto-dismiss">Modifications enregistrées</span>
+    {% endif %}
 </form>

--- a/gsl_projet/templates/includes/projet_detail/_dotation_projet_readonly_block.html
+++ b/gsl_projet/templates/includes/projet_detail/_dotation_projet_readonly_block.html
@@ -2,26 +2,26 @@
 
 <div class="fr-callout fr-background-alt--blue-france fr-ml-0 fr-mt-2w">
     <h5 class="fr-callout__title">
-        {{ item.dp.dotation }}
+        {{ dp.dotation }}
     </h5>
-    {% ui_status_badge type=item.dp.status %}
+    {% ui_status_badge type=dp.status %}
     <ul class="fr-mt-1w">
         <li>
             <b>Montant des dépenses éligibles retenues :</b>
-            {{ item.dp.assiette|euro:2 }}
+            {{ dp.assiette|euro:2 }}
         </li>
         <li>
             <b>Montant accordé :</b>
-            {% if item.dp.status == 'accepted' %}
-                {{ item.dp.montant_retenu|euro:2 }}
+            {% if dp.status == 'accepted' %}
+                {{ dp.montant_retenu|euro:2 }}
             {% else %}
                 —
             {% endif %}
         </li>
         <li>
             <b>Taux de subvention :</b>
-            {% if item.dp.status == 'accepted' %}
-                {{ item.dp.taux_retenu|percent:3 }}
+            {% if dp.status == 'accepted' %}
+                {{ dp.taux_retenu|percent:3 }}
             {% else %}
                 —
             {% endif %}

--- a/gsl_projet/templatetags/projet_tags.py
+++ b/gsl_projet/templatetags/projet_tags.py
@@ -1,0 +1,13 @@
+from django import template
+
+from gsl_projet.forms import DotationProjetAssietteForm
+
+register = template.Library()
+
+
+@register.inclusion_tag("includes/forms/_assiette_dotation_projet_form.html")
+def assiette_dotation_form(dotation_projet):
+    return {
+        "dotation_projet": dotation_projet,
+        "form": DotationProjetAssietteForm(instance=dotation_projet),
+    }

--- a/gsl_projet/tests/views/test_dotation_projet_views.py
+++ b/gsl_projet/tests/views/test_dotation_projet_views.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 from django.urls import reverse
 from django.utils import timezone
@@ -67,53 +69,80 @@ def _assiette_url(dp):
     return reverse("gsl_projet:patch-dotation-projet-assiette", kwargs={"pk": dp.pk})
 
 
-def test_patch_assiette_saves_value(
+def test_patch_assiette_saves_value_and_returns_updated_fragment(
     client_with_user_logged, processing_dotation_projet
 ):
-    client_with_user_logged.post(
-        _assiette_url(processing_dotation_projet), {"assiette": "50000"}
+    response = client_with_user_logged.post(
+        _assiette_url(processing_dotation_projet),
+        {"assiette": "50000"},
+        headers={"HX-Request": "true"},
     )
     processing_dotation_projet.refresh_from_db()
     assert processing_dotation_projet.assiette == 50_000
 
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert _assiette_url(processing_dotation_projet) in content
+    assert 'value="50000"' in content
+    assert "Modifications enregistrées" in content
+    assert "fr-input-group--error" not in content
 
-def test_patch_assiette_shows_success_message(
+
+def test_patch_assiette_accepts_french_formatted_value(
     client_with_user_logged, processing_dotation_projet
 ):
     response = client_with_user_logged.post(
-        _assiette_url(processing_dotation_projet), {"assiette": "50000"}, follow=True
+        _assiette_url(processing_dotation_projet),
+        {"assiette": "50 000,50"},
+        headers={"HX-Request": "true"},
     )
-    messages = [m.message for m in response.context["messages"]]
-    assert any("enregistrées avec succès" in m for m in messages)
+    processing_dotation_projet.refresh_from_db()
+    assert processing_dotation_projet.assiette == Decimal("50000.50")
+    assert response.status_code == 200
 
 
 def test_patch_assiette_invalid_does_not_save(
     client_with_user_logged, processing_dotation_projet
 ):
     client_with_user_logged.post(
-        _assiette_url(processing_dotation_projet), {"assiette": ""}
+        _assiette_url(processing_dotation_projet),
+        {"assiette": ""},
+        headers={"HX-Request": "true"},
     )
     processing_dotation_projet.refresh_from_db()
     assert processing_dotation_projet.assiette == 10_000
 
 
-def test_patch_assiette_invalid_stores_errors_in_session(
+def test_patch_assiette_invalid_returns_errors_inline(
     client_with_user_logged, processing_dotation_projet
 ):
-    client_with_user_logged.post(
-        _assiette_url(processing_dotation_projet), {"assiette": ""}
+    response = client_with_user_logged.post(
+        _assiette_url(processing_dotation_projet),
+        {"assiette": ""},
+        headers={"HX-Request": "true"},
     )
-    assert (
-        f"assiette_errors_{processing_dotation_projet.pk}"
-        in client_with_user_logged.session
-    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "fr-input-group--error" in content
+    assert "Modifications enregistrées" not in content
 
 
 def test_patch_assiette_get_returns_405(
     client_with_user_logged, processing_dotation_projet
 ):
-    response = client_with_user_logged.get(_assiette_url(processing_dotation_projet))
+    response = client_with_user_logged.get(
+        _assiette_url(processing_dotation_projet), headers={"HX-Request": "true"}
+    )
     assert response.status_code == 405
+
+
+def test_patch_assiette_non_htmx_returns_400(
+    client_with_user_logged, processing_dotation_projet
+):
+    response = client_with_user_logged.post(
+        _assiette_url(processing_dotation_projet), {"assiette": "50000"}
+    )
+    assert response.status_code == 400
 
 
 def test_patch_assiette_notified_projet_returns_404(
@@ -125,7 +154,9 @@ def test_patch_assiette_notified_projet_returns_404(
         projet__dossier_ds__perimetre=perimetre_departemental,
         projet__notified_at=timezone.now(),
     )
-    response = client_with_user_logged.post(_assiette_url(dp), {"assiette": "50000"})
+    response = client_with_user_logged.post(
+        _assiette_url(dp), {"assiette": "50000"}, headers={"HX-Request": "true"}
+    )
     assert response.status_code == 404
 
 
@@ -137,7 +168,9 @@ def test_patch_assiette_out_of_perimeter_returns_404(client_with_user_logged):
         projet__dossier_ds__perimetre=other_perimetre,
         projet__notified_at=None,
     )
-    response = client_with_user_logged.post(_assiette_url(dp), {"assiette": "50000"})
+    response = client_with_user_logged.post(
+        _assiette_url(dp), {"assiette": "50000"}, headers={"HX-Request": "true"}
+    )
     assert response.status_code == 404
 
 

--- a/gsl_projet/tests/views/test_projet_detail.py
+++ b/gsl_projet/tests/views/test_projet_detail.py
@@ -1,6 +1,5 @@
 import re
 from datetime import datetime
-from urllib.parse import urlencode
 
 import pytest
 from django.shortcuts import reverse
@@ -436,40 +435,3 @@ def test_readonly_block_shown_for_processing_dotation_when_projet_is_notified():
     )
     assert assiette_url not in content
     assert "Montant des dépenses éligibles retenues :" in content
-
-
-def test_assiette_form_shows_errors_from_session():
-    perimetre = PerimetreArrondissementFactory()
-    user = CollegueFactory(perimetre=perimetre)
-    projet = ProjetFactory(dossier_ds__perimetre=perimetre, notified_at=None)
-    dp = DotationProjetFactory(
-        projet=projet, status=PROJET_STATUS_PROCESSING, dotation=DOTATION_DETR
-    )
-    client = ClientWithLoggedUserFactory(user=user)
-    session = client.session
-    session[f"assiette_errors_{dp.pk}"] = urlencode(
-        {"assiette": "pas_un_nombre", "csrfmiddlewaretoken": "x"}
-    )
-    session.save()
-    response = client.get(_projet_url(projet))
-    assert response.status_code == 200
-    items = response.context["dotation_projet_items"]
-    assert len(items) == 1
-    assert items[0]["form"].errors
-
-
-def test_assiette_session_errors_cleared_after_display():
-    perimetre = PerimetreArrondissementFactory()
-    user = CollegueFactory(perimetre=perimetre)
-    projet = ProjetFactory(dossier_ds__perimetre=perimetre, notified_at=None)
-    dp = DotationProjetFactory(
-        projet=projet, status=PROJET_STATUS_PROCESSING, dotation=DOTATION_DETR
-    )
-    client = ClientWithLoggedUserFactory(user=user)
-    session = client.session
-    session[f"assiette_errors_{dp.pk}"] = urlencode(
-        {"assiette": "", "csrfmiddlewaretoken": "x"}
-    )
-    session.save()
-    client.get(_projet_url(projet))
-    assert f"assiette_errors_{dp.pk}" not in client.session

--- a/gsl_projet/views.py
+++ b/gsl_projet/views.py
@@ -226,10 +226,12 @@ class DotationProjetUpdateView(UpdateView):
         return _redirect_to_referer_or_projet(self.request, self.object.projet)
 
 
+@method_decorator(htmx_only, name="dispatch")
 class DotationProjetAssietteUpdateView(UpdateView):
     model = DotationProjet
     form_class = DotationProjetAssietteForm
     http_method_names = ["post"]
+    template_name = "includes/forms/_assiette_dotation_projet_form.html"
 
     def get_queryset(self):
         return DotationProjet.objects.filter(
@@ -237,19 +239,14 @@ class DotationProjetAssietteUpdateView(UpdateView):
             projet__notified_at__isnull=True,
         )
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["dotation_projet"] = self.object
+        return context
+
     def form_valid(self, form):
         form.save()
-        messages.success(
-            self.request,
-            "Les modifications ont été enregistrées avec succès.",
-        )
-        return _redirect_to_referer_or_projet(self.request, self.object.projet)
-
-    def form_invalid(self, form):
-        self.request.session[f"assiette_errors_{self.object.pk}"] = (
-            self.request.POST.urlencode()
-        )
-        return _redirect_to_referer_or_projet(self.request, self.object.projet)
+        return self.render_to_response(self.get_context_data(form=form, saved=True))
 
 
 @method_decorator(htmx_only, name="dispatch")
@@ -297,9 +294,6 @@ def _build_projet_page_context(projet, request):
         "initial_dotations": (
             json.dumps(dotation_field.initial) if dotation_field else "[]"
         ),
-        "dotation_projet_items": [
-            _build_dotation_projet_item(dp, request) for dp in dotation_projets
-        ],
         **get_projet_go_back_context(request),
     }
     detr_dotation = projet.dotation_detr
@@ -318,17 +312,6 @@ def _build_projet_form(projet, request):
         form.is_valid()
         return form
     return ProjetForm(instance=projet)
-
-
-def _build_dotation_projet_item(dp, request):
-    session_key = f"assiette_errors_{dp.pk}"
-    if session_key in request.session:
-        form_data = QueryDict(request.session.pop(session_key))
-        form = DotationProjetAssietteForm(data=form_data, instance=dp)
-        form.is_valid()
-    else:
-        form = DotationProjetAssietteForm(instance=dp)
-    return {"dp": dp, "form": form}
 
 
 class ProjetNoteCreateView(CreateView):


### PR DESCRIPTION
Pour discussion avant de faire les autres!

Quelques points à voir ensemble notamment:
- utilisation d'un inclusion tag (pour alléger la vue principale)
- utilisation d'un message flash de succès (plutôt que de tout reloader la page), à voir aussi avec Raphaël
- bascule côté python du parsing de nombre "à la française" (50 000,50), plus sûr et aussi pour éviter une race condition entre htmx et le controleur Stimulus (qui écoutent tous les deux le submit, mais je sais pas dire dans quel ordre).