### PR TITLE
fix: display HTMX error

### DIFF
--- a/gsl_core/static/js/controllers/htmxError.js
+++ b/gsl_core/static/js/controllers/htmxError.js
@@ -1,0 +1,57 @@
+import { Controller } from 'stimulus'
+
+// Deals with non-user errors (50x, 40x other than 422, network failure…) and try
+// to insert an error near the htmx target, so to stay near the user attention.
+export class HtmxError extends Controller {
+  connect () {
+    document.body.addEventListener('htmx:beforeRequest', this.clear)
+    // `htmx:responseError` = non-2xx status ; `htmx:sendError` = network failure.
+    document.body.addEventListener('htmx:responseError', this.onResponseError)
+    document.body.addEventListener('htmx:sendError', this.onSendError)
+  }
+
+  disconnect () {
+    document.body.removeEventListener('htmx:beforeRequest', this.clear)
+    document.body.removeEventListener('htmx:responseError', this.onResponseError)
+    document.body.removeEventListener('htmx:sendError', this.onSendError)
+  }
+
+  clear = () => {
+    document.querySelectorAll('[data-htmx-error]').forEach((alert) => alert.remove())
+  }
+
+  onSendError = (event) => {
+    this.alert(event.detail.target, this.build('Connexion indisponible, veuillez réessayer.'))
+  }
+
+  onResponseError = (event) => {
+    const status = event.detail.xhr.status
+    const message = status === 403 ? "Vous n'êtes pas autorisé à effectuer cette action." : 'Une erreur est survenue, veuillez réessayer.'
+    this.alert(event.detail.target, this.build(message))
+  }
+
+  alert (target, alert) {
+    // Try to insert near the htmx context, and fallback to global context.
+    if (target && target.isConnected && target !== document.body && target.parentElement) {
+      target.insertAdjacentElement('beforebegin', alert)
+    } else {
+      const messages = document.getElementById('messages')
+      ;(messages || document.body).prepend(alert)
+    }
+  }
+
+  build (message) {
+    const alert = document.createElement('div')
+    alert.className = 'fr-alert fr-alert--error fr-alert--sm fr-mb-2w'
+    alert.setAttribute('role', 'alert')
+    alert.dataset.htmxError = ''
+    alert.dataset.controller = 'auto-dismiss'
+    alert.dataset.autoDismissDelay = '6000'
+
+    const paragraph = document.createElement('p')
+    paragraph.textContent = message
+    alert.appendChild(paragraph)
+
+    return alert
+  }
+}

--- a/gsl_core/templates/base.html
+++ b/gsl_core/templates/base.html
@@ -66,7 +66,8 @@
                     "projetNoteCard": "{% static 'js/controllers/projetNoteCard.js' %}",
                     "radioNavigate": "{% static 'js/controllers/radioNavigate.js' %}",
                     "formatMontant": "{% static 'js/controllers/formatMontant.js' %}",
-                    "autoDismiss": "{% static 'js/controllers/autoDismiss.js' %}"
+                    "autoDismiss": "{% static 'js/controllers/autoDismiss.js' %}",
+                    "htmxError": "{% static 'js/controllers/htmxError.js' %}"
                 }
             }
             </script>
@@ -85,7 +86,8 @@
         {% block extra_head_js %}
         {% endblock extra_head_js %}
     </head>
-    <body hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+    <body hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+          data-controller="htmx-error">
         {% block skiplinks %}
             {% dsfr_skiplinks skiplinks|add:extra_skiplinks %}
         {% endblock skiplinks %}
@@ -137,6 +139,7 @@
             import { DoubleDotation } from "doubleDotation"
             import { FormatMontant } from "formatMontant"
             import { FormUtils } from "formUtils"
+            import { HtmxError } from "htmxError"
             import { Modal } from "modal"
             import { ModeleArreteForm } from "modeleArreteForm"
             import { ProjetForm } from "projetForm"
@@ -168,6 +171,7 @@
             Stimulus.register("radio-navigate", RadioNavigate)
             Stimulus.register("format-montant", FormatMontant)
             Stimulus.register("auto-dismiss", AutoDismiss)
+            Stimulus.register("htmx-error", HtmxError)
         </script>
 
         {% block extra_js %}


### PR DESCRIPTION
- user errors (eg. invalid data) is returned as 200 and displayed in the HTMX partial
- other errors (50x, 403…) are handled globally, but we still try to display near the HTMX block to keep them near the user attention

<img width="642" height="449" alt="image" src="https://github.com/user-attachments/assets/05ec9e5b-64cd-4ad9-9f8b-7e4c3e3e5220" />