### PR TITLE
chore: fix and clean generate_dump.py script

### DIFF
--- a/scripts/generate_dump.sh
+++ b/scripts/generate_dump.sh
@@ -1,33 +1,27 @@
 #!/bin/bash
 
-# Charge des variables d'environnement depuis le fichier .env si présent
 if [ -f .env ]; then
-  export $(grep -v '^#' .env | xargs)
+  set -a
+  source ./.env
+  set +a
 fi
 
-# Vérifie les paramètres requis
 if [ -z "$1" ]; then
   echo "Utilisation : $0 <plateforme>"
   echo "Plateformes disponibles : local, staging, prod"
   exit 1
 fi
 
-VERBOSE=false
-# Analyse les arguments
-for arg in "$@"; do
-  if [ "$arg" == "--verbose" ]; then
-    VERBOSE=true
-  fi
-done
-
 PLATFORM=$1
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-DUMP_FILE="./tmp/db_dump_${PLATFORM}_${TIMESTAMP}.sql"
+# Binary .dump for Scalingo (pg_dump -F c), .sql for local (SQL txt)
+if [[ "$PLATFORM" == "local" ]]; then EXT="sql"; else EXT="dump"; fi
+DUMP_FILE="./tmp/db_dump_${PLATFORM}_${TIMESTAMP}.${EXT}"
+mkdir -p "$(dirname "$DUMP_FILE")"
 
 if [[ "$PLATFORM" == "local" ]]; then
   echo "Génération du dump de la base de données locale..."
 
-  # Vérifie que les variables d'environnement requises sont définies
   REQUIRED_VARS=("DATABASE_NAME" "DATABASE_USER" "DATABASE_PASSWORD" "DATABASE_HOST" "DATABASE_PORT")
   for VAR in "${REQUIRED_VARS[@]}"; do
     if [[ -z "${!VAR}" ]]; then
@@ -36,20 +30,22 @@ if [[ "$PLATFORM" == "local" ]]; then
     fi
   done
 
-  # Générer le dump depuis la base locale
-  pg_dump -h "$DATABASE_HOST" -U "$DATABASE_USER" -d "$DATABASE_NAME" -f "$DUMP_FILE"
-  echo "Dump de la base de données locale enregistré dans : $DUMP_FILE"
+  # Local
+  if pg_dump -h "$DATABASE_HOST" -U "$DATABASE_USER" -d "$DATABASE_NAME" -f "$DUMP_FILE"; then
+    echo "Dump de la base de données locale enregistré dans : $DUMP_FILE"
+  else
+    echo "Erreur : le dump de la base locale a échoué."
+    exit 1
+  fi
 
 elif [[ "$PLATFORM" == "staging" || "$PLATFORM" == "prod" ]]; then
   echo "Génération du dump de la base de données depuis Scalingo ($PLATFORM)..."
 
-  # Vérifie que l'outil CLI Scalingo est installé
   if ! command -v scalingo &> /dev/null; then
     echo "Erreur : l'outil CLI Scalingo n'est pas installé. Installez-le depuis https://doc.scalingo.com/cli/install"
     exit 1
   fi
 
-  # Définit le nom de l'application Scalingo (modifiez si nécessaire)
   if [[ "$PLATFORM" == "staging" ]]; then
     SCALINGO_APP="gsl-staging"
     REGION="osc-fr1"
@@ -58,7 +54,6 @@ elif [[ "$PLATFORM" == "staging" || "$PLATFORM" == "prod" ]]; then
     REGION="osc-secnum-fr1"
   fi
 
-  # Récupère l'URL de la base de données depuis Scalingo
   SCALINGO_DB_URL=$(scalingo --app "$SCALINGO_APP" --region="$REGION" env-get SCALINGO_POSTGRESQL_URL)
   
   if [ -z "$SCALINGO_DB_URL" ]; then
@@ -72,28 +67,28 @@ elif [[ "$PLATFORM" == "staging" || "$PLATFORM" == "prod" ]]; then
 
   echo "Connexion à la base de données Scalingo..."
   
-  # Exécute le tunnel db-tunnel en arrière-plan et capturer la sortie
-  scalingo --app "$SCALINGO_APP" --region "$REGION" db-tunnel "$SCALINGO_DB_URL" &
-  
-  # Capture le PID du processus db-tunnel
+  TUNNEL_LOG=$(mktemp)
+  scalingo --app "$SCALINGO_APP" --region "$REGION" db-tunnel "$SCALINGO_DB_URL" >"$TUNNEL_LOG" 2>&1 &
+
+  # db-tunnel PID
   TUNNEL_PID=$!
+  # Let's close the tunnel when it's done
+  trap 'echo "Fermeture du tunnel."; kill "$TUNNEL_PID" 2>/dev/null; wait "$TUNNEL_PID" 2>/dev/null; rm -f "$TUNNEL_LOG"' EXIT
 
   sleep 5
 
   TUNNEL_OUTPUT=$(ps aux | grep "$TUNNEL_PID" | grep -v "grep")
 
-  # Si le tunnel est actif, on continue, sinon on arrête le script
   if [ -z "$TUNNEL_OUTPUT" ]; then
     echo "Erreur : le tunnel n'a pas pu être établi ou n'est pas actif."
+    cat "$TUNNEL_LOG" >&2
     exit 1
   else
     echo "Tunnel actif, poursuite de l'opération..."
   fi
 
-  # Extraction du port local utilisé par le tunnel
   PORT=$(lsof -i -n -P | grep "127.0.0.1" | grep -o '[0-9]\{2,5\}' | tail -n 1)
 
-  # Vérifie du port
   if [ -z "$PORT" ]; then
     echo "Erreur : impossible de récupérer le port."
     exit 1
@@ -102,10 +97,12 @@ elif [[ "$PLATFORM" == "staging" || "$PLATFORM" == "prod" ]]; then
 
   echo "Dump en cours..."
 
-  # Génère le dump depuis Scalingo
-  pg_dump "$DB_URL" -F c -f "$DUMP_FILE"
-  
-  echo "Dump de la base de données Scalingo enregistré dans : $DUMP_FILE"
+  if pg_dump "$DB_URL" -F c -f "$DUMP_FILE"; then
+    echo "Dump de la base de données Scalingo enregistré dans : $DUMP_FILE"
+  else
+    echo "Erreur : le dump Scalingo a échoué."
+    exit 1
+  fi
 
 else
   echo "Erreur : plateforme invalide. Utilisez 'local', 'staging' ou 'prod'."


### PR DESCRIPTION
- use source to load env vars
- removed unused --verbose option parsing
- use correct file suffix (.dump / .sql)
- do not fail if tmp/ does not exist
- do not say it's downloaded while it's not
- properly close tunnel at process end

```
$ ./scripts/generate_dump.sh staging
Génération du dump de la base de données depuis Scalingo (staging)...
Connexion à la base de données Scalingo...
Tunnel actif, poursuite de l'opération...
Dump en cours...
Dump de la base de données Scalingo enregistré dans : ./tmp/db_dump_staging_20260803_182605.dump
Fermeture du tunnel.
```